### PR TITLE
CI/CD: Regression check hinted font against last tagged release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,7 +32,7 @@ jobs:
           sh scripts/regression_test.sh
 
       - name: Upload
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: roboto_files
           path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,15 +24,18 @@ jobs:
       - name: Build fonts
         run: sh sources/build.sh
 
-      - name: Upload fonts
-        uses: actions/upload-artifact@v1
-        with:
-          name: fonts
-          path: fonts/
-
       - name: Test fonts
         run: |
           fontbakery check-profile tests/test_general.py fonts/unhinted/Roboto[ital,wdth,wght].ttf
           fontbakery check-profile tests/test_android.py fonts/android/Roboto[ital,wdth,wght].ttf
           fontbakery check-profile tests/test_web.py fonts/web/Roboto[ital,wdth,wght].ttf
+          sh scripts/regression_test.sh
+
+      - name: Upload
+        uses: actions/upload-artifact@v1
+        with:
+          name: roboto_files
+          path: |
+            fonts/
+            diffs/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ vttLib==0.9.0
 statmake==0.2.2
 git+https://github.com/googlefonts/nototools@2aa38cca1c17d2262fbda706f68623f712dd446e
 fontbakery==0.7.16
-fontdiffenator==0.9.8
+fontdiffenator==0.9.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ vttLib==0.9.0
 statmake==0.2.2
 git+https://github.com/googlefonts/nototools@2aa38cca1c17d2262fbda706f68623f712dd446e
 fontbakery==0.7.16
+fontdiffenator==0.9.8

--- a/scripts/regression_test.sh
+++ b/scripts/regression_test.sh
@@ -20,7 +20,8 @@ diff ()
 {
     diffenator $OLD_FONT $GENNED_FONT -i "$2" \
         -html > $1/index.html \
-        -rd -r ./img/
+        -rd -r ./img/ \
+        --ft-hinting normal
     mv img/ $1
 }
 

--- a/scripts/regression_test.sh
+++ b/scripts/regression_test.sh
@@ -16,7 +16,8 @@ unzip -po Roboto_*.zip "hinted/Roboto\[ital\,wdth\,wght\].ttf" > $OLD_FONT
 
 
 # Diff old hinted variable font against current
-function diff {
+diff ()
+{
     diffenator $OLD_FONT $GENNED_FONT -i "$2" \
         -html > $1/index.html \
         -rd -r ./img/

--- a/scripts/regression_test.sh
+++ b/scripts/regression_test.sh
@@ -1,0 +1,37 @@
+# Regression test generated fonts against last tagged release
+set -e
+
+mkdir -p prev_release
+
+OLD_FONT=prev_release/Roboto\[ital\,wdth\,wght\].ttf
+GENNED_FONT=fonts/hinted/Roboto\[ital\,wdth\,wght\].ttf
+
+curl -s https://api.github.com/repos/TypeNetwork/Roboto/releases/latest \
+| grep "https://github.com/TypeNetwork/Roboto/releases/download/*" \
+| cut -d ":" -f 2,3 \
+| tr -d \"\, \
+| wget -i -
+unzip -po Roboto_*.zip "hinted/Roboto\[ital\,wdth\,wght\].ttf" > $OLD_FONT
+
+
+# Diff old hinted variable font against current
+function diff {
+    diffenator $OLD_FONT $GENNED_FONT -i "$2" \
+        -html > $1/index.html \
+        -rd -r ./img/
+    mv img/ $1
+}
+
+
+mkdir -p diffs \
+	 diffs/Regular \
+	 diffs/Condensed \
+	 diffs/Italic \
+	 diffs/CondensedItalic
+
+
+diff diffs/Regular "wght=400, wdth=100"
+diff diffs/Condensed "wght=400, wdth=75"
+diff diffs/Italic "ital=1, wght=400, wdth=100"
+diff diffs/CondensedItalic "ital=1, wght=400, wdth=75"
+

--- a/scripts/regression_test.sh
+++ b/scripts/regression_test.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Regression test generated fonts against last tagged release
 set -e
 


### PR DESCRIPTION
Currently, when we open a new PR, Github Actions will generate the font files. This PR will diff the generated fonts against the last tagged release. The download artifact will contain both the generated fonts and the diff reports.


cc @chrissimpkins