### PR TITLE
[Scripts] fix writeDesignSpace-min.py

### DIFF
--- a/Roboto-min.designspace
+++ b/Roboto-min.designspace
@@ -12,100 +12,94 @@
         </axis>
         <axis default="100" maximum="100" minimum="75" name="width" tag="wdth">
             <labelname xml:lang="en">Width</labelname>
-            <map input="75" output="-1" />
-            <map input="87.5" output="0" />
-            <map input="100" output="1" />
         </axis>
-        <axis default="0" maximum="12" minimum="0" name="slant" tag="slnt">
+        <axis default="0" maximum="0" minimum="-12" name="slant" tag="slnt">
             <labelname xml:lang="en">Slant</labelname>
-            <map input="0" output="-1" />
-            <map input="6" output="0" />
-            <map input="12" output="1" />
         </axis>
     </axes>
     <sources>
         <source familyname="Roboto" filename="master_ufo/Roboto-Thin.ufo" name="Roboto-Thin.ufo" stylename="Thin">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="-1" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-Regular.ufo" name="Roboto-Regular.ufo" stylename="Regular">
             <info copy="1" />
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-Black.ufo" name="Roboto-Black.ufo" stylename="Black">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="1.125000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-ThinItalic.ufo" name="Roboto-ThinItalic.ufo" stylename="Thin Italic">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="-1" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-Italic.ufo" name="Roboto-Italic.ufo" stylename="Italic">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-BlackItalic.ufo" name="Roboto-BlackItalic.ufo" stylename="Black Italic">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="1.125000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Light.ufo" name="RobotoCondensed-Light.ufo" stylename="Condensed Light">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Regular.ufo" name="RobotoCondensed-Regular.ufo" stylename="Condensed Regular">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Bold.ufo" name="RobotoCondensed-Bold.ufo" stylename="Condensed Bold">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="0.750000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-LightItalic.ufo" name="RobotoCondensed-LightItalic.ufo" stylename="Condensed Light Italic">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Italic.ufo" name="RobotoCondensed-Italic.ufo" stylename="Condensed Italic">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-BoldItalic.ufo" name="RobotoCondensed-BoldItalic.ufo" stylename="Condensed Bold Italic">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="0.750000" />
             </location>
         </source>
@@ -113,8 +107,8 @@
     <instances>
         <instance familyname="Roboto" stylename="Thin">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="-1" />
             </location>
             <kerning />
@@ -122,8 +116,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Light">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
@@ -131,8 +125,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Medium">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="0.350000" />
             </location>
             <kerning />
@@ -140,8 +134,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Bold">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="0.730000" />
             </location>
             <kerning />
@@ -149,8 +143,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Black">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="1.125000" />
             </location>
             <kerning />
@@ -158,8 +152,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Thin Italic">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="-1" />
             </location>
             <kerning />
@@ -167,8 +161,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Light Italic">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
@@ -176,8 +170,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Italic">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
             <kerning />
@@ -185,8 +179,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Medium Italic">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="0.350000" />
             </location>
             <kerning />
@@ -194,8 +188,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Bold Italic">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="0.730000" />
             </location>
             <kerning />
@@ -203,8 +197,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Black Italic">
             <location>
-                <dimension name="width" xvalue="1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="1.125000" />
             </location>
             <kerning />
@@ -212,8 +206,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Light">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
@@ -221,8 +215,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Regular">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
             <kerning />
@@ -230,8 +224,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Bold">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="-1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="0" />
                 <dimension name="weight" xvalue="0.750000" />
             </location>
             <kerning />
@@ -239,8 +233,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Light Italic">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
@@ -248,8 +242,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Italic">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
             <kerning />
@@ -257,8 +251,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Bold Italic">
             <location>
-                <dimension name="width" xvalue="-1" />
-                <dimension name="slant" xvalue="1" />
+                <dimension name="width" xvalue="75" />
+                <dimension name="slant" xvalue="-12" />
                 <dimension name="weight" xvalue="0.750000" />
             </location>
             <kerning />

