### PR TITLE
Set glyph overlap bits

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ uharfbuzz==0.37.0
 unicodedata2==15.0.0
 vttLib==0.9.0
 fontbakery==0.8.9
+glyphsets==0.5.0

--- a/scripts/regression_test.sh
+++ b/scripts/regression_test.sh
@@ -12,7 +12,7 @@ curl -s https://api.github.com/repos/googlefonts/roboto-classic/releases/latest 
 | cut -d ":" -f 2,3 \
 | tr -d \"\, \
 | wget -i -
-unzip -po Roboto_*.zip "Roboto_v3.008/hinted/Roboto\[ital\,wdth\,wght\].ttf" > $OLD_FONT
+unzip -po Roboto_*.zip "Roboto_v3.009/hinted/Roboto\[ital\,wdth\,wght\].ttf" > $OLD_FONT
 
 
 # Diff old hinted variable font against current

--- a/scripts/regression_test.sh
+++ b/scripts/regression_test.sh
@@ -12,7 +12,7 @@ curl -s https://api.github.com/repos/googlefonts/roboto-classic/releases/latest 
 | cut -d ":" -f 2,3 \
 | tr -d \"\, \
 | wget -i -
-unzip -po Roboto_*.zip "Roboto_v3.009/hinted/Roboto\[ital\,wdth\,wght\].ttf" > $OLD_FONT
+unzip -po Roboto_*.zip "hinted/Roboto\[ital\,wdth\,wght\].ttf" > $OLD_FONT
 
 
 # Diff old hinted variable font against current

--- a/scripts/set_overlaps.py
+++ b/scripts/set_overlaps.py
@@ -1,0 +1,54 @@
+"""Taken from https://github.com/google/fonts/issues/4405#issuecomment-1079185880"""
+from __future__ import annotations
+
+import argparse
+from typing import Any, Mapping
+
+import pathops
+from fontTools.ttLib import TTFont
+from fontTools.ttLib.removeOverlaps import componentsOverlap, skPathFromGlyph
+from fontTools.ttLib.tables import _g_l_y_f
+
+
+def set_overlap_bits_if_overlapping(varfont: TTFont) -> tuple[int, int]:
+    glyph_set = varfont.getGlyphSet()
+    glyf_table: _g_l_y_f.table__g_l_y_f = varfont["glyf"]
+    flag_overlap_compound = _g_l_y_f.OVERLAP_COMPOUND
+    flag_overlap_simple = _g_l_y_f.flagOverlapSimple
+    overlapping_contours = 0
+    overlapping_components = 0
+    for glyph_name in glyf_table.keys():
+        glyph = glyf_table[glyph_name]
+        # Set OVERLAP_COMPOUND bit for compound glyphs
+        if glyph.isComposite() and componentsOverlap(glyph, glyph_set):
+            overlapping_components += 1
+            glyph.components[0].flags |= flag_overlap_compound
+        # Set OVERLAP_SIMPLE bit for simple glyphs
+        elif glyph.numberOfContours > 0 and glyph_overlaps(glyph_name, glyph_set):
+            overlapping_contours += 1
+            glyph.flags[0] |= flag_overlap_simple
+    return (overlapping_contours, overlapping_components)
+
+
+def glyph_overlaps(glyph_name: str, glyph_set: Mapping[str, Any]) -> bool:
+    path = skPathFromGlyph(glyph_name, glyph_set)
+    path2 = pathops.simplify(path, clockwise=path.clockwise)  # remove overlaps
+    if path != path2:
+        return True
+    return False
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("font", type=TTFont)
+parsed_args = parser.parse_args()
+
+font = parsed_args.font
+ocont, ocomp = set_overlap_bits_if_overlapping(font)
+num_glyphs = font["maxp"].numGlyphs
+ocont_p = ocont / num_glyphs
+ocomp_p = ocomp / num_glyphs
+print(
+    font.reader.file.name,
+    f"{num_glyphs} glyphs, {ocont} overlapping contours ({ocont_p:.2%}), {ocomp} overlapping components ({ocomp_p:.2%})",
+)
+font.save(font.reader.file.name)

--- a/sources/Roboto-Black.ufo/fontinfo.plist
+++ b/sources/Roboto-Black.ufo/fontinfo.plist
@@ -377,7 +377,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-BlackItalic.ufo/fontinfo.plist
+++ b/sources/Roboto-BlackItalic.ufo/fontinfo.plist
@@ -379,7 +379,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-Italic.ufo/fontinfo.plist
+++ b/sources/Roboto-Italic.ufo/fontinfo.plist
@@ -375,7 +375,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-Regular.ufo/fontinfo.plist
+++ b/sources/Roboto-Regular.ufo/fontinfo.plist
@@ -373,7 +373,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-Thin.ufo/fontinfo.plist
+++ b/sources/Roboto-Thin.ufo/fontinfo.plist
@@ -337,7 +337,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Roboto-ThinItalic.ufo/fontinfo.plist
@@ -339,7 +339,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-Bold.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Bold.ufo/fontinfo.plist
@@ -373,7 +373,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-BoldItalic.ufo/fontinfo.plist
@@ -375,7 +375,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-Italic.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Italic.ufo/fontinfo.plist
@@ -375,7 +375,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-Light.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Light.ufo/fontinfo.plist
@@ -377,7 +377,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-LightItalic.ufo/fontinfo.plist
@@ -379,7 +379,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-Regular.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Regular.ufo/fontinfo.plist
@@ -373,7 +373,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-Thin.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Thin.ufo/fontinfo.plist
@@ -59,7 +59,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>9</integer>
+    <integer>10</integer>
     <key>xHeight</key>
     <integer>1082</integer>
   </dict>

--- a/sources/build.sh
+++ b/sources/build.sh
@@ -7,6 +7,7 @@ mkdir -p fonts
 mkdir -p fonts/unhinted
 UNHINTED_VF_PATH=fonts/unhinted/Roboto[ital,wdth,wght].ttf
 fontmake -m sources/Roboto.designspace -o variable --output-path $UNHINTED_VF_PATH
+python scripts/set_overlaps.py $UNHINTED_VF_PATH
 python scripts/drop_mvar.py $UNHINTED_VF_PATH
 python scripts/gen_stat.py $UNHINTED_VF_PATH
 python scripts/instantiate_statics.py $UNHINTED_VF_PATH fonts/unhinted/static


### PR DESCRIPTION
Some internal Google Teams have reported that glyph overlaps are not rendering well on Android or Mac. This PR will enable overlap bits for glyphs that have overlapping contours. The bits are set as a post production step using a new script, `scripts/set_overlaps.py`