### PR TITLE
Center colon between two numbers with contextual alternates

### DIFF
--- a/sources/Roboto-Black.ufo/features.fea
+++ b/sources/Roboto-Black.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/Roboto-BlackItalic.ufo/features.fea
+++ b/sources/Roboto-BlackItalic.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/Roboto-Italic.ufo/features.fea
+++ b/sources/Roboto-Italic.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/Roboto-Regular.ufo/features.fea
+++ b/sources/Roboto-Regular.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/Roboto-Thin.ufo/features.fea
+++ b/sources/Roboto-Thin.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/Roboto-ThinItalic.ufo/features.fea
+++ b/sources/Roboto-ThinItalic.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/RobotoCondensed-Bold.ufo/features.fea
+++ b/sources/RobotoCondensed-Bold.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/RobotoCondensed-BoldItalic.ufo/features.fea
+++ b/sources/RobotoCondensed-BoldItalic.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/RobotoCondensed-Italic.ufo/features.fea
+++ b/sources/RobotoCondensed-Italic.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/RobotoCondensed-Light.ufo/features.fea
+++ b/sources/RobotoCondensed-Light.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/RobotoCondensed-LightItalic.ufo/features.fea
+++ b/sources/RobotoCondensed-LightItalic.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/RobotoCondensed-Regular.ufo/features.fea
+++ b/sources/RobotoCondensed-Regular.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);

--- a/sources/RobotoCondensed-Thin.ufo/features.fea
+++ b/sources/RobotoCondensed-Thin.ufo/features.fea
@@ -1024,4 +1024,8 @@ feature subs {
    sub @frac1 by @subs;
 } subs;
 
+feature calt {
+  sub [ @LNUM @PNUM ] colon' [ @LNUM @PNUM ] by colon.pnum;
+} calt;
+
 include(BASE.fea);


### PR DESCRIPTION
This change makes it so a colon is automatically centered when it is placed between two numbers by substituting it with colon.pnum (U+EE01), a character that has been used for the clock in Android's lockscreen.