--- a/Roboto-min.designspace
+++ b/Roboto-min.designspace
@@ -1,99 +1,111 @@
 <?xml version='1.0' encoding='utf-8'?>
 <designspace format="3">
     <axes>
-        <axis default="-0.1" maximum="1.125" minimum="-1" name="weight" tag="wght">
+        <axis default="400" maximum="900" minimum="250" name="weight" tag="wght">
             <labelname xml:lang="en">Weight</labelname>
+            <map input="250" output="-1" />
+            <map input="300" output="-0.550000" />
+            <map input="400" output="-0.1" />
+            <map input="500" output="0.350000" />
+            <map input="700" output="0.730000" />
+            <map input="900" output="1.125" />
         </axis>
         <axis default="100" maximum="100" minimum="75" name="width" tag="wdth">
             <labelname xml:lang="en">Width</labelname>
+            <map input="75" output="-1" />
+            <map input="87.5" output="0" />
+            <map input="100" output="1" />
         </axis>
         <axis default="0" maximum="12" minimum="0" name="slant" tag="slnt">
             <labelname xml:lang="en">Slant</labelname>
+            <map input="0" output="-1" />
+            <map input="6" output="0" />
+            <map input="12" output="1" />
         </axis>
     </axes>
     <sources>
         <source familyname="Roboto" filename="master_ufo/Roboto-Thin.ufo" name="Roboto-Thin.ufo" stylename="Thin">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="-1" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-Regular.ufo" name="Roboto-Regular.ufo" stylename="Regular">
             <info copy="1" />
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-Black.ufo" name="Roboto-Black.ufo" stylename="Black">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="1.125000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-ThinItalic.ufo" name="Roboto-ThinItalic.ufo" stylename="Thin Italic">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="-1" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-Italic.ufo" name="Roboto-Italic.ufo" stylename="Italic">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-BlackItalic.ufo" name="Roboto-BlackItalic.ufo" stylename="Black Italic">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="1.125000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Light.ufo" name="RobotoCondensed-Light.ufo" stylename="Condensed Light">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Regular.ufo" name="RobotoCondensed-Regular.ufo" stylename="Condensed Regular">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Bold.ufo" name="RobotoCondensed-Bold.ufo" stylename="Condensed Bold">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="0.750000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-LightItalic.ufo" name="RobotoCondensed-LightItalic.ufo" stylename="Condensed Light Italic">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Italic.ufo" name="RobotoCondensed-Italic.ufo" stylename="Condensed Italic">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-BoldItalic.ufo" name="RobotoCondensed-BoldItalic.ufo" stylename="Condensed Bold Italic">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="0.750000" />
             </location>
         </source>
@@ -101,8 +113,8 @@
     <instances>
         <instance familyname="Roboto" stylename="Thin">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="-1" />
             </location>
             <kerning />
@@ -110,8 +122,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Light">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
@@ -119,8 +131,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Medium">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="0.350000" />
             </location>
             <kerning />
@@ -128,8 +140,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Bold">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="0.730000" />
             </location>
             <kerning />
@@ -137,8 +149,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Black">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="1.125000" />
             </location>
             <kerning />
@@ -146,8 +158,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Thin Italic">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="-1" />
             </location>
             <kerning />
@@ -155,8 +167,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Light Italic">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
@@ -164,8 +176,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Italic">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
             <kerning />
@@ -173,8 +185,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Medium Italic">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="0.350000" />
             </location>
             <kerning />
@@ -182,8 +194,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Bold Italic">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="0.730000" />
             </location>
             <kerning />
@@ -191,8 +203,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Black Italic">
             <location>
-                <dimension name="width" xvalue="100" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="1.125000" />
             </location>
             <kerning />
@@ -200,8 +212,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Light">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
@@ -209,8 +221,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Regular">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
             <kerning />
@@ -218,8 +230,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Bold">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="0" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="-1" />
                 <dimension name="weight" xvalue="0.750000" />
             </location>
             <kerning />
@@ -227,8 +239,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Light Italic">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
@@ -236,8 +248,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Italic">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="-0.100000" />
             </location>
             <kerning />
@@ -245,8 +257,8 @@
         </instance>
         <instance familyname="Roboto" stylename="Condensed Bold Italic">
             <location>
-                <dimension name="width" xvalue="75" />
-                <dimension name="slant" xvalue="12" />
+                <dimension name="width" xvalue="-1" />
+                <dimension name="slant" xvalue="1" />
                 <dimension name="weight" xvalue="0.750000" />
             </location>
             <kerning />

--- a/Roboto-min.designspace
+++ b/Roboto-min.designspace
@@ -5,10 +5,10 @@
             <labelname xml:lang="en">Weight</labelname>
             <map input="250" output="-1" />
             <map input="300" output="-0.550000" />
-            <map input="400" output="-0.1" />
+            <map input="400" output="-0.100000" />
             <map input="500" output="0.350000" />
             <map input="700" output="0.730000" />
-            <map input="900" output="1.125" />
+            <map input="900" output="1.125000" />
         </axis>
         <axis default="100" maximum="100" minimum="75" name="width" tag="wdth">
             <labelname xml:lang="en">Width</labelname>
@@ -20,240 +20,249 @@
     <sources>
         <source familyname="Roboto" filename="master_ufo/Roboto-Thin.ufo" name="Roboto-Thin.ufo" stylename="Thin">
             <location>
+                <dimension name="weight" xvalue="-1" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="-1" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-Regular.ufo" name="Roboto-Regular.ufo" stylename="Regular">
             <info copy="1" />
             <location>
+                <dimension name="weight" xvalue="-0.100000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-Black.ufo" name="Roboto-Black.ufo" stylename="Black">
             <location>
+                <dimension name="weight" xvalue="1.125000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="1.125000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-ThinItalic.ufo" name="Roboto-ThinItalic.ufo" stylename="Thin Italic">
             <location>
+                <dimension name="weight" xvalue="-1" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="-1" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-Italic.ufo" name="Roboto-Italic.ufo" stylename="Italic">
             <location>
+                <dimension name="weight" xvalue="-0.100000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/Roboto-BlackItalic.ufo" name="Roboto-BlackItalic.ufo" stylename="Black Italic">
             <location>
+                <dimension name="weight" xvalue="1.125000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="1.125000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Light.ufo" name="RobotoCondensed-Light.ufo" stylename="Condensed Light">
             <location>
+                <dimension name="weight" xvalue="-0.550000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="-0.550000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Regular.ufo" name="RobotoCondensed-Regular.ufo" stylename="Condensed Regular">
             <location>
+                <dimension name="weight" xvalue="-0.100000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Bold.ufo" name="RobotoCondensed-Bold.ufo" stylename="Condensed Bold">
             <location>
+                <dimension name="weight" xvalue="0.750000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="0.750000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-LightItalic.ufo" name="RobotoCondensed-LightItalic.ufo" stylename="Condensed Light Italic">
             <location>
+                <dimension name="weight" xvalue="-0.550000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="-0.550000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-Italic.ufo" name="RobotoCondensed-Italic.ufo" stylename="Condensed Italic">
             <location>
+                <dimension name="weight" xvalue="-0.100000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="-0.100000" />
             </location>
         </source>
         <source familyname="Roboto" filename="master_ufo/RobotoCondensed-BoldItalic.ufo" name="RobotoCondensed-BoldItalic.ufo" stylename="Condensed Bold Italic">
             <location>
+                <dimension name="weight" xvalue="0.750000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="0.750000" />
             </location>
         </source>
     </sources>
     <instances>
         <instance familyname="Roboto" stylename="Thin">
             <location>
+                <dimension name="weight" xvalue="-1" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="-1" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Light">
             <location>
+                <dimension name="weight" xvalue="-0.550000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="-0.550000" />
+            </location>
+            <kerning />
+            <info />
+        </instance>
+        <instance familyname="Roboto" stylename="Regular">
+            <location>
+                <dimension name="weight" xvalue="-0.100000" />
+                <dimension name="width" xvalue="100" />
+                <dimension name="slant" xvalue="0" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Medium">
             <location>
+                <dimension name="weight" xvalue="0.350000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="0.350000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Bold">
             <location>
+                <dimension name="weight" xvalue="0.730000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="0.730000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Black">
             <location>
+                <dimension name="weight" xvalue="1.125000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="1.125000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Thin Italic">
             <location>
+                <dimension name="weight" xvalue="-1" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="-1" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Light Italic">
             <location>
+                <dimension name="weight" xvalue="-0.550000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Italic">
             <location>
+                <dimension name="weight" xvalue="-0.100000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="-0.100000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Medium Italic">
             <location>
+                <dimension name="weight" xvalue="0.350000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="0.350000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Bold Italic">
             <location>
+                <dimension name="weight" xvalue="0.730000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="0.730000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Black Italic">
             <location>
+                <dimension name="weight" xvalue="1.125000" />
                 <dimension name="width" xvalue="100" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="1.125000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Condensed Light">
             <location>
+                <dimension name="weight" xvalue="-0.550000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Condensed Regular">
             <location>
+                <dimension name="weight" xvalue="-0.100000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="-0.100000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Condensed Bold">
             <location>
+                <dimension name="weight" xvalue="0.750000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="0" />
-                <dimension name="weight" xvalue="0.750000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Condensed Light Italic">
             <location>
+                <dimension name="weight" xvalue="-0.550000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="-0.550000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Condensed Italic">
             <location>
+                <dimension name="weight" xvalue="-0.100000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="-0.100000" />
             </location>
             <kerning />
             <info />
         </instance>
         <instance familyname="Roboto" stylename="Condensed Bold Italic">
             <location>
+                <dimension name="weight" xvalue="0.750000" />
                 <dimension name="width" xvalue="75" />
                 <dimension name="slant" xvalue="-12" />
-                <dimension name="weight" xvalue="0.750000" />
             </location>
             <kerning />
             <info />

--- a/Scripts/writeDesignSpace-min.py
+++ b/Scripts/writeDesignSpace-min.py
@@ -7,31 +7,31 @@ designSpacePath = "Roboto-min.designspace"
 familyName = "Roboto"
 
 sources = [
-	dict(path="master_ufo/Roboto-Thin.ufo", name="Roboto-Thin.ufo", location=dict(weight=-1), styleName="Thin", familyName=familyName, copyInfo=False),
-	dict(path="master_ufo/Roboto-Regular.ufo", name="Roboto-Regular.ufo", location=dict(weight=-0.1, width=100, slant=0), styleName="Regular", familyName=familyName, copyInfo=True),
-	dict(path="master_ufo/Roboto-Black.ufo", name="Roboto-Black.ufo", location=dict(weight=1.125), styleName="Black", familyName=familyName, copyInfo=False),
-	
-	dict(path="master_ufo/Roboto-ThinItalic.ufo", name="Roboto-ThinItalic.ufo", location=dict(weight=-1, slant=12), styleName="Thin Italic", familyName=familyName, copyInfo=False),
-	dict(path="master_ufo/Roboto-Italic.ufo", name="Roboto-Italic.ufo", location=dict(slant=12), styleName="Italic", familyName=familyName, copyInfo=False),
-	dict(path="master_ufo/Roboto-BlackItalic.ufo", name="Roboto-BlackItalic.ufo", location=dict(weight=1.125, slant=12), styleName="Black Italic", familyName=familyName, copyInfo=False),
+    dict(path="master_ufo/Roboto-Thin.ufo", name="Roboto-Thin.ufo", location=dict(weight=-1, width=100, slant=0), styleName="Thin", familyName=familyName, copyInfo=False),
+    dict(path="master_ufo/Roboto-Regular.ufo", name="Roboto-Regular.ufo", location=dict(weight=-0.1, width=100, slant=0), styleName="Regular", familyName=familyName, copyInfo=True),
+    dict(path="master_ufo/Roboto-Black.ufo", name="Roboto-Black.ufo", location=dict(weight=1.125, width=100, slant=0), styleName="Black", familyName=familyName, copyInfo=False),
+    
+    dict(path="master_ufo/Roboto-ThinItalic.ufo", name="Roboto-ThinItalic.ufo", location=dict(weight=-1, width=100, slant=-12), styleName="Thin Italic", familyName=familyName, copyInfo=False),
+    dict(path="master_ufo/Roboto-Italic.ufo", name="Roboto-Italic.ufo", location=dict(weight=-0.1, width=100, slant=-12), styleName="Italic", familyName=familyName, copyInfo=False),
+    dict(path="master_ufo/Roboto-BlackItalic.ufo", name="Roboto-BlackItalic.ufo", location=dict(weight=1.125, width=100, slant=-12), styleName="Black Italic", familyName=familyName, copyInfo=False),
 
-	dict(path="master_ufo/RobotoCondensed-Light.ufo", name="RobotoCondensed-Light.ufo", location=dict(weight=-0.55, width=75), styleName="Condensed Light", familyName=familyName, copyInfo=False),
-	dict(path="master_ufo/RobotoCondensed-Regular.ufo", name="RobotoCondensed-Regular.ufo", location=dict(width=75), styleName="Condensed Regular", familyName=familyName, copyInfo=False),
-	dict(path="master_ufo/RobotoCondensed-Bold.ufo", name="RobotoCondensed-Bold.ufo", location=dict(weight=0.75, width=75), styleName="Condensed Bold", familyName=familyName, copyInfo=False),
+    dict(path="master_ufo/RobotoCondensed-Light.ufo", name="RobotoCondensed-Light.ufo", location=dict(weight=-0.55, width=75, slant=0), styleName="Condensed Light", familyName=familyName, copyInfo=False),
+    dict(path="master_ufo/RobotoCondensed-Regular.ufo", name="RobotoCondensed-Regular.ufo", location=dict(weight=-0.1, width=75, slant=0), styleName="Condensed Regular", familyName=familyName, copyInfo=False),
+    dict(path="master_ufo/RobotoCondensed-Bold.ufo", name="RobotoCondensed-Bold.ufo", location=dict(weight=0.75, width=75, slant=0), styleName="Condensed Bold", familyName=familyName, copyInfo=False),
 
-	dict(path="master_ufo/RobotoCondensed-LightItalic.ufo", name="RobotoCondensed-LightItalic.ufo", location=dict(weight=-0.55, width=75, slant=12), styleName="Condensed Light Italic", familyName=familyName, copyInfo=False),
-	dict(path="master_ufo/RobotoCondensed-Italic.ufo", name="RobotoCondensed-Italic.ufo", location=dict(width=75, slant=12), styleName="Condensed Italic", familyName=familyName, copyInfo=False),
-	dict(path="master_ufo/RobotoCondensed-BoldItalic.ufo", name="RobotoCondensed-BoldItalic.ufo", location=dict(weight=0.75, width=75, slant=12), styleName="Condensed Bold Italic", familyName=familyName, copyInfo=False),
+    dict(path="master_ufo/RobotoCondensed-LightItalic.ufo", name="RobotoCondensed-LightItalic.ufo", location=dict(weight=-0.55, width=75, slant=-12), styleName="Condensed Light Italic", familyName=familyName, copyInfo=False),
+    dict(path="master_ufo/RobotoCondensed-Italic.ufo", name="RobotoCondensed-Italic.ufo", location=dict(weight=-0.1, width=75, slant=-12), styleName="Condensed Italic", familyName=familyName, copyInfo=False),
+    dict(path="master_ufo/RobotoCondensed-BoldItalic.ufo", name="RobotoCondensed-BoldItalic.ufo", location=dict(weight=0.75, width=75, slant=-12), styleName="Condensed Bold Italic", familyName=familyName, copyInfo=False),
 ]
 axes = [
-	dict(minimum=-1, maximum=1.125, default=-0.1, name="weight", tag="wght", labelNames={"en": "Weight"}, map=[]),
-	dict(minimum=75, maximum=100, default=100, name="width", tag="wdth", labelNames={"en": "Width"}, map=[]),
-	dict(minimum=0, maximum=12, default=0, name="slant", tag="slnt", labelNames={"en": "Slant"}, map=[]),
+    dict(minimum=250, maximum=900, default=400, name="weight", tag="wght", labelNames={"en": "Weight"}, map=[(250.0, -1.0), (300.0, -0.55), (400.0, -0.1), (500.0, 0.35), (700.0, 0.73), (900.0, 1.125)]),
+    dict(minimum=75, maximum=100, default=100, name="width", tag="wdth", labelNames={"en": "Width"}, map=[]),
+    dict(minimum=-12, maximum=0, default=0, name="slant", tag="slnt", labelNames={"en": "Slant"}, map=[]),
 ]
 
 instances = []
 for source in sources:
-	instances.append(dict(location=source["location"], styleName=source["styleName"], familyName=source["familyName"]))
+    instances.append(dict(location=source["location"], styleName=source["styleName"], familyName=source["familyName"]))
 
 #Thin
 instances.insert(1, dict(location=dict(weight=-0.55), styleName="Light", familyName=familyName))
@@ -40,44 +40,42 @@ instances.insert(3, dict(location=dict(weight=0.35), styleName="Medium", familyN
 instances.insert(4, dict(location=dict(weight=0.73), styleName="Bold", familyName=familyName))
 #Bold
 #Thin Italic
-instances.insert(7, dict(location=dict(weight=-0.55, slant=12), styleName="Light Italic", familyName=familyName))
+instances.insert(7, dict(location=dict(weight=-0.55, slant=-12), styleName="Light Italic", familyName=familyName))
 #Italic
-instances.insert(9, dict(location=dict(weight=0.35, slant=12), styleName="Medium Italic", familyName=familyName))
-instances.insert(10, dict(location=dict(weight=0.73, slant=12), styleName="Bold Italic", familyName=familyName))
+instances.insert(9, dict(location=dict(weight=0.35, slant=-12), styleName="Medium Italic", familyName=familyName))
+instances.insert(10, dict(location=dict(weight=0.73, slant=-12), styleName="Bold Italic", familyName=familyName))
 #Black Italic
-
-instances.pop(2) # fix bug with 2 regular?
 
 doc = DesignSpaceDocument()
 
 for source in sources:
-	s = SourceDescriptor()
-	s.path = source["path"]
-	s.name = source["name"]
-	s.copyInfo = source["copyInfo"]
-	s.location = source["location"]
-	s.familyName = source["familyName"]
-	s.styleName = source["styleName"]
-	doc.addSource(s)
+    s = SourceDescriptor()
+    s.path = source["path"]
+    s.name = source["name"]
+    s.copyInfo = source["copyInfo"]
+    s.location = source["location"]
+    s.familyName = source["familyName"]
+    s.styleName = source["styleName"]
+    doc.addSource(s)
 
 for instance in instances:
-	i = InstanceDescriptor()
-	i.location = instance["location"]
-	i.familyName = instance["familyName"]
-	i.styleName = instance["styleName"]
-	doc.addInstance(i)
+    i = InstanceDescriptor()
+    i.location = instance["location"]
+    i.familyName = instance["familyName"]
+    i.styleName = instance["styleName"]
+    doc.addInstance(i)
 
 for axis in axes:
-	a = AxisDescriptor()
-	a.minimum = axis["minimum"]
-	a.maximum = axis["maximum"]
-	a.default = axis["default"]
-	a.name = axis["name"]
-	a.tag = axis["tag"]
-	for languageCode, labelName in axis["labelNames"].items():
-		a.labelNames[languageCode] = labelName
-	a.map = axis["map"]
-	doc.addAxis(a)
+    a = AxisDescriptor()
+    a.minimum = axis["minimum"]
+    a.maximum = axis["maximum"]
+    a.default = axis["default"]
+    a.name = axis["name"]
+    a.tag = axis["tag"]
+    for languageCode, labelName in axis["labelNames"].items():
+        a.labelNames[languageCode] = labelName
+    a.map = axis["map"]
+    doc.addAxis(a)
 
 #doc.checkAxes()
 


### PR DESCRIPTION
The writeDesignSpace-min.py script has been updated and will fix the following issues we encountered in #13

- Map elements added for weight axis.
- Slant axis uses negative integers
- Regular instance added 
