### PR TITLE
Add 18 new glyphs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-python@v1
         with:
           # TODO use build matrix?
-          python-version: 3.11.14
+          python-version: 3.11.15
 
       - name: Install dependencies
         run: |

--- a/sources/Roboto-Black.ufo/fontinfo.plist
+++ b/sources/Roboto-Black.ufo/fontinfo.plist
@@ -377,7 +377,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-Black.ufo/glyphs/contents.plist
+++ b/sources/Roboto-Black.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/Roboto-Black.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="1133"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="111" y="0" type="line"/>
+      <point x="576" y="0" type="line" smooth="yes"/>
+      <point x="844" y="0"/>
+      <point x="1049" y="117"/>
+      <point x="1049" y="418" type="curve" smooth="yes"/>
+      <point x="1049" y="670"/>
+      <point x="906" y="735"/>
+      <point x="810" y="766" type="curve"/>
+      <point x="810" y="776" type="line"/>
+      <point x="894" y="803"/>
+      <point x="1027" y="872"/>
+      <point x="1027" y="1098" type="curve" smooth="yes"/>
+      <point x="1027" y="1326"/>
+      <point x="889" y="1455"/>
+      <point x="537" y="1455" type="curve" smooth="yes"/>
+      <point x="111" y="1455" type="line"/>
+    </contour>
+    <contour>
+      <point x="279" y="-201" type="line"/>
+      <point x="484" y="-201" type="line"/>
+      <point x="484" y="154" type="line"/>
+      <point x="279" y="154" type="line"/>
+    </contour>
+    <contour>
+      <point x="586" y="-201" type="line"/>
+      <point x="791" y="-201" type="line"/>
+      <point x="791" y="154" type="line"/>
+      <point x="586" y="154" type="line"/>
+    </contour>
+    <contour>
+      <point x="488" y="305" type="line"/>
+      <point x="488" y="612" type="line"/>
+      <point x="537" y="612" type="line" smooth="yes"/>
+      <point x="629" y="612"/>
+      <point x="662" y="539"/>
+      <point x="662" y="457" type="curve" smooth="yes"/>
+      <point x="662" y="371"/>
+      <point x="625" y="305"/>
+      <point x="543" y="305" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="488" y="901" type="line"/>
+      <point x="488" y="1156" type="line"/>
+      <point x="523" y="1156" type="line" smooth="yes"/>
+      <point x="594" y="1156"/>
+      <point x="640" y="1115"/>
+      <point x="640" y="1038" type="curve" smooth="yes"/>
+      <point x="640" y="963"/>
+      <point x="603" y="901"/>
+      <point x="525" y="901" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="279" y="1308" type="line"/>
+      <point x="484" y="1308" type="line"/>
+      <point x="484" y="1662" type="line"/>
+      <point x="279" y="1662" type="line"/>
+    </contour>
+    <contour>
+      <point x="586" y="1308" type="line"/>
+      <point x="791" y="1308" type="line"/>
+      <point x="791" y="1662" type="line"/>
+      <point x="586" y="1662" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Black.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Black.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="1213"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="453" y="0" type="line"/>
+      <point x="1176" y="0" type="line"/>
+      <point x="1176" y="205" type="line"/>
+      <point x="717" y="205" type="line"/>
+      <point x="717" y="328" type="line"/>
+      <point x="767" y="332"/>
+      <point x="814" y="348"/>
+      <point x="892" y="387" type="curve"/>
+      <point x="892" y="596" type="line"/>
+      <point x="820" y="563"/>
+      <point x="771" y="541"/>
+      <point x="717" y="535" type="curve"/>
+      <point x="717" y="1077" type="line"/>
+      <point x="762" y="1073"/>
+      <point x="795" y="1053"/>
+      <point x="861" y="1026" type="curve"/>
+      <point x="914" y="1223" type="line"/>
+      <point x="830" y="1257"/>
+      <point x="785" y="1276"/>
+      <point x="717" y="1280" type="curve"/>
+      <point x="717" y="1462" type="line"/>
+      <point x="453" y="1462" type="line"/>
+      <point x="453" y="1268" type="line"/>
+      <point x="234" y="1227"/>
+      <point x="70" y="1083"/>
+      <point x="70" y="805" type="curve" smooth="yes"/>
+      <point x="70" y="528"/>
+      <point x="218" y="379"/>
+      <point x="453" y="338" type="curve"/>
+    </contour>
+    <contour>
+      <point x="453" y="553" type="line"/>
+      <point x="367" y="604"/>
+      <point x="336" y="678"/>
+      <point x="336" y="805" type="curve" smooth="yes"/>
+      <point x="336" y="932"/>
+      <point x="367" y="1004"/>
+      <point x="453" y="1059" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="1195"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1303"/>
+  <unicode hex="2108"/>
+  <anchor x="636" y="1600" name="parent_top"/>
+  <anchor x="636" y="1600" name="top"/>
+  <anchor x="1303" y="1600" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="620" y="-21" type="curve" smooth="yes"/>
+      <point x="1008" y="-21"/>
+      <point x="1236" y="249"/>
+      <point x="1236" y="687" type="curve" smooth="yes"/>
+      <point x="1236" y="765" type="line" smooth="yes"/>
+      <point x="1236" y="1204"/>
+      <point x="995" y="1476"/>
+      <point x="624" y="1476" type="curve" smooth="yes"/>
+      <point x="244" y="1476"/>
+      <point x="43" y="1254"/>
+      <point x="15" y="952" type="curve"/>
+      <point x="365" y="952" type="line"/>
+      <point x="370" y="1116"/>
+      <point x="438" y="1205"/>
+      <point x="624" y="1205" type="curve" smooth="yes"/>
+      <point x="797" y="1205"/>
+      <point x="887" y="1078"/>
+      <point x="887" y="767" type="curve" smooth="yes"/>
+      <point x="887" y="687" type="line" smooth="yes"/>
+      <point x="887" y="378"/>
+      <point x="811" y="248"/>
+      <point x="620" y="248" type="curve" smooth="yes"/>
+      <point x="460" y="248"/>
+      <point x="372" y="328"/>
+      <point x="367" y="492" type="curve"/>
+      <point x="17" y="492" type="line"/>
+      <point x="33" y="187"/>
+      <point x="261" y="-21"/>
+    </contour>
+    <contour>
+      <point x="481" y="593" type="line"/>
+      <point x="1110" y="593" type="line"/>
+      <point x="1110" y="864" type="line"/>
+      <point x="481" y="864" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2108.glif
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Black.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1712"/>
+  <unicode hex="2114"/>
+  <anchor x="1250" y="-10" name="bottom"/>
+  <anchor x="1712" y="-407" name="bottom_dd"/>
+  <anchor x="738" y="1486" name="marktop"/>
+  <anchor x="1240" y="1600" name="parent_top"/>
+  <anchor x="1240" y="1600" name="top"/>
+  <anchor x="1712" y="1600" name="top0315"/>
+  <anchor x="1712" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1238" y="-20" type="curve" smooth="yes"/>
+      <point x="1526" y="-20"/>
+      <point x="1658" y="205"/>
+      <point x="1658" y="532" type="curve" smooth="yes"/>
+      <point x="1658" y="553" type="line"/>
+      <point x="1658" y="870"/>
+      <point x="1526" y="1102"/>
+      <point x="1236" y="1102" type="curve" smooth="yes"/>
+      <point x="977" y="1102"/>
+      <point x="875" y="856"/>
+      <point x="831" y="554" type="curve"/>
+      <point x="831" y="529" type="line"/>
+      <point x="875" y="225"/>
+      <point x="977" y="-20"/>
+    </contour>
+    <contour>
+      <point x="149" y="0" type="line"/>
+      <point x="487" y="0" type="line"/>
+      <point x="487" y="1536" type="line"/>
+      <point x="149" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="657" y="0" type="line"/>
+      <point x="959" y="0" type="line"/>
+      <point x="994" y="266" type="line"/>
+      <point x="994" y="1536" type="line"/>
+      <point x="657" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="1154" y="239" type="curve" smooth="yes"/>
+      <point x="1008" y="239"/>
+      <point x="961" y="335"/>
+      <point x="965" y="502" type="curve"/>
+      <point x="965" y="581" type="line"/>
+      <point x="962" y="744"/>
+      <point x="1008" y="842"/>
+      <point x="1152" y="842" type="curve" smooth="yes"/>
+      <point x="1293" y="842"/>
+      <point x="1321" y="710"/>
+      <point x="1321" y="553" type="curve" smooth="yes"/>
+      <point x="1321" y="532" type="line"/>
+      <point x="1321" y="358"/>
+      <point x="1299" y="239"/>
+    </contour>
+    <contour>
+      <point x="-31" y="1211" type="line"/>
+      <point x="1191" y="1211" type="line"/>
+      <point x="1191" y="1402" type="line"/>
+      <point x="-31" y="1402" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="786"/>
+  <advance width="1610"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="205" y="-241" type="curve" smooth="yes"/>
-      <point x="272" y="-241"/>
-      <point x="318" y="-180"/>
-      <point x="318" y="-95" type="curve" smooth="yes"/>
-      <point x="318" y="8"/>
-      <point x="229" y="99"/>
-      <point x="174" y="200" type="curve"/>
-      <point x="220" y="272"/>
-      <point x="279" y="341"/>
-      <point x="338" y="394" type="curve" smooth="yes"/>
-      <point x="403" y="452"/>
-      <point x="472" y="492"/>
-      <point x="530" y="492" type="curve" smooth="yes"/>
-      <point x="629" y="492"/>
-      <point x="636" y="359"/>
-      <point x="636" y="322" type="curve" smooth="yes"/>
-      <point x="636" y="285"/>
-      <point x="624" y="30"/>
-      <point x="465" y="30" type="curve" smooth="yes"/>
-      <point x="415" y="30"/>
-      <point x="367" y="57"/>
-      <point x="367" y="112" type="curve" smooth="yes"/>
-      <point x="367" y="119"/>
-      <point x="368" y="126"/>
-      <point x="370" y="132" type="curve"/>
-      <point x="402" y="136"/>
-      <point x="434" y="151"/>
-      <point x="434" y="194" type="curve" smooth="yes"/>
-      <point x="434" y="225"/>
-      <point x="413" y="244"/>
-      <point x="383" y="244" type="curve" smooth="yes"/>
-      <point x="336" y="244"/>
-      <point x="308" y="206"/>
-      <point x="308" y="140" type="curve" smooth="yes"/>
-      <point x="308" y="51"/>
-      <point x="369" y="-10"/>
-      <point x="472" y="-10" type="curve" smooth="yes"/>
-      <point x="644" y="-10"/>
-      <point x="735" y="159"/>
-      <point x="735" y="306" type="curve" smooth="yes"/>
-      <point x="735" y="437"/>
-      <point x="676" y="549"/>
-      <point x="559" y="549" type="curve" smooth="yes"/>
-      <point x="510" y="549"/>
-      <point x="418" y="512"/>
-      <point x="315" y="419" type="curve" smooth="yes"/>
-      <point x="264" y="373"/>
-      <point x="205" y="310"/>
-      <point x="155" y="238" type="curve"/>
-      <point x="140" y="272"/>
-      <point x="131" y="307"/>
-      <point x="131" y="345" type="curve" smooth="yes"/>
-      <point x="131" y="474"/>
-      <point x="160" y="548"/>
-      <point x="238" y="625" type="curve"/>
-      <point x="223" y="647" type="line"/>
-      <point x="166" y="610"/>
-      <point x="46" y="496"/>
-      <point x="46" y="337" type="curve" smooth="yes"/>
-      <point x="46" y="267"/>
-      <point x="69" y="206"/>
-      <point x="100" y="149" type="curve"/>
-      <point x="66" y="85"/>
-      <point x="41" y="11"/>
-      <point x="41" y="-56" type="curve" smooth="yes"/>
-      <point x="41" y="-163"/>
-      <point x="112" y="-241"/>
+      <point x="420" y="-494" type="curve" smooth="yes"/>
+      <point x="557" y="-494"/>
+      <point x="651" y="-369"/>
+      <point x="651" y="-195" type="curve" smooth="yes"/>
+      <point x="651" y="16"/>
+      <point x="469" y="203"/>
+      <point x="356" y="410" type="curve"/>
+      <point x="451" y="557"/>
+      <point x="571" y="698"/>
+      <point x="692" y="807" type="curve" smooth="yes"/>
+      <point x="825" y="926"/>
+      <point x="967" y="1008"/>
+      <point x="1085" y="1008" type="curve" smooth="yes"/>
+      <point x="1288" y="1008"/>
+      <point x="1303" y="735"/>
+      <point x="1303" y="659" type="curve" smooth="yes"/>
+      <point x="1303" y="584"/>
+      <point x="1278" y="61"/>
+      <point x="952" y="61" type="curve" smooth="yes"/>
+      <point x="850" y="61"/>
+      <point x="752" y="117"/>
+      <point x="752" y="229" type="curve" smooth="yes"/>
+      <point x="752" y="244"/>
+      <point x="754" y="258"/>
+      <point x="758" y="270" type="curve"/>
+      <point x="823" y="279"/>
+      <point x="889" y="309"/>
+      <point x="889" y="397" type="curve" smooth="yes"/>
+      <point x="889" y="461"/>
+      <point x="846" y="500"/>
+      <point x="784" y="500" type="curve" smooth="yes"/>
+      <point x="688" y="500"/>
+      <point x="631" y="422"/>
+      <point x="631" y="287" type="curve" smooth="yes"/>
+      <point x="631" y="104"/>
+      <point x="756" y="-20"/>
+      <point x="967" y="-20" type="curve" smooth="yes"/>
+      <point x="1319" y="-20"/>
+      <point x="1505" y="326"/>
+      <point x="1505" y="627" type="curve" smooth="yes"/>
+      <point x="1505" y="895"/>
+      <point x="1384" y="1124"/>
+      <point x="1145" y="1124" type="curve" smooth="yes"/>
+      <point x="1044" y="1124"/>
+      <point x="856" y="1049"/>
+      <point x="645" y="858" type="curve" smooth="yes"/>
+      <point x="541" y="764"/>
+      <point x="420" y="635"/>
+      <point x="317" y="487" type="curve"/>
+      <point x="287" y="557"/>
+      <point x="268" y="629"/>
+      <point x="268" y="707" type="curve" smooth="yes"/>
+      <point x="268" y="971"/>
+      <point x="328" y="1122"/>
+      <point x="487" y="1280" type="curve"/>
+      <point x="457" y="1325" type="line"/>
+      <point x="340" y="1249"/>
+      <point x="94" y="1016"/>
+      <point x="94" y="690" type="curve" smooth="yes"/>
+      <point x="94" y="547"/>
+      <point x="141" y="422"/>
+      <point x="205" y="305" type="curve"/>
+      <point x="135" y="174"/>
+      <point x="84" y="23"/>
+      <point x="84" y="-115" type="curve" smooth="yes"/>
+      <point x="84" y="-334"/>
+      <point x="229" y="-494"/>
     </contour>
     <contour>
-      <point x="188" y="-199" type="curve" smooth="yes"/>
-      <point x="144" y="-199"/>
-      <point x="80" y="-145"/>
-      <point x="80" y="-51" type="curve" smooth="yes"/>
-      <point x="80" y="-4"/>
-      <point x="96" y="52"/>
-      <point x="123" y="110" type="curve"/>
-      <point x="174" y="24"/>
-      <point x="234" y="-52"/>
-      <point x="234" y="-134" type="curve" smooth="yes"/>
-      <point x="234" y="-176"/>
-      <point x="216" y="-199"/>
+      <point x="385" y="-408" type="curve" smooth="yes"/>
+      <point x="295" y="-408"/>
+      <point x="164" y="-297"/>
+      <point x="164" y="-104" type="curve" smooth="yes"/>
+      <point x="164" y="-8"/>
+      <point x="197" y="106"/>
+      <point x="252" y="225" type="curve"/>
+      <point x="356" y="49"/>
+      <point x="479" y="-106"/>
+      <point x="479" y="-274" type="curve" smooth="yes"/>
+      <point x="479" y="-360"/>
+      <point x="442" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="786"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="205" y="-241" type="curve" smooth="yes"/>
+      <point x="272" y="-241"/>
+      <point x="318" y="-180"/>
+      <point x="318" y="-95" type="curve" smooth="yes"/>
+      <point x="318" y="8"/>
+      <point x="229" y="99"/>
+      <point x="174" y="200" type="curve"/>
+      <point x="220" y="272"/>
+      <point x="279" y="341"/>
+      <point x="338" y="394" type="curve" smooth="yes"/>
+      <point x="403" y="452"/>
+      <point x="472" y="492"/>
+      <point x="530" y="492" type="curve" smooth="yes"/>
+      <point x="629" y="492"/>
+      <point x="636" y="359"/>
+      <point x="636" y="322" type="curve" smooth="yes"/>
+      <point x="636" y="285"/>
+      <point x="624" y="30"/>
+      <point x="465" y="30" type="curve" smooth="yes"/>
+      <point x="415" y="30"/>
+      <point x="367" y="57"/>
+      <point x="367" y="112" type="curve" smooth="yes"/>
+      <point x="367" y="119"/>
+      <point x="368" y="126"/>
+      <point x="370" y="132" type="curve"/>
+      <point x="402" y="136"/>
+      <point x="434" y="151"/>
+      <point x="434" y="194" type="curve" smooth="yes"/>
+      <point x="434" y="225"/>
+      <point x="413" y="244"/>
+      <point x="383" y="244" type="curve" smooth="yes"/>
+      <point x="336" y="244"/>
+      <point x="308" y="206"/>
+      <point x="308" y="140" type="curve" smooth="yes"/>
+      <point x="308" y="51"/>
+      <point x="369" y="-10"/>
+      <point x="472" y="-10" type="curve" smooth="yes"/>
+      <point x="644" y="-10"/>
+      <point x="735" y="159"/>
+      <point x="735" y="306" type="curve" smooth="yes"/>
+      <point x="735" y="437"/>
+      <point x="676" y="549"/>
+      <point x="559" y="549" type="curve" smooth="yes"/>
+      <point x="510" y="549"/>
+      <point x="418" y="512"/>
+      <point x="315" y="419" type="curve" smooth="yes"/>
+      <point x="264" y="373"/>
+      <point x="205" y="310"/>
+      <point x="155" y="238" type="curve"/>
+      <point x="140" y="272"/>
+      <point x="131" y="307"/>
+      <point x="131" y="345" type="curve" smooth="yes"/>
+      <point x="131" y="474"/>
+      <point x="160" y="548"/>
+      <point x="238" y="625" type="curve"/>
+      <point x="223" y="647" type="line"/>
+      <point x="166" y="610"/>
+      <point x="46" y="496"/>
+      <point x="46" y="337" type="curve" smooth="yes"/>
+      <point x="46" y="267"/>
+      <point x="69" y="206"/>
+      <point x="100" y="149" type="curve"/>
+      <point x="66" y="85"/>
+      <point x="41" y="11"/>
+      <point x="41" y="-56" type="curve" smooth="yes"/>
+      <point x="41" y="-163"/>
+      <point x="112" y="-241"/>
+    </contour>
+    <contour>
+      <point x="188" y="-199" type="curve" smooth="yes"/>
+      <point x="144" y="-199"/>
+      <point x="80" y="-145"/>
+      <point x="80" y="-51" type="curve" smooth="yes"/>
+      <point x="80" y="-4"/>
+      <point x="96" y="52"/>
+      <point x="123" y="110" type="curve"/>
+      <point x="174" y="24"/>
+      <point x="234" y="-52"/>
+      <point x="234" y="-134" type="curve" smooth="yes"/>
+      <point x="234" y="-176"/>
+      <point x="216" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2127.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1382"/>
+  <advance width="1369"/>
   <unicode hex="2127"/>
-  <anchor x="697" y="1445" name="top"/>
+  <anchor x="684" y="1445" name="top"/>
   <outline>
     <contour>
-      <point x="699" y="-20" type="curve" smooth="yes"/>
-      <point x="1046" y="-20"/>
-      <point x="1283" y="232"/>
-      <point x="1283" y="586" type="curve"/>
-      <point x="1283" y="661" type="line"/>
-      <point x="1283" y="1028"/>
-      <point x="986" y="1293"/>
-      <point x="742" y="1323" type="curve"/>
-      <point x="742" y="1177" type="line"/>
-      <point x="823" y="1126"/>
-      <point x="882" y="986"/>
-      <point x="882" y="661" type="curve"/>
-      <point x="882" y="584" type="line"/>
-      <point x="882" y="366"/>
-      <point x="814" y="254"/>
-      <point x="699" y="254" type="curve" smooth="yes"/>
-      <point x="582" y="254"/>
-      <point x="513" y="366"/>
-      <point x="513" y="584" type="curve"/>
-      <point x="513" y="661" type="line"/>
-      <point x="513" y="984"/>
-      <point x="573" y="1125"/>
-      <point x="647" y="1177" type="curve"/>
-      <point x="647" y="1323" type="line"/>
-      <point x="407" y="1291"/>
-      <point x="112" y="1028"/>
-      <point x="112" y="661" type="curve"/>
-      <point x="112" y="586" type="line"/>
-      <point x="112" y="232"/>
-      <point x="351" y="-20"/>
+      <point x="686" y="-20" type="curve" smooth="yes"/>
+      <point x="1033" y="-20"/>
+      <point x="1270" y="232"/>
+      <point x="1270" y="586" type="curve"/>
+      <point x="1270" y="661" type="line"/>
+      <point x="1270" y="1028"/>
+      <point x="973" y="1293"/>
+      <point x="729" y="1323" type="curve"/>
+      <point x="729" y="1177" type="line"/>
+      <point x="810" y="1126"/>
+      <point x="869" y="986"/>
+      <point x="869" y="661" type="curve"/>
+      <point x="869" y="584" type="line"/>
+      <point x="869" y="366"/>
+      <point x="801" y="254"/>
+      <point x="686" y="254" type="curve" smooth="yes"/>
+      <point x="569" y="254"/>
+      <point x="500" y="366"/>
+      <point x="500" y="584" type="curve"/>
+      <point x="500" y="661" type="line"/>
+      <point x="500" y="984"/>
+      <point x="560" y="1125"/>
+      <point x="634" y="1177" type="curve"/>
+      <point x="634" y="1323" type="line"/>
+      <point x="394" y="1291"/>
+      <point x="99" y="1028"/>
+      <point x="99" y="661" type="curve"/>
+      <point x="99" y="586" type="line"/>
+      <point x="99" y="232"/>
+      <point x="338" y="-20"/>
     </contour>
     <contour>
-      <point x="134" y="1181" type="line"/>
-      <point x="647" y="1181" type="line"/>
-      <point x="647" y="1455" type="line"/>
-      <point x="134" y="1455" type="line"/>
+      <point x="121" y="1181" type="line"/>
+      <point x="634" y="1181" type="line"/>
+      <point x="634" y="1455" type="line"/>
+      <point x="121" y="1455" type="line"/>
     </contour>
     <contour>
-      <point x="742" y="1181" type="line"/>
-      <point x="1262" y="1181" type="line"/>
-      <point x="1262" y="1455" type="line"/>
-      <point x="742" y="1455" type="line"/>
+      <point x="729" y="1181" type="line"/>
+      <point x="1249" y="1181" type="line"/>
+      <point x="1249" y="1455" type="line"/>
+      <point x="729" y="1455" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1382"/>
+  <unicode hex="2127"/>
+  <anchor x="697" y="1445" name="top"/>
+  <outline>
+    <contour>
+      <point x="699" y="-20" type="curve" smooth="yes"/>
+      <point x="1046" y="-20"/>
+      <point x="1283" y="232"/>
+      <point x="1283" y="586" type="curve"/>
+      <point x="1283" y="661" type="line"/>
+      <point x="1283" y="1028"/>
+      <point x="986" y="1293"/>
+      <point x="742" y="1323" type="curve"/>
+      <point x="742" y="1177" type="line"/>
+      <point x="823" y="1126"/>
+      <point x="882" y="986"/>
+      <point x="882" y="661" type="curve"/>
+      <point x="882" y="584" type="line"/>
+      <point x="882" y="366"/>
+      <point x="814" y="254"/>
+      <point x="699" y="254" type="curve" smooth="yes"/>
+      <point x="582" y="254"/>
+      <point x="513" y="366"/>
+      <point x="513" y="584" type="curve"/>
+      <point x="513" y="661" type="line"/>
+      <point x="513" y="984"/>
+      <point x="573" y="1125"/>
+      <point x="647" y="1177" type="curve"/>
+      <point x="647" y="1323" type="line"/>
+      <point x="407" y="1291"/>
+      <point x="112" y="1028"/>
+      <point x="112" y="661" type="curve"/>
+      <point x="112" y="586" type="line"/>
+      <point x="112" y="232"/>
+      <point x="351" y="-20"/>
+    </contour>
+    <contour>
+      <point x="134" y="1181" type="line"/>
+      <point x="647" y="1181" type="line"/>
+      <point x="647" y="1455" type="line"/>
+      <point x="134" y="1455" type="line"/>
+    </contour>
+    <contour>
+      <point x="742" y="1181" type="line"/>
+      <point x="1262" y="1181" type="line"/>
+      <point x="1262" y="1455" type="line"/>
+      <point x="742" y="1455" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="699"/>
+  <unicode hex="2129"/>
+  <anchor x="405" y="-197" name="bottom"/>
+  <anchor x="0" y="-197" name="bottom0315"/>
+  <anchor x="405" y="-197" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="254" y="-11" type="line"/>
+      <point x="592" y="-11" type="line"/>
+      <point x="592" y="751" type="line"/>
+      <point x="592" y="986"/>
+      <point x="468" y="1082"/>
+      <point x="251" y="1082" type="curve" smooth="yes"/>
+      <point x="180" y="1082"/>
+      <point x="120" y="1072"/>
+      <point x="61" y="1053" type="curve"/>
+      <point x="61" y="812" type="line"/>
+      <point x="84" y="816"/>
+      <point x="107" y="818"/>
+      <point x="145" y="818" type="curve" smooth="yes"/>
+      <point x="228" y="818"/>
+      <point x="255" y="795"/>
+      <point x="255" y="709" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="563"/>
+  <unicode hex="2139"/>
+  <anchor x="281" y="10" name="bottom"/>
+  <anchor x="563" y="-407" name="bottom_dd"/>
+  <anchor x="280" y="1600" name="parent_top"/>
+  <anchor x="361" y="654" name="rhotichook"/>
+  <anchor x="280" y="1600" name="top"/>
+  <anchor x="563" y="1600" name="top0315"/>
+  <anchor x="563" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2139.glif
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni213A_.glif
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1795"/>
+  <unicode hex="213A"/>
+  <anchor x="1539" y="663" name="bottom"/>
+  <anchor x="1936" y="1379" name="bottom_dd"/>
+  <anchor x="-71" y="665" name="parent_top"/>
+  <anchor x="-71" y="665" name="top"/>
+  <anchor x="-71" y="1379" name="top0315"/>
+  <anchor x="-71" y="1379" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="772" y="37" type="curve"/>
+      <point x="831" y="37" type="line"/>
+      <point x="1276" y="37"/>
+      <point x="1549" y="300"/>
+      <point x="1549" y="675" type="curve" smooth="yes"/>
+      <point x="1549" y="1047"/>
+      <point x="1276" y="1311"/>
+      <point x="831" y="1311" type="curve"/>
+      <point x="772" y="1311" type="line"/>
+      <point x="327" y="1311"/>
+      <point x="53" y="1045"/>
+      <point x="53" y="673" type="curve" smooth="yes"/>
+      <point x="53" y="298"/>
+      <point x="327" y="37"/>
+    </contour>
+    <contour>
+      <point x="770" y="394" type="line" smooth="yes"/>
+      <point x="482" y="394"/>
+      <point x="328" y="487"/>
+      <point x="328" y="673" type="curve" smooth="yes"/>
+      <point x="328" y="852"/>
+      <point x="482" y="954"/>
+      <point x="770" y="954" type="curve"/>
+      <point x="831" y="954" type="line"/>
+      <point x="1116" y="954"/>
+      <point x="1275" y="854"/>
+      <point x="1275" y="675" type="curve" smooth="yes"/>
+      <point x="1275" y="489"/>
+      <point x="1116" y="394"/>
+      <point x="831" y="394" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1473" y="677" type="line"/>
+      <point x="1795" y="1076" type="line"/>
+      <point x="1611" y="1294" type="line"/>
+      <point x="1289" y="888" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1396"/>
+  <unicode hex="2141"/>
+  <anchor x="686" y="-143" name="bottom"/>
+  <anchor x="0" y="-143" name="bottom0315"/>
+  <anchor x="0" y="-143" name="bottom_dd"/>
+  <anchor x="686" y="-143" name="parent_bottom"/>
+  <anchor x="670" y="1457" name="top"/>
+  <anchor x="0" y="1864" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="692" y="-20" type="curve" smooth="yes"/>
+      <point x="1054" y="-20"/>
+      <point x="1314" y="236"/>
+      <point x="1314" y="689" type="curve" smooth="yes"/>
+      <point x="1314" y="770" type="line" smooth="yes"/>
+      <point x="1314" y="1223"/>
+      <point x="1060" y="1477"/>
+      <point x="673" y="1477" type="curve" smooth="yes"/>
+      <point x="359" y="1477"/>
+      <point x="169" y="1359"/>
+      <point x="94" y="1277" type="curve"/>
+      <point x="94" y="679" type="line"/>
+      <point x="689" y="679" type="line"/>
+      <point x="689" y="920" type="line"/>
+      <point x="445" y="920" type="line"/>
+      <point x="445" y="1146" type="line"/>
+      <point x="474" y="1173"/>
+      <point x="536" y="1207"/>
+      <point x="648" y="1207" type="curve" smooth="yes"/>
+      <point x="862" y="1207"/>
+      <point x="957" y="1061"/>
+      <point x="957" y="770" type="curve" smooth="yes"/>
+      <point x="957" y="687" type="line" smooth="yes"/>
+      <point x="957" y="394"/>
+      <point x="849" y="250"/>
+      <point x="680" y="250" type="curve" smooth="yes"/>
+      <point x="518" y="250"/>
+      <point x="453" y="332"/>
+      <point x="432" y="476" type="curve"/>
+      <point x="95" y="476" type="line"/>
+      <point x="124" y="185"/>
+      <point x="291" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="1110"/>
+  <unicode hex="2142"/>
+  <anchor x="813" y="-144" name="bottom"/>
+  <anchor x="0" y="-144" name="bottom0315"/>
+  <anchor x="0" y="-144" name="bottom_dd"/>
+  <anchor x="813" y="-144" name="parent_bottom"/>
+  <anchor x="518" y="1446" name="top"/>
+  <anchor x="0" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="648" y="0" type="line"/>
+      <point x="999" y="0" type="line"/>
+      <point x="999" y="1456" type="line"/>
+      <point x="648" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="37" y="1186" type="line"/>
+      <point x="773" y="1186" type="line"/>
+      <point x="773" y="1456" type="line"/>
+      <point x="37" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="1110"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="648" y="0" type="line"/>
+      <point x="999" y="0" type="line"/>
+      <point x="999" y="1456" type="line"/>
+      <point x="648" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="37" y="0" type="line"/>
+      <point x="773" y="0" type="line"/>
+      <point x="773" y="270" type="line"/>
+      <point x="37" y="270" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1286"/>
+  <unicode hex="2144"/>
+  <anchor x="642" y="-144" name="bottom"/>
+  <anchor x="0" y="-144" name="bottom0315"/>
+  <anchor x="0" y="-144" name="bottom_dd"/>
+  <anchor x="642" y="-144" name="parent_bottom"/>
+  <anchor x="645" y="1409" name="top"/>
+  <anchor x="0" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="-4" y="0" type="line"/>
+      <point x="374" y="0" type="line"/>
+      <point x="643" y="632" type="line"/>
+      <point x="911" y="0" type="line"/>
+      <point x="1290" y="0" type="line"/>
+      <point x="821" y="933" type="line"/>
+      <point x="821" y="1456" type="line"/>
+      <point x="464" y="1456" type="line"/>
+      <point x="464" y="933" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni214A_.glif
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Black.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1582"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="113" y="300" type="line"/>
+      <point x="464" y="300" type="line"/>
+      <point x="464" y="1185" type="line"/>
+      <point x="894" y="1185" type="line"/>
+      <point x="1041" y="1185"/>
+      <point x="1103" y="1079"/>
+      <point x="1103" y="960" type="curve"/>
+      <point x="1103" y="847"/>
+      <point x="1041" y="765"/>
+      <point x="894" y="765" type="curve"/>
+      <point x="754" y="765" type="line"/>
+      <point x="754" y="494" type="line"/>
+      <point x="894" y="494" type="line"/>
+      <point x="1244" y="494"/>
+      <point x="1458" y="680"/>
+      <point x="1458" y="962" type="curve"/>
+      <point x="1458" y="1247"/>
+      <point x="1244" y="1456"/>
+      <point x="894" y="1456" type="curve"/>
+      <point x="113" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="909" y="0" type="line"/>
+      <point x="1545" y="0" type="line"/>
+      <point x="1545" y="270" type="line"/>
+      <point x="909" y="270" type="line"/>
+    </contour>
+    <contour>
+      <point x="583" y="0" type="line"/>
+      <point x="934" y="0" type="line"/>
+      <point x="934" y="1600" type="line"/>
+      <point x="583" y="1600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1381"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="784" y="-21" type="curve" smooth="yes"/>
+      <point x="1034" y="-21"/>
+      <point x="1195" y="142"/>
+      <point x="1195" y="372" type="curve" smooth="yes"/>
+      <point x="1195" y="520"/>
+      <point x="1107" y="647"/>
+      <point x="969" y="822" type="curve" smooth="yes"/>
+      <point x="411" y="1456" type="line"/>
+      <point x="35" y="1456" type="line"/>
+      <point x="720" y="668" type="line" smooth="yes"/>
+      <point x="822" y="546"/>
+      <point x="904" y="458"/>
+      <point x="904" y="368" type="curve" smooth="yes"/>
+      <point x="904" y="297"/>
+      <point x="864" y="239"/>
+      <point x="785" y="239" type="curve" smooth="yes"/>
+      <point x="714" y="239"/>
+      <point x="673" y="298"/>
+      <point x="673" y="353" type="curve"/>
+      <point x="673" y="398"/>
+      <point x="681" y="445"/>
+      <point x="764" y="498" type="curve"/>
+      <point x="1073" y="691" type="line"/>
+      <point x="1221" y="799"/>
+      <point x="1325" y="896"/>
+      <point x="1325" y="1065" type="curve"/>
+      <point x="1325" y="1306"/>
+      <point x="1143" y="1477"/>
+      <point x="849" y="1477" type="curve"/>
+      <point x="668" y="1477"/>
+      <point x="544" y="1430"/>
+      <point x="404" y="1330" type="curve" smooth="yes"/>
+      <point x="396" y="1326"/>
+      <point x="373" y="1311"/>
+      <point x="366" y="1307" type="curve" smooth="yes"/>
+      <point x="186" y="1171"/>
+      <point x="122" y="964"/>
+      <point x="122" y="728" type="curve"/>
+      <point x="404" y="728" type="line"/>
+      <point x="404" y="1017"/>
+      <point x="611" y="1217"/>
+      <point x="826" y="1217" type="curve" smooth="yes"/>
+      <point x="912" y="1217"/>
+      <point x="986" y="1146"/>
+      <point x="986" y="1042" type="curve"/>
+      <point x="986" y="983"/>
+      <point x="971" y="935"/>
+      <point x="930" y="884" type="curve" smooth="yes"/>
+      <point x="596" y="651" type="line" smooth="yes"/>
+      <point x="485" y="572"/>
+      <point x="403" y="462"/>
+      <point x="403" y="329" type="curve"/>
+      <point x="403" y="140"/>
+      <point x="552" y="-21"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni214B_.glif
@@ -4,66 +4,66 @@
   <unicode hex="214B"/>
   <outline>
     <contour>
-      <point x="784" y="-21" type="curve" smooth="yes"/>
-      <point x="1034" y="-21"/>
-      <point x="1195" y="142"/>
-      <point x="1195" y="372" type="curve" smooth="yes"/>
-      <point x="1195" y="520"/>
-      <point x="1107" y="647"/>
-      <point x="969" y="822" type="curve" smooth="yes"/>
-      <point x="411" y="1456" type="line"/>
-      <point x="35" y="1456" type="line"/>
-      <point x="720" y="668" type="line" smooth="yes"/>
-      <point x="822" y="546"/>
-      <point x="904" y="458"/>
-      <point x="904" y="368" type="curve" smooth="yes"/>
-      <point x="904" y="297"/>
-      <point x="864" y="239"/>
-      <point x="785" y="239" type="curve" smooth="yes"/>
-      <point x="714" y="239"/>
-      <point x="673" y="298"/>
-      <point x="673" y="353" type="curve"/>
-      <point x="673" y="398"/>
-      <point x="681" y="445"/>
-      <point x="764" y="498" type="curve"/>
-      <point x="1073" y="691" type="line"/>
-      <point x="1221" y="799"/>
-      <point x="1325" y="896"/>
-      <point x="1325" y="1065" type="curve"/>
-      <point x="1325" y="1306"/>
-      <point x="1143" y="1477"/>
-      <point x="849" y="1477" type="curve"/>
-      <point x="668" y="1477"/>
-      <point x="544" y="1430"/>
-      <point x="404" y="1330" type="curve" smooth="yes"/>
-      <point x="396" y="1326"/>
-      <point x="373" y="1311"/>
-      <point x="366" y="1307" type="curve" smooth="yes"/>
-      <point x="186" y="1171"/>
-      <point x="122" y="964"/>
-      <point x="122" y="728" type="curve"/>
-      <point x="404" y="728" type="line"/>
-      <point x="404" y="1017"/>
-      <point x="611" y="1217"/>
-      <point x="826" y="1217" type="curve" smooth="yes"/>
-      <point x="912" y="1217"/>
-      <point x="986" y="1146"/>
-      <point x="986" y="1042" type="curve"/>
-      <point x="986" y="983"/>
-      <point x="971" y="935"/>
-      <point x="930" y="884" type="curve" smooth="yes"/>
-      <point x="596" y="651" type="line" smooth="yes"/>
-      <point x="485" y="572"/>
-      <point x="403" y="462"/>
-      <point x="403" y="329" type="curve"/>
-      <point x="403" y="140"/>
-      <point x="552" y="-21"/>
+      <point x="764" y="-21" type="curve" smooth="yes"/>
+      <point x="1014" y="-21"/>
+      <point x="1175" y="142"/>
+      <point x="1175" y="372" type="curve" smooth="yes"/>
+      <point x="1175" y="520"/>
+      <point x="1087" y="647"/>
+      <point x="949" y="822" type="curve" smooth="yes"/>
+      <point x="391" y="1456" type="line"/>
+      <point x="15" y="1456" type="line"/>
+      <point x="700" y="668" type="line" smooth="yes"/>
+      <point x="802" y="546"/>
+      <point x="884" y="458"/>
+      <point x="884" y="368" type="curve" smooth="yes"/>
+      <point x="884" y="297"/>
+      <point x="844" y="239"/>
+      <point x="765" y="239" type="curve" smooth="yes"/>
+      <point x="694" y="239"/>
+      <point x="653" y="298"/>
+      <point x="653" y="353" type="curve"/>
+      <point x="653" y="398"/>
+      <point x="661" y="445"/>
+      <point x="744" y="498" type="curve"/>
+      <point x="1053" y="691" type="line"/>
+      <point x="1201" y="799"/>
+      <point x="1305" y="896"/>
+      <point x="1305" y="1065" type="curve"/>
+      <point x="1305" y="1306"/>
+      <point x="1123" y="1477"/>
+      <point x="829" y="1477" type="curve"/>
+      <point x="648" y="1477"/>
+      <point x="524" y="1430"/>
+      <point x="384" y="1330" type="curve" smooth="yes"/>
+      <point x="376" y="1326"/>
+      <point x="353" y="1311"/>
+      <point x="346" y="1307" type="curve" smooth="yes"/>
+      <point x="166" y="1171"/>
+      <point x="102" y="964"/>
+      <point x="102" y="728" type="curve"/>
+      <point x="384" y="728" type="line"/>
+      <point x="384" y="1017"/>
+      <point x="591" y="1217"/>
+      <point x="806" y="1217" type="curve" smooth="yes"/>
+      <point x="892" y="1217"/>
+      <point x="966" y="1146"/>
+      <point x="966" y="1042" type="curve"/>
+      <point x="966" y="983"/>
+      <point x="951" y="935"/>
+      <point x="910" y="884" type="curve" smooth="yes"/>
+      <point x="576" y="651" type="line" smooth="yes"/>
+      <point x="465" y="572"/>
+      <point x="383" y="462"/>
+      <point x="383" y="329" type="curve"/>
+      <point x="383" y="140"/>
+      <point x="532" y="-21"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Black.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="615"/>
+  <advance width="1260"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="265" y="-10" type="curve" smooth="yes"/>
-      <point x="347" y="-10"/>
-      <point x="374" y="51"/>
-      <point x="374" y="117" type="curve" smooth="yes"/>
-      <point x="374" y="140"/>
-      <point x="366" y="204"/>
-      <point x="358" y="277" type="curve"/>
-      <point x="434" y="291"/>
-      <point x="500" y="326"/>
-      <point x="542" y="375" type="curve"/>
-      <point x="551" y="361"/>
-      <point x="556" y="345"/>
-      <point x="556" y="327" type="curve" smooth="yes"/>
-      <point x="556" y="281"/>
-      <point x="509" y="238"/>
-      <point x="491" y="224" type="curve"/>
-      <point x="525" y="224" type="line"/>
-      <point x="544" y="238"/>
-      <point x="586" y="281"/>
-      <point x="586" y="326" type="curve" smooth="yes"/>
-      <point x="586" y="354"/>
-      <point x="576" y="378"/>
-      <point x="559" y="397" type="curve"/>
-      <point x="580" y="427"/>
-      <point x="592" y="462"/>
-      <point x="592" y="500" type="curve" smooth="yes"/>
-      <point x="592" y="608"/>
-      <point x="521" y="725"/>
-      <point x="412" y="725" type="curve" smooth="yes"/>
-      <point x="329" y="725"/>
-      <point x="302" y="664"/>
-      <point x="302" y="569" type="curve" smooth="yes"/>
-      <point x="302" y="548"/>
-      <point x="303" y="515"/>
-      <point x="304" y="477" type="curve"/>
-      <point x="292" y="478"/>
-      <point x="281" y="478"/>
-      <point x="271" y="478" type="curve" smooth="yes"/>
-      <point x="260" y="478"/>
-      <point x="241" y="477"/>
-      <point x="220" y="475" type="curve"/>
-      <point x="222" y="613" type="line"/>
-      <point x="237" y="635"/>
-      <point x="251" y="658"/>
-      <point x="251" y="675" type="curve" smooth="yes"/>
-      <point x="251" y="681"/>
-      <point x="250" y="708"/>
-      <point x="223" y="708" type="curve" smooth="yes"/>
-      <point x="188" y="708"/>
-      <point x="200" y="669"/>
-      <point x="184" y="669" type="curve" smooth="yes"/>
-      <point x="164" y="669"/>
-      <point x="153" y="715"/>
-      <point x="105" y="715" type="curve" smooth="yes"/>
-      <point x="82" y="715"/>
-      <point x="41" y="702"/>
-      <point x="41" y="643" type="curve" smooth="yes"/>
-      <point x="41" y="603"/>
-      <point x="68" y="572"/>
-      <point x="112" y="572" type="curve" smooth="yes"/>
-      <point x="119" y="572"/>
-      <point x="126" y="573"/>
-      <point x="131" y="574" type="curve"/>
-      <point x="130" y="592" type="line"/>
-      <point x="126" y="591"/>
-      <point x="118" y="590"/>
-      <point x="112" y="590" type="curve" smooth="yes"/>
-      <point x="94" y="590"/>
-      <point x="88" y="606"/>
-      <point x="88" y="617" type="curve" smooth="yes"/>
-      <point x="88" y="630"/>
-      <point x="97" y="644"/>
-      <point x="116" y="644" type="curve" smooth="yes"/>
-      <point x="138" y="644"/>
-      <point x="185" y="625"/>
-      <point x="202" y="615" type="curve"/>
-      <point x="186" y="471" type="line"/>
-      <point x="124" y="460"/>
-      <point x="54" y="433"/>
-      <point x="54" y="369" type="curve" smooth="yes"/>
-      <point x="54" y="315"/>
-      <point x="107" y="290"/>
-      <point x="167" y="279" type="curve"/>
-      <point x="160" y="208"/>
-      <point x="156" y="144"/>
-      <point x="156" y="117" type="curve" smooth="yes"/>
-      <point x="156" y="51"/>
-      <point x="183" y="-10"/>
+      <point x="543" y="-20" type="curve" smooth="yes"/>
+      <point x="711" y="-20"/>
+      <point x="766" y="104"/>
+      <point x="766" y="240" type="curve" smooth="yes"/>
+      <point x="766" y="287"/>
+      <point x="750" y="418"/>
+      <point x="733" y="567" type="curve"/>
+      <point x="889" y="596"/>
+      <point x="1024" y="668"/>
+      <point x="1110" y="768" type="curve"/>
+      <point x="1128" y="739"/>
+      <point x="1139" y="707"/>
+      <point x="1139" y="670" type="curve" smooth="yes"/>
+      <point x="1139" y="575"/>
+      <point x="1042" y="487"/>
+      <point x="1006" y="459" type="curve"/>
+      <point x="1075" y="459" type="line"/>
+      <point x="1114" y="487"/>
+      <point x="1200" y="575"/>
+      <point x="1200" y="668" type="curve" smooth="yes"/>
+      <point x="1200" y="725"/>
+      <point x="1180" y="774"/>
+      <point x="1145" y="813" type="curve"/>
+      <point x="1188" y="874"/>
+      <point x="1212" y="946"/>
+      <point x="1212" y="1024" type="curve" smooth="yes"/>
+      <point x="1212" y="1245"/>
+      <point x="1067" y="1485"/>
+      <point x="844" y="1485" type="curve" smooth="yes"/>
+      <point x="674" y="1485"/>
+      <point x="618" y="1360"/>
+      <point x="618" y="1165" type="curve" smooth="yes"/>
+      <point x="618" y="1122"/>
+      <point x="621" y="1055"/>
+      <point x="623" y="977" type="curve"/>
+      <point x="598" y="979"/>
+      <point x="575" y="979"/>
+      <point x="555" y="979" type="curve" smooth="yes"/>
+      <point x="532" y="979"/>
+      <point x="494" y="977"/>
+      <point x="451" y="973" type="curve"/>
+      <point x="455" y="1255" type="line"/>
+      <point x="485" y="1300"/>
+      <point x="514" y="1348"/>
+      <point x="514" y="1382" type="curve" smooth="yes"/>
+      <point x="514" y="1395"/>
+      <point x="512" y="1450"/>
+      <point x="457" y="1450" type="curve" smooth="yes"/>
+      <point x="385" y="1450"/>
+      <point x="410" y="1370"/>
+      <point x="377" y="1370" type="curve" smooth="yes"/>
+      <point x="336" y="1370"/>
+      <point x="313" y="1464"/>
+      <point x="215" y="1464" type="curve" smooth="yes"/>
+      <point x="168" y="1464"/>
+      <point x="84" y="1438"/>
+      <point x="84" y="1317" type="curve" smooth="yes"/>
+      <point x="84" y="1235"/>
+      <point x="139" y="1171"/>
+      <point x="229" y="1171" type="curve" smooth="yes"/>
+      <point x="244" y="1171"/>
+      <point x="258" y="1174"/>
+      <point x="268" y="1176" type="curve"/>
+      <point x="266" y="1212" type="line"/>
+      <point x="258" y="1210"/>
+      <point x="242" y="1208"/>
+      <point x="229" y="1208" type="curve" smooth="yes"/>
+      <point x="193" y="1208"/>
+      <point x="180" y="1241"/>
+      <point x="180" y="1264" type="curve" smooth="yes"/>
+      <point x="180" y="1290"/>
+      <point x="199" y="1319"/>
+      <point x="238" y="1319" type="curve" smooth="yes"/>
+      <point x="283" y="1319"/>
+      <point x="379" y="1280"/>
+      <point x="414" y="1260" type="curve"/>
+      <point x="381" y="965" type="line"/>
+      <point x="254" y="942"/>
+      <point x="111" y="887"/>
+      <point x="111" y="756" type="curve" smooth="yes"/>
+      <point x="111" y="645"/>
+      <point x="219" y="594"/>
+      <point x="342" y="571" type="curve"/>
+      <point x="328" y="426"/>
+      <point x="319" y="295"/>
+      <point x="319" y="240" type="curve" smooth="yes"/>
+      <point x="319" y="104"/>
+      <point x="375" y="-20"/>
     </contour>
     <contour>
-      <point x="265" y="20" type="curve" smooth="yes"/>
-      <point x="228" y="20"/>
-      <point x="208" y="58"/>
-      <point x="208" y="115" type="curve" smooth="yes"/>
-      <point x="208" y="146"/>
-      <point x="210" y="206"/>
-      <point x="212" y="273" type="curve"/>
-      <point x="237" y="270"/>
-      <point x="261" y="270"/>
-      <point x="282" y="270" type="curve" smooth="yes"/>
-      <point x="292" y="270"/>
-      <point x="303" y="270"/>
-      <point x="314" y="271" type="curve"/>
-      <point x="317" y="195"/>
-      <point x="321" y="132"/>
-      <point x="321" y="115" type="curve" smooth="yes"/>
-      <point x="321" y="58"/>
-      <point x="301" y="20"/>
+      <point x="543" y="41" type="curve" smooth="yes"/>
+      <point x="467" y="41"/>
+      <point x="426" y="119"/>
+      <point x="426" y="236" type="curve" smooth="yes"/>
+      <point x="426" y="299"/>
+      <point x="430" y="422"/>
+      <point x="434" y="559" type="curve"/>
+      <point x="485" y="553"/>
+      <point x="535" y="553"/>
+      <point x="578" y="553" type="curve" smooth="yes"/>
+      <point x="598" y="553"/>
+      <point x="621" y="553"/>
+      <point x="643" y="555" type="curve"/>
+      <point x="649" y="399"/>
+      <point x="657" y="270"/>
+      <point x="657" y="236" type="curve" smooth="yes"/>
+      <point x="657" y="119"/>
+      <point x="616" y="41"/>
     </contour>
     <contour>
-      <point x="169" y="299" type="line"/>
-      <point x="89" y="318"/>
-      <point x="79" y="358"/>
-      <point x="79" y="372" type="curve" smooth="yes"/>
-      <point x="79" y="384"/>
-      <point x="85" y="434"/>
-      <point x="184" y="453" type="curve"/>
+      <point x="346" y="612" type="line"/>
+      <point x="182" y="651"/>
+      <point x="162" y="733"/>
+      <point x="162" y="762" type="curve" smooth="yes"/>
+      <point x="162" y="786"/>
+      <point x="174" y="889"/>
+      <point x="377" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="281" y="288" type="curve" smooth="yes"/>
-      <point x="254" y="288"/>
-      <point x="233" y="289"/>
-      <point x="213" y="291" type="curve"/>
-      <point x="219" y="458" type="line"/>
-      <point x="234" y="459"/>
-      <point x="251" y="460"/>
-      <point x="270" y="460" type="curve" smooth="yes"/>
-      <point x="282" y="460"/>
-      <point x="293" y="459"/>
-      <point x="305" y="459" type="curve"/>
-      <point x="313" y="289" type="line"/>
-      <point x="302" y="288"/>
-      <point x="292" y="288"/>
+      <point x="575" y="590" type="curve" smooth="yes"/>
+      <point x="520" y="590"/>
+      <point x="477" y="592"/>
+      <point x="436" y="596" type="curve"/>
+      <point x="449" y="938" type="line"/>
+      <point x="479" y="940"/>
+      <point x="514" y="942"/>
+      <point x="553" y="942" type="curve" smooth="yes"/>
+      <point x="578" y="942"/>
+      <point x="600" y="940"/>
+      <point x="625" y="940" type="curve"/>
+      <point x="641" y="592" type="line"/>
+      <point x="618" y="590"/>
+      <point x="598" y="590"/>
     </contour>
     <contour>
-      <point x="356" y="295" type="curve"/>
-      <point x="337" y="457" type="line"/>
-      <point x="397" y="452"/>
-      <point x="457" y="439"/>
-      <point x="499" y="414" type="curve"/>
-      <point x="476" y="351"/>
-      <point x="428" y="311"/>
+      <point x="729" y="604" type="curve"/>
+      <point x="690" y="936" type="line"/>
+      <point x="813" y="926"/>
+      <point x="936" y="899"/>
+      <point x="1022" y="848" type="curve"/>
+      <point x="975" y="719"/>
+      <point x="877" y="637"/>
     </contour>
     <contour>
-      <point x="505" y="436" type="curve"/>
-      <point x="456" y="460"/>
-      <point x="390" y="471"/>
-      <point x="335" y="475" type="curve"/>
-      <point x="331" y="514"/>
-      <point x="329" y="548"/>
-      <point x="329" y="572" type="curve" smooth="yes"/>
-      <point x="329" y="636"/>
-      <point x="335" y="707"/>
-      <point x="409" y="707" type="curve" smooth="yes"/>
-      <point x="500" y="707"/>
-      <point x="516" y="593"/>
-      <point x="516" y="519" type="curve" smooth="yes"/>
-      <point x="516" y="488"/>
-      <point x="512" y="461"/>
+      <point x="1034" y="893" type="curve"/>
+      <point x="934" y="942"/>
+      <point x="799" y="965"/>
+      <point x="686" y="973" type="curve"/>
+      <point x="678" y="1053"/>
+      <point x="674" y="1122"/>
+      <point x="674" y="1171" type="curve" smooth="yes"/>
+      <point x="674" y="1303"/>
+      <point x="686" y="1448"/>
+      <point x="838" y="1448" type="curve" smooth="yes"/>
+      <point x="1024" y="1448"/>
+      <point x="1057" y="1214"/>
+      <point x="1057" y="1063" type="curve" smooth="yes"/>
+      <point x="1057" y="999"/>
+      <point x="1049" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Black.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="615"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="265" y="-10" type="curve" smooth="yes"/>
+      <point x="347" y="-10"/>
+      <point x="374" y="51"/>
+      <point x="374" y="117" type="curve" smooth="yes"/>
+      <point x="374" y="140"/>
+      <point x="366" y="204"/>
+      <point x="358" y="277" type="curve"/>
+      <point x="434" y="291"/>
+      <point x="500" y="326"/>
+      <point x="542" y="375" type="curve"/>
+      <point x="551" y="361"/>
+      <point x="556" y="345"/>
+      <point x="556" y="327" type="curve" smooth="yes"/>
+      <point x="556" y="281"/>
+      <point x="509" y="238"/>
+      <point x="491" y="224" type="curve"/>
+      <point x="525" y="224" type="line"/>
+      <point x="544" y="238"/>
+      <point x="586" y="281"/>
+      <point x="586" y="326" type="curve" smooth="yes"/>
+      <point x="586" y="354"/>
+      <point x="576" y="378"/>
+      <point x="559" y="397" type="curve"/>
+      <point x="580" y="427"/>
+      <point x="592" y="462"/>
+      <point x="592" y="500" type="curve" smooth="yes"/>
+      <point x="592" y="608"/>
+      <point x="521" y="725"/>
+      <point x="412" y="725" type="curve" smooth="yes"/>
+      <point x="329" y="725"/>
+      <point x="302" y="664"/>
+      <point x="302" y="569" type="curve" smooth="yes"/>
+      <point x="302" y="548"/>
+      <point x="303" y="515"/>
+      <point x="304" y="477" type="curve"/>
+      <point x="292" y="478"/>
+      <point x="281" y="478"/>
+      <point x="271" y="478" type="curve" smooth="yes"/>
+      <point x="260" y="478"/>
+      <point x="241" y="477"/>
+      <point x="220" y="475" type="curve"/>
+      <point x="222" y="613" type="line"/>
+      <point x="237" y="635"/>
+      <point x="251" y="658"/>
+      <point x="251" y="675" type="curve" smooth="yes"/>
+      <point x="251" y="681"/>
+      <point x="250" y="708"/>
+      <point x="223" y="708" type="curve" smooth="yes"/>
+      <point x="188" y="708"/>
+      <point x="200" y="669"/>
+      <point x="184" y="669" type="curve" smooth="yes"/>
+      <point x="164" y="669"/>
+      <point x="153" y="715"/>
+      <point x="105" y="715" type="curve" smooth="yes"/>
+      <point x="82" y="715"/>
+      <point x="41" y="702"/>
+      <point x="41" y="643" type="curve" smooth="yes"/>
+      <point x="41" y="603"/>
+      <point x="68" y="572"/>
+      <point x="112" y="572" type="curve" smooth="yes"/>
+      <point x="119" y="572"/>
+      <point x="126" y="573"/>
+      <point x="131" y="574" type="curve"/>
+      <point x="130" y="592" type="line"/>
+      <point x="126" y="591"/>
+      <point x="118" y="590"/>
+      <point x="112" y="590" type="curve" smooth="yes"/>
+      <point x="94" y="590"/>
+      <point x="88" y="606"/>
+      <point x="88" y="617" type="curve" smooth="yes"/>
+      <point x="88" y="630"/>
+      <point x="97" y="644"/>
+      <point x="116" y="644" type="curve" smooth="yes"/>
+      <point x="138" y="644"/>
+      <point x="185" y="625"/>
+      <point x="202" y="615" type="curve"/>
+      <point x="186" y="471" type="line"/>
+      <point x="124" y="460"/>
+      <point x="54" y="433"/>
+      <point x="54" y="369" type="curve" smooth="yes"/>
+      <point x="54" y="315"/>
+      <point x="107" y="290"/>
+      <point x="167" y="279" type="curve"/>
+      <point x="160" y="208"/>
+      <point x="156" y="144"/>
+      <point x="156" y="117" type="curve" smooth="yes"/>
+      <point x="156" y="51"/>
+      <point x="183" y="-10"/>
+    </contour>
+    <contour>
+      <point x="265" y="20" type="curve" smooth="yes"/>
+      <point x="228" y="20"/>
+      <point x="208" y="58"/>
+      <point x="208" y="115" type="curve" smooth="yes"/>
+      <point x="208" y="146"/>
+      <point x="210" y="206"/>
+      <point x="212" y="273" type="curve"/>
+      <point x="237" y="270"/>
+      <point x="261" y="270"/>
+      <point x="282" y="270" type="curve" smooth="yes"/>
+      <point x="292" y="270"/>
+      <point x="303" y="270"/>
+      <point x="314" y="271" type="curve"/>
+      <point x="317" y="195"/>
+      <point x="321" y="132"/>
+      <point x="321" y="115" type="curve" smooth="yes"/>
+      <point x="321" y="58"/>
+      <point x="301" y="20"/>
+    </contour>
+    <contour>
+      <point x="169" y="299" type="line"/>
+      <point x="89" y="318"/>
+      <point x="79" y="358"/>
+      <point x="79" y="372" type="curve" smooth="yes"/>
+      <point x="79" y="384"/>
+      <point x="85" y="434"/>
+      <point x="184" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="281" y="288" type="curve" smooth="yes"/>
+      <point x="254" y="288"/>
+      <point x="233" y="289"/>
+      <point x="213" y="291" type="curve"/>
+      <point x="219" y="458" type="line"/>
+      <point x="234" y="459"/>
+      <point x="251" y="460"/>
+      <point x="270" y="460" type="curve" smooth="yes"/>
+      <point x="282" y="460"/>
+      <point x="293" y="459"/>
+      <point x="305" y="459" type="curve"/>
+      <point x="313" y="289" type="line"/>
+      <point x="302" y="288"/>
+      <point x="292" y="288"/>
+    </contour>
+    <contour>
+      <point x="356" y="295" type="curve"/>
+      <point x="337" y="457" type="line"/>
+      <point x="397" y="452"/>
+      <point x="457" y="439"/>
+      <point x="499" y="414" type="curve"/>
+      <point x="476" y="351"/>
+      <point x="428" y="311"/>
+    </contour>
+    <contour>
+      <point x="505" y="436" type="curve"/>
+      <point x="456" y="460"/>
+      <point x="390" y="471"/>
+      <point x="335" y="475" type="curve"/>
+      <point x="331" y="514"/>
+      <point x="329" y="548"/>
+      <point x="329" y="572" type="curve" smooth="yes"/>
+      <point x="329" y="636"/>
+      <point x="335" y="707"/>
+      <point x="409" y="707" type="curve" smooth="yes"/>
+      <point x="500" y="707"/>
+      <point x="516" y="593"/>
+      <point x="516" y="519" type="curve" smooth="yes"/>
+      <point x="516" y="488"/>
+      <point x="512" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="1003"/>
+  <unicode hex="214E"/>
+  <anchor x="436" y="10" name="bottom"/>
+  <anchor x="996" y="-407" name="bottom_dd"/>
+  <anchor x="554" y="1320" name="parent_top"/>
+  <anchor x="554" y="1320" name="top"/>
+  <anchor x="996" y="1320" name="top0315"/>
+  <anchor x="996" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="554" y="0" type="line"/>
+      <point x="892" y="0" type="line"/>
+      <point x="892" y="1082" type="line"/>
+      <point x="554" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="35" y="0" type="line"/>
+      <point x="654" y="0" type="line"/>
+      <point x="654" y="260" type="line"/>
+      <point x="35" y="260" type="line"/>
+    </contour>
+    <contour>
+      <point x="75" y="465" type="line"/>
+      <point x="654" y="465" type="line"/>
+      <point x="654" y="725" type="line"/>
+      <point x="75" y="725" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:49 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Black.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-Black.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:49 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Black.ufo/lib.plist
+++ b/sources/Roboto-Black.ufo/lib.plist
@@ -6888,6 +6888,24 @@
       <string>Uogonek.unic</string>
       <string>uni1E2D.ccmp</string>
       <string>uni1ECB.ccmp</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/Roboto-BlackItalic.ufo/fontinfo.plist
+++ b/sources/Roboto-BlackItalic.ufo/fontinfo.plist
@@ -379,7 +379,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/contents.plist
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="1062"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="-52" y="0" type="line"/>
+      <point x="400" y="0" type="line" smooth="yes"/>
+      <point x="752" y="0"/>
+      <point x="945" y="152"/>
+      <point x="945" y="459" type="curve" smooth="yes"/>
+      <point x="945" y="633"/>
+      <point x="875" y="719"/>
+      <point x="771" y="758" type="curve"/>
+      <point x="771" y="766" type="line"/>
+      <point x="951" y="823"/>
+      <point x="1051" y="948"/>
+      <point x="1051" y="1147" type="curve" smooth="yes"/>
+      <point x="1051" y="1333"/>
+      <point x="963" y="1462"/>
+      <point x="658" y="1462" type="curve" smooth="yes"/>
+      <point x="257" y="1462" type="line"/>
+    </contour>
+    <contour>
+      <point x="128" y="-201" type="line"/>
+      <point x="269" y="-201" type="line"/>
+      <point x="357" y="205" type="line"/>
+      <point x="216" y="205" type="line"/>
+    </contour>
+    <contour>
+      <point x="370" y="-201" type="line"/>
+      <point x="511" y="-201" type="line"/>
+      <point x="599" y="205" type="line"/>
+      <point x="458" y="205" type="line"/>
+    </contour>
+    <contour>
+      <point x="380" y="305" type="line"/>
+      <point x="443" y="612" type="line"/>
+      <point x="478" y="612" type="line" smooth="yes"/>
+      <point x="548" y="612"/>
+      <point x="578" y="571"/>
+      <point x="578" y="496" type="curve" smooth="yes"/>
+      <point x="578" y="377"/>
+      <point x="519" y="305"/>
+      <point x="435" y="305" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="503" y="901" type="line"/>
+      <point x="560" y="1163" type="line"/>
+      <point x="597" y="1163" type="line" smooth="yes"/>
+      <point x="650" y="1163"/>
+      <point x="677" y="1133"/>
+      <point x="677" y="1069" type="curve" smooth="yes"/>
+      <point x="677" y="981"/>
+      <point x="636" y="901"/>
+      <point x="552" y="901" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="437" y="1264" type="line"/>
+      <point x="578" y="1264" type="line"/>
+      <point x="666" y="1669" type="line"/>
+      <point x="525" y="1669" type="line"/>
+    </contour>
+    <contour>
+      <point x="679" y="1264" type="line"/>
+      <point x="820" y="1264" type="line"/>
+      <point x="908" y="1669" type="line"/>
+      <point x="767" y="1669" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="1211"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="349" y="0" type="line"/>
+      <point x="1072" y="0" type="line"/>
+      <point x="1106" y="205" type="line"/>
+      <point x="647" y="205" type="line"/>
+      <point x="668" y="328" type="line"/>
+      <point x="719" y="332"/>
+      <point x="768" y="348"/>
+      <point x="853" y="387" type="curve"/>
+      <point x="888" y="596" type="line"/>
+      <point x="810" y="563"/>
+      <point x="758" y="541"/>
+      <point x="703" y="535" type="curve"/>
+      <point x="793" y="1077" type="line"/>
+      <point x="838" y="1073"/>
+      <point x="867" y="1053"/>
+      <point x="929" y="1026" type="curve"/>
+      <point x="1015" y="1223" type="line"/>
+      <point x="936" y="1257"/>
+      <point x="895" y="1276"/>
+      <point x="827" y="1280" type="curve"/>
+      <point x="858" y="1462" type="line"/>
+      <point x="594" y="1462" type="line"/>
+      <point x="561" y="1268" type="line"/>
+      <point x="335" y="1227"/>
+      <point x="147" y="1083"/>
+      <point x="101" y="805" type="curve" smooth="yes"/>
+      <point x="54" y="528"/>
+      <point x="177" y="379"/>
+      <point x="406" y="338" type="curve"/>
+    </contour>
+    <contour>
+      <point x="442" y="553" type="line"/>
+      <point x="364" y="604"/>
+      <point x="345" y="678"/>
+      <point x="367" y="805" type="curve" smooth="yes"/>
+      <point x="388" y="932"/>
+      <point x="431" y="1004"/>
+      <point x="526" y="1059" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="1160"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1264"/>
+  <unicode hex="2108"/>
+  <anchor x="789.702" y="1600" name="parent_top"/>
+  <anchor x="789.702" y="1600" name="top"/>
+  <anchor x="1436.692" y="1600" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="515.311" y="-20.845" type="curve" smooth="yes"/>
+      <point x="931.079" y="-27.993"/>
+      <point x="1162.42" y="308.846"/>
+      <point x="1216.143" y="687.515" type="curve" smooth="yes"/>
+      <point x="1226.801" y="765.261" type="line" smooth="yes"/>
+      <point x="1270.174" y="1112.395"/>
+      <point x="1132.355" y="1469.355"/>
+      <point x="736.761" y="1476.533" type="curve" smooth="yes"/>
+      <point x="410.886" y="1482.446"/>
+      <point x="129.854" y="1282.623"/>
+      <point x="83.037" y="951.381" type="curve"/>
+      <point x="423.737" y="952.431" type="line"/>
+      <point x="448.059" y="1116.147"/>
+      <point x="546.415" y="1213.095"/>
+      <point x="717.608" y="1206.717" type="curve" smooth="yes"/>
+      <point x="937" y="1198.544"/>
+      <point x="904.335" y="919.571"/>
+      <point x="886.257" y="767.73" type="curve" smooth="yes"/>
+      <point x="876.342" y="686.754" type="line" smooth="yes"/>
+      <point x="850.007" y="486.448"/>
+      <point x="781.003" y="238.015"/>
+      <point x="533.955" y="247.413" type="curve" smooth="yes"/>
+      <point x="380.466" y="253.253"/>
+      <point x="328.441" y="349.237"/>
+      <point x="332.136" y="492.611" type="curve"/>
+      <point x="-8.329" y="493.457" type="line"/>
+      <point x="-1.417" y="178.841"/>
+      <point x="200.126" y="-15.426"/>
+    </contour>
+    <contour>
+      <point x="1076.519" y="593.077" type="line"/>
+      <point x="1124.055" y="863.906" type="line"/>
+      <point x="511.84" y="863.922" type="line"/>
+      <point x="464.304" y="593.094" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2108.glif
@@ -37,10 +37,10 @@
       <point x="200.126" y="-15.426"/>
     </contour>
     <contour>
+      <point x="464.304" y="593.094" type="line"/>
       <point x="1076.519" y="593.077" type="line"/>
       <point x="1124.055" y="863.906" type="line"/>
       <point x="511.84" y="863.922" type="line"/>
-      <point x="464.304" y="593.094" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1663"/>
+  <unicode hex="2114"/>
+  <anchor x="1108.873" y="-10" name="bottom"/>
+  <anchor x="1488.418" y="-407" name="bottom_dd"/>
+  <anchor x="855.025" y="1486" name="marktop"/>
+  <anchor x="1377.352" y="1600" name="parent_top"/>
+  <anchor x="1377.352" y="1600" name="top"/>
+  <anchor x="1835.192" y="1600" name="top0315"/>
+  <anchor x="1835.192" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1121" y="-21" type="curve" smooth="yes"/>
+      <point x="1438" y="-29"/>
+      <point x="1566" y="267"/>
+      <point x="1599" y="537" type="curve" smooth="yes"/>
+      <point x="1601" y="559" type="line" smooth="yes"/>
+      <point x="1628" y="807"/>
+      <point x="1563" y="1097"/>
+      <point x="1263" y="1103" type="curve" smooth="yes"/>
+      <point x="984" y="1109"/>
+      <point x="839" y="786"/>
+      <point x="798" y="552" type="curve"/>
+      <point x="796" y="526" type="line"/>
+      <point x="790" y="307"/>
+      <point x="849" y="-13"/>
+    </contour>
+    <contour>
+      <point x="26" y="0" type="line"/>
+      <point x="356" y="0" type="line"/>
+      <point x="622" y="1536" type="line"/>
+      <point x="292" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="534" y="0" type="line"/>
+      <point x="831" y="0" type="line"/>
+      <point x="906" y="248" type="line"/>
+      <point x="1130" y="1536" type="line"/>
+      <point x="801" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="1060" y="239" type="curve" smooth="yes"/>
+      <point x="908" y="243"/>
+      <point x="912" y="384"/>
+      <point x="925" y="501" type="curve" smooth="yes"/>
+      <point x="934" y="581" type="line" smooth="yes"/>
+      <point x="949" y="714"/>
+      <point x="1004" y="851"/>
+      <point x="1161" y="844" type="curve" smooth="yes"/>
+      <point x="1305" y="838"/>
+      <point x="1282" y="660"/>
+      <point x="1272" y="560" type="curve" smooth="yes"/>
+      <point x="1271" y="538" type="line" smooth="yes"/>
+      <point x="1257" y="408"/>
+      <point x="1225" y="234"/>
+    </contour>
+    <contour>
+      <point x="74" y="1211" type="line"/>
+      <point x="1296" y="1211" type="line"/>
+      <point x="1331" y="1402" type="line"/>
+      <point x="109" y="1402" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="811"/>
+  <advance width="1534"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="182" y="-241" type="curve" smooth="yes"/>
-      <point x="252" y="-241"/>
-      <point x="299" y="-180"/>
-      <point x="299" y="-95" type="curve" smooth="yes"/>
-      <point x="299" y="8"/>
-      <point x="207" y="99"/>
-      <point x="150" y="200" type="curve"/>
-      <point x="197" y="272"/>
-      <point x="257" y="341"/>
-      <point x="319" y="394" type="curve" smooth="yes"/>
-      <point x="387" y="452"/>
-      <point x="458" y="492"/>
-      <point x="517" y="492" type="curve" smooth="yes"/>
-      <point x="619" y="492"/>
-      <point x="627" y="359"/>
-      <point x="627" y="322" type="curve" smooth="yes"/>
-      <point x="627" y="285"/>
-      <point x="614" y="30"/>
-      <point x="450" y="30" type="curve" smooth="yes"/>
-      <point x="399" y="30"/>
-      <point x="350" y="57"/>
-      <point x="350" y="112" type="curve" smooth="yes"/>
-      <point x="350" y="119"/>
-      <point x="351" y="126"/>
-      <point x="352" y="132" type="curve"/>
-      <point x="385" y="136"/>
-      <point x="418" y="151"/>
-      <point x="418" y="194" type="curve" smooth="yes"/>
-      <point x="418" y="225"/>
-      <point x="397" y="244"/>
-      <point x="366" y="244" type="curve" smooth="yes"/>
-      <point x="318" y="244"/>
-      <point x="288" y="206"/>
-      <point x="288" y="140" type="curve" smooth="yes"/>
-      <point x="288" y="51"/>
-      <point x="352" y="-10"/>
-      <point x="458" y="-10" type="curve" smooth="yes"/>
-      <point x="636" y="-10"/>
-      <point x="729" y="159"/>
-      <point x="729" y="306" type="curve" smooth="yes"/>
-      <point x="729" y="437"/>
-      <point x="669" y="549"/>
-      <point x="547" y="549" type="curve" smooth="yes"/>
-      <point x="497" y="549"/>
-      <point x="401" y="512"/>
-      <point x="295" y="419" type="curve" smooth="yes"/>
-      <point x="243" y="373"/>
-      <point x="182" y="310"/>
-      <point x="130" y="238" type="curve"/>
-      <point x="115" y="272"/>
-      <point x="106" y="307"/>
-      <point x="106" y="345" type="curve" smooth="yes"/>
-      <point x="106" y="474"/>
-      <point x="136" y="548"/>
-      <point x="217" y="625" type="curve"/>
-      <point x="201" y="647" type="line"/>
-      <point x="142" y="610"/>
-      <point x="18" y="496"/>
-      <point x="18" y="337" type="curve" smooth="yes"/>
-      <point x="18" y="267"/>
-      <point x="42" y="206"/>
-      <point x="74" y="149" type="curve"/>
-      <point x="39" y="85"/>
-      <point x="13" y="11"/>
-      <point x="13" y="-56" type="curve" smooth="yes"/>
-      <point x="13" y="-163"/>
-      <point x="87" y="-241"/>
+      <point x="401" y="-494" type="curve" smooth="yes"/>
+      <point x="538" y="-494"/>
+      <point x="632" y="-369"/>
+      <point x="632" y="-195" type="curve" smooth="yes"/>
+      <point x="632" y="16"/>
+      <point x="450" y="203"/>
+      <point x="337" y="410" type="curve"/>
+      <point x="432" y="557"/>
+      <point x="552" y="698"/>
+      <point x="673" y="807" type="curve" smooth="yes"/>
+      <point x="806" y="926"/>
+      <point x="948" y="1008"/>
+      <point x="1066" y="1008" type="curve" smooth="yes"/>
+      <point x="1269" y="1008"/>
+      <point x="1284" y="735"/>
+      <point x="1284" y="659" type="curve" smooth="yes"/>
+      <point x="1284" y="584"/>
+      <point x="1259" y="61"/>
+      <point x="933" y="61" type="curve" smooth="yes"/>
+      <point x="831" y="61"/>
+      <point x="733" y="117"/>
+      <point x="733" y="229" type="curve" smooth="yes"/>
+      <point x="733" y="244"/>
+      <point x="735" y="258"/>
+      <point x="739" y="270" type="curve"/>
+      <point x="804" y="279"/>
+      <point x="870" y="309"/>
+      <point x="870" y="397" type="curve" smooth="yes"/>
+      <point x="870" y="461"/>
+      <point x="827" y="500"/>
+      <point x="765" y="500" type="curve" smooth="yes"/>
+      <point x="669" y="500"/>
+      <point x="612" y="422"/>
+      <point x="612" y="287" type="curve" smooth="yes"/>
+      <point x="612" y="104"/>
+      <point x="737" y="-20"/>
+      <point x="948" y="-20" type="curve" smooth="yes"/>
+      <point x="1300" y="-20"/>
+      <point x="1486" y="326"/>
+      <point x="1486" y="627" type="curve" smooth="yes"/>
+      <point x="1486" y="895"/>
+      <point x="1365" y="1124"/>
+      <point x="1126" y="1124" type="curve" smooth="yes"/>
+      <point x="1025" y="1124"/>
+      <point x="837" y="1049"/>
+      <point x="626" y="858" type="curve" smooth="yes"/>
+      <point x="522" y="764"/>
+      <point x="401" y="635"/>
+      <point x="298" y="487" type="curve"/>
+      <point x="268" y="557"/>
+      <point x="249" y="629"/>
+      <point x="249" y="707" type="curve" smooth="yes"/>
+      <point x="249" y="971"/>
+      <point x="309" y="1122"/>
+      <point x="468" y="1280" type="curve"/>
+      <point x="438" y="1325" type="line"/>
+      <point x="321" y="1249"/>
+      <point x="75" y="1016"/>
+      <point x="75" y="690" type="curve" smooth="yes"/>
+      <point x="75" y="547"/>
+      <point x="122" y="422"/>
+      <point x="186" y="305" type="curve"/>
+      <point x="116" y="174"/>
+      <point x="65" y="23"/>
+      <point x="65" y="-115" type="curve" smooth="yes"/>
+      <point x="65" y="-334"/>
+      <point x="210" y="-494"/>
     </contour>
     <contour>
-      <point x="164" y="-199" type="curve" smooth="yes"/>
-      <point x="120" y="-199"/>
-      <point x="53" y="-145"/>
-      <point x="53" y="-51" type="curve" smooth="yes"/>
-      <point x="53" y="-4"/>
-      <point x="69" y="52"/>
-      <point x="97" y="110" type="curve"/>
-      <point x="151" y="24"/>
-      <point x="212" y="-52"/>
-      <point x="212" y="-134" type="curve" smooth="yes"/>
-      <point x="212" y="-176"/>
-      <point x="193" y="-199"/>
+      <point x="366" y="-408" type="curve" smooth="yes"/>
+      <point x="276" y="-408"/>
+      <point x="145" y="-297"/>
+      <point x="145" y="-104" type="curve" smooth="yes"/>
+      <point x="145" y="-8"/>
+      <point x="178" y="106"/>
+      <point x="233" y="225" type="curve"/>
+      <point x="337" y="49"/>
+      <point x="460" y="-106"/>
+      <point x="460" y="-274" type="curve" smooth="yes"/>
+      <point x="460" y="-360"/>
+      <point x="423" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="811"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="182" y="-241" type="curve" smooth="yes"/>
+      <point x="252" y="-241"/>
+      <point x="299" y="-180"/>
+      <point x="299" y="-95" type="curve" smooth="yes"/>
+      <point x="299" y="8"/>
+      <point x="207" y="99"/>
+      <point x="150" y="200" type="curve"/>
+      <point x="197" y="272"/>
+      <point x="257" y="341"/>
+      <point x="319" y="394" type="curve" smooth="yes"/>
+      <point x="387" y="452"/>
+      <point x="458" y="492"/>
+      <point x="517" y="492" type="curve" smooth="yes"/>
+      <point x="619" y="492"/>
+      <point x="627" y="359"/>
+      <point x="627" y="322" type="curve" smooth="yes"/>
+      <point x="627" y="285"/>
+      <point x="614" y="30"/>
+      <point x="450" y="30" type="curve" smooth="yes"/>
+      <point x="399" y="30"/>
+      <point x="350" y="57"/>
+      <point x="350" y="112" type="curve" smooth="yes"/>
+      <point x="350" y="119"/>
+      <point x="351" y="126"/>
+      <point x="352" y="132" type="curve"/>
+      <point x="385" y="136"/>
+      <point x="418" y="151"/>
+      <point x="418" y="194" type="curve" smooth="yes"/>
+      <point x="418" y="225"/>
+      <point x="397" y="244"/>
+      <point x="366" y="244" type="curve" smooth="yes"/>
+      <point x="318" y="244"/>
+      <point x="288" y="206"/>
+      <point x="288" y="140" type="curve" smooth="yes"/>
+      <point x="288" y="51"/>
+      <point x="352" y="-10"/>
+      <point x="458" y="-10" type="curve" smooth="yes"/>
+      <point x="636" y="-10"/>
+      <point x="729" y="159"/>
+      <point x="729" y="306" type="curve" smooth="yes"/>
+      <point x="729" y="437"/>
+      <point x="669" y="549"/>
+      <point x="547" y="549" type="curve" smooth="yes"/>
+      <point x="497" y="549"/>
+      <point x="401" y="512"/>
+      <point x="295" y="419" type="curve" smooth="yes"/>
+      <point x="243" y="373"/>
+      <point x="182" y="310"/>
+      <point x="130" y="238" type="curve"/>
+      <point x="115" y="272"/>
+      <point x="106" y="307"/>
+      <point x="106" y="345" type="curve" smooth="yes"/>
+      <point x="106" y="474"/>
+      <point x="136" y="548"/>
+      <point x="217" y="625" type="curve"/>
+      <point x="201" y="647" type="line"/>
+      <point x="142" y="610"/>
+      <point x="18" y="496"/>
+      <point x="18" y="337" type="curve" smooth="yes"/>
+      <point x="18" y="267"/>
+      <point x="42" y="206"/>
+      <point x="74" y="149" type="curve"/>
+      <point x="39" y="85"/>
+      <point x="13" y="11"/>
+      <point x="13" y="-56" type="curve" smooth="yes"/>
+      <point x="13" y="-163"/>
+      <point x="87" y="-241"/>
+    </contour>
+    <contour>
+      <point x="164" y="-199" type="curve" smooth="yes"/>
+      <point x="120" y="-199"/>
+      <point x="53" y="-145"/>
+      <point x="53" y="-51" type="curve" smooth="yes"/>
+      <point x="53" y="-4"/>
+      <point x="69" y="52"/>
+      <point x="97" y="110" type="curve"/>
+      <point x="151" y="24"/>
+      <point x="212" y="-52"/>
+      <point x="212" y="-134" type="curve" smooth="yes"/>
+      <point x="212" y="-176"/>
+      <point x="193" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2127.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1341"/>
+  <advance width="1364"/>
   <unicode hex="2127"/>
-  <anchor x="863.491" y="1446" name="top"/>
+  <anchor x="839" y="1446" name="top"/>
   <outline>
     <contour>
-      <point x="633" y="-19" type="curve" smooth="yes"/>
-      <point x="988" y="-26"/>
-      <point x="1240" y="250"/>
-      <point x="1285" y="587" type="curve" smooth="yes"/>
-      <point x="1295" y="662" type="line" smooth="yes"/>
-      <point x="1326" y="946"/>
-      <point x="1170" y="1259"/>
-      <point x="875" y="1325" type="curve"/>
-      <point x="862" y="1178" type="line"/>
-      <point x="988" y="1086"/>
-      <point x="920" y="786"/>
-      <point x="905" y="663" type="curve" smooth="yes"/>
-      <point x="895" y="585" type="line" smooth="yes"/>
-      <point x="878" y="457"/>
-      <point x="826" y="244"/>
-      <point x="657" y="253" type="curve" smooth="yes"/>
-      <point x="506" y="261"/>
-      <point x="528" y="482"/>
-      <point x="540" y="583" type="curve" smooth="yes"/>
-      <point x="550" y="662" type="line" smooth="yes"/>
-      <point x="574" y="844"/>
-      <point x="613" y="1064"/>
-      <point x="772" y="1179" type="curve"/>
-      <point x="786" y="1326" type="line"/>
-      <point x="457" y="1280"/>
-      <point x="202" y="984"/>
-      <point x="158" y="662" type="curve" smooth="yes"/>
-      <point x="148" y="587" type="line" smooth="yes"/>
-      <point x="112" y="267"/>
-      <point x="295" y="-12"/>
+      <point x="609" y="-19" type="curve" smooth="yes"/>
+      <point x="964" y="-26"/>
+      <point x="1216" y="250"/>
+      <point x="1261" y="587" type="curve" smooth="yes"/>
+      <point x="1271" y="662" type="line" smooth="yes"/>
+      <point x="1302" y="946"/>
+      <point x="1146" y="1259"/>
+      <point x="851" y="1325" type="curve"/>
+      <point x="838" y="1178" type="line"/>
+      <point x="964" y="1086"/>
+      <point x="896" y="786"/>
+      <point x="881" y="663" type="curve" smooth="yes"/>
+      <point x="871" y="585" type="line" smooth="yes"/>
+      <point x="854" y="457"/>
+      <point x="802" y="244"/>
+      <point x="633" y="253" type="curve" smooth="yes"/>
+      <point x="482" y="261"/>
+      <point x="504" y="482"/>
+      <point x="516" y="583" type="curve" smooth="yes"/>
+      <point x="526" y="662" type="line" smooth="yes"/>
+      <point x="550" y="844"/>
+      <point x="589" y="1064"/>
+      <point x="748" y="1179" type="curve"/>
+      <point x="762" y="1326" type="line"/>
+      <point x="433" y="1280"/>
+      <point x="178" y="984"/>
+      <point x="134" y="662" type="curve" smooth="yes"/>
+      <point x="124" y="587" type="line" smooth="yes"/>
+      <point x="88" y="267"/>
+      <point x="271" y="-12"/>
     </contour>
     <contour>
-      <point x="270" y="1182" type="line"/>
-      <point x="770" y="1182" type="line"/>
-      <point x="818" y="1456" type="line"/>
-      <point x="318" y="1456" type="line"/>
+      <point x="246" y="1182" type="line"/>
+      <point x="746" y="1182" type="line"/>
+      <point x="794" y="1456" type="line"/>
+      <point x="294" y="1456" type="line"/>
     </contour>
     <contour>
-      <point x="860" y="1182" type="line"/>
-      <point x="1367" y="1182" type="line"/>
-      <point x="1415" y="1456" type="line"/>
-      <point x="908" y="1456" type="line"/>
+      <point x="836" y="1182" type="line"/>
+      <point x="1343" y="1182" type="line"/>
+      <point x="1391" y="1456" type="line"/>
+      <point x="884" y="1456" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1341"/>
+  <unicode hex="2127"/>
+  <anchor x="863.491" y="1446" name="top"/>
+  <outline>
+    <contour>
+      <point x="633" y="-19" type="curve" smooth="yes"/>
+      <point x="988" y="-26"/>
+      <point x="1240" y="250"/>
+      <point x="1285" y="587" type="curve" smooth="yes"/>
+      <point x="1295" y="662" type="line" smooth="yes"/>
+      <point x="1326" y="946"/>
+      <point x="1170" y="1259"/>
+      <point x="875" y="1325" type="curve"/>
+      <point x="862" y="1178" type="line"/>
+      <point x="988" y="1086"/>
+      <point x="920" y="786"/>
+      <point x="905" y="663" type="curve" smooth="yes"/>
+      <point x="895" y="585" type="line" smooth="yes"/>
+      <point x="878" y="457"/>
+      <point x="826" y="244"/>
+      <point x="657" y="253" type="curve" smooth="yes"/>
+      <point x="506" y="261"/>
+      <point x="528" y="482"/>
+      <point x="540" y="583" type="curve" smooth="yes"/>
+      <point x="550" y="662" type="line" smooth="yes"/>
+      <point x="574" y="844"/>
+      <point x="613" y="1064"/>
+      <point x="772" y="1179" type="curve"/>
+      <point x="786" y="1326" type="line"/>
+      <point x="457" y="1280"/>
+      <point x="202" y="984"/>
+      <point x="158" y="662" type="curve" smooth="yes"/>
+      <point x="148" y="587" type="line" smooth="yes"/>
+      <point x="112" y="267"/>
+      <point x="295" y="-12"/>
+    </contour>
+    <contour>
+      <point x="270" y="1182" type="line"/>
+      <point x="770" y="1182" type="line"/>
+      <point x="818" y="1456" type="line"/>
+      <point x="318" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="860" y="1182" type="line"/>
+      <point x="1367" y="1182" type="line"/>
+      <point x="1415" y="1456" type="line"/>
+      <point x="908" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="677"/>
+  <unicode hex="2129"/>
+  <anchor x="274.402" y="-196" name="bottom"/>
+  <anchor x="-118.448" y="-196" name="bottom0315"/>
+  <anchor x="274.402" y="-196" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="158" y="-10" type="line"/>
+      <point x="488" y="-10" type="line"/>
+      <point x="615" y="752" type="line"/>
+      <point x="634" y="956"/>
+      <point x="529" y="1078"/>
+      <point x="324" y="1082" type="curve" smooth="yes"/>
+      <point x="263" y="1082"/>
+      <point x="204" y="1074"/>
+      <point x="146" y="1056" type="curve"/>
+      <point x="123" y="812" type="line"/>
+      <point x="151" y="815"/>
+      <point x="179" y="818"/>
+      <point x="208" y="817" type="curve" smooth="yes"/>
+      <point x="281" y="814"/>
+      <point x="291" y="781"/>
+      <point x="283" y="712" type="curve" smooth="yes"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2139.glif
@@ -2,13 +2,13 @@
 <glyph name="uni2139" format="2">
   <advance width="546"/>
   <unicode hex="2139"/>
-  <anchor x="170.629" y="10" name="bottom"/>
-  <anchor x="372.118" y="-407" name="bottom_dd"/>
-  <anchor x="444.382" y="1600" name="parent_top"/>
-  <anchor x="359.5" y="654" name="rhotichook"/>
-  <anchor x="444.382" y="1600" name="top"/>
-  <anchor x="718.892" y="1600" name="top0315"/>
-  <anchor x="718.892" y="1600" name="top_dd"/>
+  <anchor x="170.629" y="10.0" name="bottom"/>
+  <anchor x="372.118" y="-407.0" name="bottom_dd"/>
+  <anchor x="444.382" y="1600.0" name="parent_top"/>
+  <anchor x="359.5" y="654.0" name="rhotichook"/>
+  <anchor x="444.382" y="1600.0" name="top"/>
+  <anchor x="718.892" y="1600.0" name="top0315"/>
+  <anchor x="718.892" y="1600.0" name="top_dd"/>
   <outline>
     <component base="i"/>
   </outline>
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="546"/>
+  <unicode hex="2139"/>
+  <anchor x="170.629" y="10" name="bottom"/>
+  <anchor x="372.118" y="-407" name="bottom_dd"/>
+  <anchor x="444.382" y="1600" name="parent_top"/>
+  <anchor x="359.5" y="654" name="rhotichook"/>
+  <anchor x="444.382" y="1600" name="top"/>
+  <anchor x="718.892" y="1600" name="top0315"/>
+  <anchor x="718.892" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1732"/>
+  <unicode hex="213A"/>
+  <anchor x="1615.58" y="687.715" name="bottom"/>
+  <anchor x="1897.858" y="1373.069" name="bottom_dd"/>
+  <anchor x="-18.603" y="684.004" name="parent_top"/>
+  <anchor x="-18.603" y="684.004" name="top"/>
+  <anchor x="-138.868" y="1366.063" name="top0315"/>
+  <anchor x="-138.868" y="1366.063" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="943" y="86" type="curve" smooth="yes"/>
+      <point x="1003" y="88" type="line" smooth="yes"/>
+      <point x="1363" y="108"/>
+      <point x="1683" y="323"/>
+      <point x="1620" y="719" type="curve" smooth="yes"/>
+      <point x="1556" y="1130"/>
+      <point x="1166" y="1321"/>
+      <point x="782" y="1305" type="curve" smooth="yes"/>
+      <point x="722" y="1302" type="line" smooth="yes"/>
+      <point x="365" y="1282"/>
+      <point x="47" y="1065"/>
+      <point x="109" y="673" type="curve" smooth="yes"/>
+      <point x="173" y="264"/>
+      <point x="560" y="71"/>
+    </contour>
+    <contour>
+      <point x="880" y="429" type="line" smooth="yes"/>
+      <point x="684" y="421"/>
+      <point x="414" y="461"/>
+      <point x="383" y="700" type="curve" smooth="yes"/>
+      <point x="354" y="918"/>
+      <point x="628" y="951"/>
+      <point x="785" y="960" type="curve" smooth="yes"/>
+      <point x="848" y="963" type="line" smooth="yes"/>
+      <point x="1041" y="971"/>
+      <point x="1317" y="927"/>
+      <point x="1348" y="692" type="curve" smooth="yes"/>
+      <point x="1378" y="471"/>
+      <point x="1102" y="440"/>
+      <point x="943" y="432" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1534" y="700" type="line"/>
+      <point x="1803" y="1097" type="line"/>
+      <point x="1594" y="1292" type="line"/>
+      <point x="1326" y="888" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni213A_.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni213A" format="2">
-  <advance width="1732"/>
+  <advance width="1773"/>
   <unicode hex="213A"/>
-  <anchor x="1615.58" y="687.715" name="bottom"/>
-  <anchor x="1897.858" y="1373.069" name="bottom_dd"/>
-  <anchor x="-18.603" y="684.004" name="parent_top"/>
-  <anchor x="-18.603" y="684.004" name="top"/>
-  <anchor x="-138.868" y="1366.063" name="top0315"/>
-  <anchor x="-138.868" y="1366.063" name="top_dd"/>
+  <anchor x="1524" y="688" name="bottom"/>
+  <anchor x="1806" y="1373" name="bottom_dd"/>
+  <anchor x="-111" y="684" name="parent_top"/>
+  <anchor x="-111" y="684" name="top"/>
+  <anchor x="-231" y="1366" name="top0315"/>
+  <anchor x="-231" y="1366" name="top_dd"/>
   <outline>
     <contour>
-      <point x="943" y="86" type="curve" smooth="yes"/>
-      <point x="1003" y="88" type="line" smooth="yes"/>
-      <point x="1363" y="108"/>
-      <point x="1683" y="323"/>
-      <point x="1620" y="719" type="curve" smooth="yes"/>
-      <point x="1556" y="1130"/>
-      <point x="1166" y="1321"/>
-      <point x="782" y="1305" type="curve" smooth="yes"/>
-      <point x="722" y="1302" type="line" smooth="yes"/>
-      <point x="365" y="1282"/>
-      <point x="47" y="1065"/>
-      <point x="109" y="673" type="curve" smooth="yes"/>
-      <point x="173" y="264"/>
-      <point x="560" y="71"/>
+      <point x="680" y="37" type="curve"/>
+      <point x="739" y="37" type="line"/>
+      <point x="1224" y="37"/>
+      <point x="1501" y="300"/>
+      <point x="1564" y="675" type="curve" smooth="yes"/>
+      <point x="1626" y="1047"/>
+      <point x="1367" y="1311"/>
+      <point x="952" y="1311" type="curve"/>
+      <point x="893" y="1311" type="line"/>
+      <point x="408" y="1311"/>
+      <point x="130" y="1045"/>
+      <point x="67" y="673" type="curve" smooth="yes"/>
+      <point x="5" y="298"/>
+      <point x="265" y="37"/>
     </contour>
     <contour>
-      <point x="880" y="429" type="line" smooth="yes"/>
-      <point x="684" y="421"/>
-      <point x="414" y="461"/>
-      <point x="383" y="700" type="curve" smooth="yes"/>
-      <point x="354" y="918"/>
-      <point x="628" y="951"/>
-      <point x="785" y="960" type="curve" smooth="yes"/>
-      <point x="848" y="963" type="line" smooth="yes"/>
-      <point x="1041" y="971"/>
-      <point x="1317" y="927"/>
-      <point x="1348" y="692" type="curve" smooth="yes"/>
-      <point x="1378" y="471"/>
-      <point x="1102" y="440"/>
-      <point x="943" y="432" type="curve" smooth="yes"/>
+      <point x="738" y="394" type="line" smooth="yes"/>
+      <point x="450" y="394"/>
+      <point x="311" y="487"/>
+      <point x="342" y="673" type="curve" smooth="yes"/>
+      <point x="372" y="852"/>
+      <point x="543" y="954"/>
+      <point x="831" y="954" type="curve"/>
+      <point x="892" y="954" type="line"/>
+      <point x="1177" y="954"/>
+      <point x="1320" y="854"/>
+      <point x="1290" y="675" type="curve" smooth="yes"/>
+      <point x="1259" y="489"/>
+      <point x="1084" y="394"/>
+      <point x="799" y="394" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="1534" y="700" type="line"/>
-      <point x="1803" y="1097" type="line"/>
-      <point x="1594" y="1292" type="line"/>
-      <point x="1326" y="888" type="line"/>
+      <point x="1488" y="677" type="line"/>
+      <point x="1877" y="1076" type="line"/>
+      <point x="1729" y="1294" type="line"/>
+      <point x="1339" y="888" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1354"/>
+  <unicode hex="2141"/>
+  <anchor x="573.518" y="-138" name="bottom"/>
+  <anchor x="-91.902" y="-138" name="bottom0315"/>
+  <anchor x="-91.902" y="-138" name="bottom_dd"/>
+  <anchor x="573.518" y="-138" name="parent_bottom"/>
+  <anchor x="834.449" y="1462" name="top"/>
+  <anchor x="254.872" y="1869" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="620" y="-15" type="curve" smooth="yes"/>
+      <point x="1032" y="-22"/>
+      <point x="1276" y="318"/>
+      <point x="1328" y="695" type="curve" smooth="yes"/>
+      <point x="1339" y="775" type="line" smooth="yes"/>
+      <point x="1385" y="1143"/>
+      <point x="1226" y="1476"/>
+      <point x="821" y="1481" type="curve" smooth="yes"/>
+      <point x="628" y="1484"/>
+      <point x="368" y="1439"/>
+      <point x="234" y="1283" type="curve"/>
+      <point x="140" y="684" type="line"/>
+      <point x="719" y="684" type="line"/>
+      <point x="761" y="925" type="line"/>
+      <point x="524" y="925" type="line"/>
+      <point x="569" y="1152" type="line"/>
+      <point x="633" y="1195"/>
+      <point x="705" y="1212"/>
+      <point x="782" y="1211" type="curve" smooth="yes"/>
+      <point x="1020" y="1206"/>
+      <point x="1013" y="955"/>
+      <point x="991" y="776" type="curve" smooth="yes"/>
+      <point x="980" y="692" type="line" smooth="yes"/>
+      <point x="953" y="502"/>
+      <point x="862" y="245"/>
+      <point x="628" y="254" type="curve" smooth="yes"/>
+      <point x="483" y="260"/>
+      <point x="437" y="349"/>
+      <point x="427" y="482" type="curve"/>
+      <point x="100" y="483" type="line"/>
+      <point x="120" y="165"/>
+      <point x="297" y="-10"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="1077"/>
+  <unicode hex="2142"/>
+  <anchor x="695.128" y="-144" name="bottom"/>
+  <anchor x="-93.482" y="-144" name="bottom0315"/>
+  <anchor x="-93.482" y="-144" name="bottom_dd"/>
+  <anchor x="695.128" y="-144" name="parent_bottom"/>
+  <anchor x="683.701" y="1446" name="top"/>
+  <anchor x="253.292" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="558" y="0" type="line"/>
+      <point x="901" y="0" type="line"/>
+      <point x="1153" y="1456" type="line"/>
+      <point x="811" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="171" y="1186" type="line"/>
+      <point x="887" y="1186" type="line"/>
+      <point x="934" y="1456" type="line"/>
+      <point x="218" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="1059"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="532" y="0" type="line"/>
+      <point x="883" y="0" type="line"/>
+      <point x="1127" y="1456" type="line"/>
+      <point x="776" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="-79" y="0" type="line"/>
+      <point x="657" y="0" type="line"/>
+      <point x="702" y="270" type="line"/>
+      <point x="-34" y="270" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1248"/>
+  <unicode hex="2144"/>
+  <anchor x="529.538" y="-144" name="bottom"/>
+  <anchor x="-93.202" y="-144" name="bottom0315"/>
+  <anchor x="-93.202" y="-144" name="bottom_dd"/>
+  <anchor x="529.538" y="-144" name="parent_bottom"/>
+  <anchor x="800.778" y="1409" name="top"/>
+  <anchor x="253.572" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="-82" y="0" type="line"/>
+      <point x="302" y="0" type="line"/>
+      <point x="671" y="630" type="line"/>
+      <point x="821" y="0" type="line"/>
+      <point x="1179" y="1" type="line"/>
+      <point x="887" y="916" type="line"/>
+      <point x="981" y="1456" type="line"/>
+      <point x="632" y="1456" type="line"/>
+      <point x="545" y="949" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni214A_.glif
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1536"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="54" y="300" type="line"/>
+      <point x="396" y="300" type="line"/>
+      <point x="550" y="1185" type="line"/>
+      <point x="994" y="1184" type="line" smooth="yes"/>
+      <point x="1116" y="1184"/>
+      <point x="1157" y="1079"/>
+      <point x="1140" y="968" type="curve" smooth="yes"/>
+      <point x="1120" y="834"/>
+      <point x="1017" y="764"/>
+      <point x="887" y="764" type="curve" smooth="yes"/>
+      <point x="783" y="764" type="line"/>
+      <point x="741" y="493" type="line"/>
+      <point x="875" y="493" type="line" smooth="yes"/>
+      <point x="1174" y="492"/>
+      <point x="1460" y="646"/>
+      <point x="1486" y="970" type="curve" smooth="yes"/>
+      <point x="1510" y="1269"/>
+      <point x="1290" y="1455"/>
+      <point x="1005" y="1455" type="curve" smooth="yes"/>
+      <point x="254" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="681" y="0" type="line"/>
+      <point x="1397" y="0" type="line"/>
+      <point x="1444" y="270" type="line"/>
+      <point x="728" y="270" type="line"/>
+    </contour>
+    <contour>
+      <point x="462" y="0" type="line"/>
+      <point x="804" y="0" type="line"/>
+      <point x="1082" y="1600" type="line"/>
+      <point x="739" y="1600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1340"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="726" y="-18" type="curve" smooth="yes"/>
+      <point x="965" y="-24"/>
+      <point x="1148" y="145"/>
+      <point x="1165" y="383" type="curve" smooth="yes"/>
+      <point x="1177" y="543"/>
+      <point x="1090" y="696"/>
+      <point x="1005" y="825" type="curve" smooth="yes"/>
+      <point x="563" y="1459" type="line"/>
+      <point x="214" y="1459" type="line"/>
+      <point x="759" y="671" type="line" smooth="yes"/>
+      <point x="814" y="589"/>
+      <point x="903" y="484"/>
+      <point x="887" y="377" type="curve" smooth="yes"/>
+      <point x="875" y="306"/>
+      <point x="823" y="239"/>
+      <point x="745" y="241" type="curve" smooth="yes"/>
+      <point x="685" y="242"/>
+      <point x="655" y="292"/>
+      <point x="662" y="348" type="curve" smooth="yes"/>
+      <point x="670" y="418"/>
+      <point x="721" y="464"/>
+      <point x="777" y="499" type="curve" smooth="yes"/>
+      <point x="1110" y="693" type="line" smooth="yes"/>
+      <point x="1250" y="782"/>
+      <point x="1389" y="899"/>
+      <point x="1399" y="1075" type="curve" smooth="yes"/>
+      <point x="1414" y="1327"/>
+      <point x="1219" y="1474"/>
+      <point x="982" y="1479" type="curve" smooth="yes"/>
+      <point x="810" y="1483"/>
+      <point x="675" y="1422"/>
+      <point x="531" y="1335" type="curve" smooth="yes"/>
+      <point x="517" y="1326"/>
+      <point x="503" y="1320"/>
+      <point x="490" y="1311" type="curve" smooth="yes"/>
+      <point x="295" y="1185"/>
+      <point x="202" y="953"/>
+      <point x="188" y="730" type="curve"/>
+      <point x="460" y="731" type="line"/>
+      <point x="488" y="963"/>
+      <point x="681" y="1236"/>
+      <point x="942" y="1221" type="curve" smooth="yes"/>
+      <point x="1031" y="1215"/>
+      <point x="1068" y="1134"/>
+      <point x="1058" y="1053" type="curve" smooth="yes"/>
+      <point x="1051" y="995"/>
+      <point x="1021" y="927"/>
+      <point x="976" y="888" type="curve"/>
+      <point x="612" y="655" type="line" smooth="yes"/>
+      <point x="497" y="579"/>
+      <point x="397" y="468"/>
+      <point x="389" y="324" type="curve" smooth="yes"/>
+      <point x="379" y="126"/>
+      <point x="534" y="-14"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni214B_.glif
@@ -4,66 +4,66 @@
   <unicode hex="214B"/>
   <outline>
     <contour>
-      <point x="726" y="-18" type="curve" smooth="yes"/>
-      <point x="965" y="-24"/>
-      <point x="1148" y="145"/>
-      <point x="1165" y="383" type="curve" smooth="yes"/>
-      <point x="1177" y="543"/>
-      <point x="1090" y="696"/>
-      <point x="1005" y="825" type="curve" smooth="yes"/>
-      <point x="563" y="1459" type="line"/>
-      <point x="214" y="1459" type="line"/>
-      <point x="759" y="671" type="line" smooth="yes"/>
-      <point x="814" y="589"/>
-      <point x="903" y="484"/>
-      <point x="887" y="377" type="curve" smooth="yes"/>
-      <point x="875" y="306"/>
-      <point x="823" y="239"/>
-      <point x="745" y="241" type="curve" smooth="yes"/>
-      <point x="685" y="242"/>
-      <point x="655" y="292"/>
-      <point x="662" y="348" type="curve" smooth="yes"/>
-      <point x="670" y="418"/>
-      <point x="721" y="464"/>
-      <point x="777" y="499" type="curve" smooth="yes"/>
-      <point x="1110" y="693" type="line" smooth="yes"/>
-      <point x="1250" y="782"/>
-      <point x="1389" y="899"/>
-      <point x="1399" y="1075" type="curve" smooth="yes"/>
-      <point x="1414" y="1327"/>
-      <point x="1219" y="1474"/>
-      <point x="982" y="1479" type="curve" smooth="yes"/>
-      <point x="810" y="1483"/>
-      <point x="675" y="1422"/>
-      <point x="531" y="1335" type="curve" smooth="yes"/>
-      <point x="517" y="1326"/>
-      <point x="503" y="1320"/>
-      <point x="490" y="1311" type="curve" smooth="yes"/>
-      <point x="295" y="1185"/>
-      <point x="202" y="953"/>
-      <point x="188" y="730" type="curve"/>
-      <point x="460" y="731" type="line"/>
-      <point x="488" y="963"/>
-      <point x="681" y="1236"/>
-      <point x="942" y="1221" type="curve" smooth="yes"/>
-      <point x="1031" y="1215"/>
-      <point x="1068" y="1134"/>
-      <point x="1058" y="1053" type="curve" smooth="yes"/>
-      <point x="1051" y="995"/>
-      <point x="1021" y="927"/>
-      <point x="976" y="888" type="curve"/>
-      <point x="612" y="655" type="line" smooth="yes"/>
-      <point x="497" y="579"/>
-      <point x="397" y="468"/>
-      <point x="389" y="324" type="curve" smooth="yes"/>
-      <point x="379" y="126"/>
-      <point x="534" y="-14"/>
+      <point x="667" y="-18" type="curve" smooth="yes"/>
+      <point x="906" y="-24"/>
+      <point x="1089" y="145"/>
+      <point x="1106" y="383" type="curve" smooth="yes"/>
+      <point x="1118" y="543"/>
+      <point x="1031" y="696"/>
+      <point x="946" y="825" type="curve" smooth="yes"/>
+      <point x="504" y="1459" type="line"/>
+      <point x="155" y="1459" type="line"/>
+      <point x="700" y="671" type="line" smooth="yes"/>
+      <point x="755" y="589"/>
+      <point x="844" y="484"/>
+      <point x="828" y="377" type="curve" smooth="yes"/>
+      <point x="816" y="306"/>
+      <point x="764" y="239"/>
+      <point x="686" y="241" type="curve" smooth="yes"/>
+      <point x="626" y="242"/>
+      <point x="596" y="292"/>
+      <point x="603" y="348" type="curve" smooth="yes"/>
+      <point x="611" y="418"/>
+      <point x="662" y="464"/>
+      <point x="718" y="499" type="curve" smooth="yes"/>
+      <point x="1051" y="693" type="line" smooth="yes"/>
+      <point x="1191" y="782"/>
+      <point x="1330" y="899"/>
+      <point x="1340" y="1075" type="curve" smooth="yes"/>
+      <point x="1355" y="1327"/>
+      <point x="1160" y="1474"/>
+      <point x="923" y="1479" type="curve" smooth="yes"/>
+      <point x="751" y="1483"/>
+      <point x="616" y="1422"/>
+      <point x="472" y="1335" type="curve" smooth="yes"/>
+      <point x="458" y="1326"/>
+      <point x="444" y="1320"/>
+      <point x="431" y="1311" type="curve" smooth="yes"/>
+      <point x="236" y="1185"/>
+      <point x="143" y="953"/>
+      <point x="129" y="730" type="curve"/>
+      <point x="401" y="731" type="line"/>
+      <point x="429" y="963"/>
+      <point x="622" y="1236"/>
+      <point x="883" y="1221" type="curve" smooth="yes"/>
+      <point x="972" y="1215"/>
+      <point x="1009" y="1134"/>
+      <point x="999" y="1053" type="curve" smooth="yes"/>
+      <point x="992" y="995"/>
+      <point x="962" y="927"/>
+      <point x="917" y="888" type="curve"/>
+      <point x="553" y="655" type="line" smooth="yes"/>
+      <point x="438" y="579"/>
+      <point x="338" y="468"/>
+      <point x="330" y="324" type="curve" smooth="yes"/>
+      <point x="320" y="126"/>
+      <point x="475" y="-14"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="619"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="235" y="-10" type="curve" smooth="yes"/>
+      <point x="317" y="-10"/>
+      <point x="344" y="51"/>
+      <point x="344" y="117" type="curve" smooth="yes"/>
+      <point x="344" y="140"/>
+      <point x="336" y="204"/>
+      <point x="328" y="277" type="curve"/>
+      <point x="404" y="291"/>
+      <point x="470" y="326"/>
+      <point x="512" y="375" type="curve"/>
+      <point x="521" y="361"/>
+      <point x="526" y="345"/>
+      <point x="526" y="327" type="curve" smooth="yes"/>
+      <point x="526" y="281"/>
+      <point x="479" y="238"/>
+      <point x="461" y="224" type="curve"/>
+      <point x="495" y="224" type="line"/>
+      <point x="514" y="238"/>
+      <point x="556" y="281"/>
+      <point x="556" y="326" type="curve" smooth="yes"/>
+      <point x="556" y="354"/>
+      <point x="546" y="378"/>
+      <point x="529" y="397" type="curve"/>
+      <point x="550" y="427"/>
+      <point x="562" y="462"/>
+      <point x="562" y="500" type="curve" smooth="yes"/>
+      <point x="562" y="608"/>
+      <point x="491" y="725"/>
+      <point x="382" y="725" type="curve" smooth="yes"/>
+      <point x="299" y="725"/>
+      <point x="272" y="664"/>
+      <point x="272" y="569" type="curve" smooth="yes"/>
+      <point x="272" y="548"/>
+      <point x="273" y="515"/>
+      <point x="274" y="477" type="curve"/>
+      <point x="262" y="478"/>
+      <point x="251" y="478"/>
+      <point x="241" y="478" type="curve" smooth="yes"/>
+      <point x="230" y="478"/>
+      <point x="211" y="477"/>
+      <point x="190" y="475" type="curve"/>
+      <point x="192" y="613" type="line"/>
+      <point x="207" y="635"/>
+      <point x="221" y="658"/>
+      <point x="221" y="675" type="curve" smooth="yes"/>
+      <point x="221" y="681"/>
+      <point x="220" y="708"/>
+      <point x="193" y="708" type="curve" smooth="yes"/>
+      <point x="158" y="708"/>
+      <point x="170" y="669"/>
+      <point x="154" y="669" type="curve" smooth="yes"/>
+      <point x="134" y="669"/>
+      <point x="123" y="715"/>
+      <point x="75" y="715" type="curve" smooth="yes"/>
+      <point x="52" y="715"/>
+      <point x="11" y="702"/>
+      <point x="11" y="643" type="curve" smooth="yes"/>
+      <point x="11" y="603"/>
+      <point x="38" y="572"/>
+      <point x="82" y="572" type="curve" smooth="yes"/>
+      <point x="89" y="572"/>
+      <point x="96" y="573"/>
+      <point x="101" y="574" type="curve"/>
+      <point x="100" y="592" type="line"/>
+      <point x="96" y="591"/>
+      <point x="88" y="590"/>
+      <point x="82" y="590" type="curve" smooth="yes"/>
+      <point x="64" y="590"/>
+      <point x="58" y="606"/>
+      <point x="58" y="617" type="curve" smooth="yes"/>
+      <point x="58" y="630"/>
+      <point x="67" y="644"/>
+      <point x="86" y="644" type="curve" smooth="yes"/>
+      <point x="108" y="644"/>
+      <point x="155" y="625"/>
+      <point x="172" y="615" type="curve"/>
+      <point x="156" y="471" type="line"/>
+      <point x="94" y="460"/>
+      <point x="24" y="433"/>
+      <point x="24" y="369" type="curve" smooth="yes"/>
+      <point x="24" y="315"/>
+      <point x="77" y="290"/>
+      <point x="137" y="279" type="curve"/>
+      <point x="130" y="208"/>
+      <point x="126" y="144"/>
+      <point x="126" y="117" type="curve" smooth="yes"/>
+      <point x="126" y="51"/>
+      <point x="153" y="-10"/>
+    </contour>
+    <contour>
+      <point x="235" y="20" type="curve" smooth="yes"/>
+      <point x="198" y="20"/>
+      <point x="178" y="58"/>
+      <point x="178" y="115" type="curve" smooth="yes"/>
+      <point x="178" y="146"/>
+      <point x="180" y="206"/>
+      <point x="182" y="273" type="curve"/>
+      <point x="207" y="270"/>
+      <point x="231" y="270"/>
+      <point x="252" y="270" type="curve" smooth="yes"/>
+      <point x="262" y="270"/>
+      <point x="273" y="270"/>
+      <point x="284" y="271" type="curve"/>
+      <point x="287" y="195"/>
+      <point x="291" y="132"/>
+      <point x="291" y="115" type="curve" smooth="yes"/>
+      <point x="291" y="58"/>
+      <point x="271" y="20"/>
+    </contour>
+    <contour>
+      <point x="139" y="299" type="line"/>
+      <point x="59" y="318"/>
+      <point x="49" y="358"/>
+      <point x="49" y="372" type="curve" smooth="yes"/>
+      <point x="49" y="384"/>
+      <point x="55" y="434"/>
+      <point x="154" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="251" y="288" type="curve" smooth="yes"/>
+      <point x="224" y="288"/>
+      <point x="203" y="289"/>
+      <point x="183" y="291" type="curve"/>
+      <point x="189" y="458" type="line"/>
+      <point x="204" y="459"/>
+      <point x="221" y="460"/>
+      <point x="240" y="460" type="curve" smooth="yes"/>
+      <point x="252" y="460"/>
+      <point x="263" y="459"/>
+      <point x="275" y="459" type="curve"/>
+      <point x="283" y="289" type="line"/>
+      <point x="272" y="288"/>
+      <point x="262" y="288"/>
+    </contour>
+    <contour>
+      <point x="326" y="295" type="curve"/>
+      <point x="307" y="457" type="line"/>
+      <point x="367" y="452"/>
+      <point x="427" y="439"/>
+      <point x="469" y="414" type="curve"/>
+      <point x="446" y="351"/>
+      <point x="398" y="311"/>
+    </contour>
+    <contour>
+      <point x="475" y="436" type="curve"/>
+      <point x="426" y="460"/>
+      <point x="360" y="471"/>
+      <point x="305" y="475" type="curve"/>
+      <point x="301" y="514"/>
+      <point x="299" y="548"/>
+      <point x="299" y="572" type="curve" smooth="yes"/>
+      <point x="299" y="636"/>
+      <point x="305" y="707"/>
+      <point x="379" y="707" type="curve" smooth="yes"/>
+      <point x="470" y="707"/>
+      <point x="486" y="593"/>
+      <point x="486" y="519" type="curve" smooth="yes"/>
+      <point x="486" y="488"/>
+      <point x="482" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="619"/>
+  <advance width="1266"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="235" y="-10" type="curve" smooth="yes"/>
-      <point x="317" y="-10"/>
-      <point x="344" y="51"/>
-      <point x="344" y="117" type="curve" smooth="yes"/>
-      <point x="344" y="140"/>
-      <point x="336" y="204"/>
-      <point x="328" y="277" type="curve"/>
-      <point x="404" y="291"/>
-      <point x="470" y="326"/>
-      <point x="512" y="375" type="curve"/>
-      <point x="521" y="361"/>
-      <point x="526" y="345"/>
-      <point x="526" y="327" type="curve" smooth="yes"/>
-      <point x="526" y="281"/>
-      <point x="479" y="238"/>
-      <point x="461" y="224" type="curve"/>
-      <point x="495" y="224" type="line"/>
-      <point x="514" y="238"/>
-      <point x="556" y="281"/>
-      <point x="556" y="326" type="curve" smooth="yes"/>
-      <point x="556" y="354"/>
-      <point x="546" y="378"/>
-      <point x="529" y="397" type="curve"/>
-      <point x="550" y="427"/>
-      <point x="562" y="462"/>
-      <point x="562" y="500" type="curve" smooth="yes"/>
-      <point x="562" y="608"/>
-      <point x="491" y="725"/>
-      <point x="382" y="725" type="curve" smooth="yes"/>
-      <point x="299" y="725"/>
-      <point x="272" y="664"/>
-      <point x="272" y="569" type="curve" smooth="yes"/>
-      <point x="272" y="548"/>
-      <point x="273" y="515"/>
-      <point x="274" y="477" type="curve"/>
-      <point x="262" y="478"/>
-      <point x="251" y="478"/>
-      <point x="241" y="478" type="curve" smooth="yes"/>
-      <point x="230" y="478"/>
-      <point x="211" y="477"/>
-      <point x="190" y="475" type="curve"/>
-      <point x="192" y="613" type="line"/>
-      <point x="207" y="635"/>
-      <point x="221" y="658"/>
-      <point x="221" y="675" type="curve" smooth="yes"/>
-      <point x="221" y="681"/>
-      <point x="220" y="708"/>
-      <point x="193" y="708" type="curve" smooth="yes"/>
-      <point x="158" y="708"/>
-      <point x="170" y="669"/>
-      <point x="154" y="669" type="curve" smooth="yes"/>
-      <point x="134" y="669"/>
-      <point x="123" y="715"/>
-      <point x="75" y="715" type="curve" smooth="yes"/>
-      <point x="52" y="715"/>
-      <point x="11" y="702"/>
-      <point x="11" y="643" type="curve" smooth="yes"/>
-      <point x="11" y="603"/>
-      <point x="38" y="572"/>
-      <point x="82" y="572" type="curve" smooth="yes"/>
-      <point x="89" y="572"/>
-      <point x="96" y="573"/>
-      <point x="101" y="574" type="curve"/>
-      <point x="100" y="592" type="line"/>
-      <point x="96" y="591"/>
-      <point x="88" y="590"/>
-      <point x="82" y="590" type="curve" smooth="yes"/>
-      <point x="64" y="590"/>
-      <point x="58" y="606"/>
-      <point x="58" y="617" type="curve" smooth="yes"/>
-      <point x="58" y="630"/>
-      <point x="67" y="644"/>
-      <point x="86" y="644" type="curve" smooth="yes"/>
-      <point x="108" y="644"/>
-      <point x="155" y="625"/>
-      <point x="172" y="615" type="curve"/>
-      <point x="156" y="471" type="line"/>
-      <point x="94" y="460"/>
-      <point x="24" y="433"/>
-      <point x="24" y="369" type="curve" smooth="yes"/>
-      <point x="24" y="315"/>
-      <point x="77" y="290"/>
-      <point x="137" y="279" type="curve"/>
-      <point x="130" y="208"/>
-      <point x="126" y="144"/>
-      <point x="126" y="117" type="curve" smooth="yes"/>
-      <point x="126" y="51"/>
-      <point x="153" y="-10"/>
+      <point x="596" y="-20" type="curve" smooth="yes"/>
+      <point x="764" y="-20"/>
+      <point x="819" y="104"/>
+      <point x="819" y="240" type="curve" smooth="yes"/>
+      <point x="819" y="287"/>
+      <point x="803" y="418"/>
+      <point x="786" y="567" type="curve"/>
+      <point x="942" y="596"/>
+      <point x="1077" y="668"/>
+      <point x="1163" y="768" type="curve"/>
+      <point x="1181" y="739"/>
+      <point x="1192" y="707"/>
+      <point x="1192" y="670" type="curve" smooth="yes"/>
+      <point x="1192" y="575"/>
+      <point x="1095" y="487"/>
+      <point x="1059" y="459" type="curve"/>
+      <point x="1128" y="459" type="line"/>
+      <point x="1167" y="487"/>
+      <point x="1253" y="575"/>
+      <point x="1253" y="668" type="curve" smooth="yes"/>
+      <point x="1253" y="725"/>
+      <point x="1233" y="774"/>
+      <point x="1198" y="813" type="curve"/>
+      <point x="1241" y="874"/>
+      <point x="1265" y="946"/>
+      <point x="1265" y="1024" type="curve" smooth="yes"/>
+      <point x="1265" y="1245"/>
+      <point x="1120" y="1485"/>
+      <point x="897" y="1485" type="curve" smooth="yes"/>
+      <point x="727" y="1485"/>
+      <point x="671" y="1360"/>
+      <point x="671" y="1165" type="curve" smooth="yes"/>
+      <point x="671" y="1122"/>
+      <point x="674" y="1055"/>
+      <point x="676" y="977" type="curve"/>
+      <point x="651" y="979"/>
+      <point x="628" y="979"/>
+      <point x="608" y="979" type="curve" smooth="yes"/>
+      <point x="585" y="979"/>
+      <point x="547" y="977"/>
+      <point x="504" y="973" type="curve"/>
+      <point x="508" y="1255" type="line"/>
+      <point x="538" y="1300"/>
+      <point x="567" y="1348"/>
+      <point x="567" y="1382" type="curve" smooth="yes"/>
+      <point x="567" y="1395"/>
+      <point x="565" y="1450"/>
+      <point x="510" y="1450" type="curve" smooth="yes"/>
+      <point x="438" y="1450"/>
+      <point x="463" y="1370"/>
+      <point x="430" y="1370" type="curve" smooth="yes"/>
+      <point x="389" y="1370"/>
+      <point x="366" y="1464"/>
+      <point x="268" y="1464" type="curve" smooth="yes"/>
+      <point x="221" y="1464"/>
+      <point x="137" y="1438"/>
+      <point x="137" y="1317" type="curve" smooth="yes"/>
+      <point x="137" y="1235"/>
+      <point x="192" y="1171"/>
+      <point x="282" y="1171" type="curve" smooth="yes"/>
+      <point x="297" y="1171"/>
+      <point x="311" y="1174"/>
+      <point x="321" y="1176" type="curve"/>
+      <point x="319" y="1212" type="line"/>
+      <point x="311" y="1210"/>
+      <point x="295" y="1208"/>
+      <point x="282" y="1208" type="curve" smooth="yes"/>
+      <point x="246" y="1208"/>
+      <point x="233" y="1241"/>
+      <point x="233" y="1264" type="curve" smooth="yes"/>
+      <point x="233" y="1290"/>
+      <point x="252" y="1319"/>
+      <point x="291" y="1319" type="curve" smooth="yes"/>
+      <point x="336" y="1319"/>
+      <point x="432" y="1280"/>
+      <point x="467" y="1260" type="curve"/>
+      <point x="434" y="965" type="line"/>
+      <point x="307" y="942"/>
+      <point x="164" y="887"/>
+      <point x="164" y="756" type="curve" smooth="yes"/>
+      <point x="164" y="645"/>
+      <point x="272" y="594"/>
+      <point x="395" y="571" type="curve"/>
+      <point x="381" y="426"/>
+      <point x="372" y="295"/>
+      <point x="372" y="240" type="curve" smooth="yes"/>
+      <point x="372" y="104"/>
+      <point x="428" y="-20"/>
     </contour>
     <contour>
-      <point x="235" y="20" type="curve" smooth="yes"/>
-      <point x="198" y="20"/>
-      <point x="178" y="58"/>
-      <point x="178" y="115" type="curve" smooth="yes"/>
-      <point x="178" y="146"/>
-      <point x="180" y="206"/>
-      <point x="182" y="273" type="curve"/>
-      <point x="207" y="270"/>
-      <point x="231" y="270"/>
-      <point x="252" y="270" type="curve" smooth="yes"/>
-      <point x="262" y="270"/>
-      <point x="273" y="270"/>
-      <point x="284" y="271" type="curve"/>
-      <point x="287" y="195"/>
-      <point x="291" y="132"/>
-      <point x="291" y="115" type="curve" smooth="yes"/>
-      <point x="291" y="58"/>
-      <point x="271" y="20"/>
+      <point x="596" y="41" type="curve" smooth="yes"/>
+      <point x="520" y="41"/>
+      <point x="479" y="119"/>
+      <point x="479" y="236" type="curve" smooth="yes"/>
+      <point x="479" y="299"/>
+      <point x="483" y="422"/>
+      <point x="487" y="559" type="curve"/>
+      <point x="538" y="553"/>
+      <point x="588" y="553"/>
+      <point x="631" y="553" type="curve" smooth="yes"/>
+      <point x="651" y="553"/>
+      <point x="674" y="553"/>
+      <point x="696" y="555" type="curve"/>
+      <point x="702" y="399"/>
+      <point x="710" y="270"/>
+      <point x="710" y="236" type="curve" smooth="yes"/>
+      <point x="710" y="119"/>
+      <point x="669" y="41"/>
     </contour>
     <contour>
-      <point x="139" y="299" type="line"/>
-      <point x="59" y="318"/>
-      <point x="49" y="358"/>
-      <point x="49" y="372" type="curve" smooth="yes"/>
-      <point x="49" y="384"/>
-      <point x="55" y="434"/>
-      <point x="154" y="453" type="curve"/>
+      <point x="399" y="612" type="line"/>
+      <point x="235" y="651"/>
+      <point x="215" y="733"/>
+      <point x="215" y="762" type="curve" smooth="yes"/>
+      <point x="215" y="786"/>
+      <point x="227" y="889"/>
+      <point x="430" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="251" y="288" type="curve" smooth="yes"/>
-      <point x="224" y="288"/>
-      <point x="203" y="289"/>
-      <point x="183" y="291" type="curve"/>
-      <point x="189" y="458" type="line"/>
-      <point x="204" y="459"/>
-      <point x="221" y="460"/>
-      <point x="240" y="460" type="curve" smooth="yes"/>
-      <point x="252" y="460"/>
-      <point x="263" y="459"/>
-      <point x="275" y="459" type="curve"/>
-      <point x="283" y="289" type="line"/>
-      <point x="272" y="288"/>
-      <point x="262" y="288"/>
+      <point x="628" y="590" type="curve" smooth="yes"/>
+      <point x="573" y="590"/>
+      <point x="530" y="592"/>
+      <point x="489" y="596" type="curve"/>
+      <point x="502" y="938" type="line"/>
+      <point x="532" y="940"/>
+      <point x="567" y="942"/>
+      <point x="606" y="942" type="curve" smooth="yes"/>
+      <point x="631" y="942"/>
+      <point x="653" y="940"/>
+      <point x="678" y="940" type="curve"/>
+      <point x="694" y="592" type="line"/>
+      <point x="671" y="590"/>
+      <point x="651" y="590"/>
     </contour>
     <contour>
-      <point x="326" y="295" type="curve"/>
-      <point x="307" y="457" type="line"/>
-      <point x="367" y="452"/>
-      <point x="427" y="439"/>
-      <point x="469" y="414" type="curve"/>
-      <point x="446" y="351"/>
-      <point x="398" y="311"/>
+      <point x="782" y="604" type="curve"/>
+      <point x="743" y="936" type="line"/>
+      <point x="866" y="926"/>
+      <point x="989" y="899"/>
+      <point x="1075" y="848" type="curve"/>
+      <point x="1028" y="719"/>
+      <point x="930" y="637"/>
     </contour>
     <contour>
-      <point x="475" y="436" type="curve"/>
-      <point x="426" y="460"/>
-      <point x="360" y="471"/>
-      <point x="305" y="475" type="curve"/>
-      <point x="301" y="514"/>
-      <point x="299" y="548"/>
-      <point x="299" y="572" type="curve" smooth="yes"/>
-      <point x="299" y="636"/>
-      <point x="305" y="707"/>
-      <point x="379" y="707" type="curve" smooth="yes"/>
-      <point x="470" y="707"/>
-      <point x="486" y="593"/>
-      <point x="486" y="519" type="curve" smooth="yes"/>
-      <point x="486" y="488"/>
-      <point x="482" y="461"/>
+      <point x="1087" y="893" type="curve"/>
+      <point x="987" y="942"/>
+      <point x="852" y="965"/>
+      <point x="739" y="973" type="curve"/>
+      <point x="731" y="1053"/>
+      <point x="727" y="1122"/>
+      <point x="727" y="1171" type="curve" smooth="yes"/>
+      <point x="727" y="1303"/>
+      <point x="739" y="1448"/>
+      <point x="891" y="1448" type="curve" smooth="yes"/>
+      <point x="1077" y="1448"/>
+      <point x="1110" y="1214"/>
+      <point x="1110" y="1063" type="curve" smooth="yes"/>
+      <point x="1110" y="999"/>
+      <point x="1102" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:58 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-BlackItalic.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-BlackItalic.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="972"/>
+  <unicode hex="214E"/>
+  <anchor x="1886" y="-824" name="bottom"/>
+  <anchor x="1415" y="-407" name="bottom_dd"/>
+  <anchor x="1545" y="-2134" name="parent_top"/>
+  <anchor x="1545" y="-2134" name="top"/>
+  <anchor x="1116" y="-2134" name="top0315"/>
+  <anchor x="1068" y="-2414" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="466" y="0" type="line"/>
+      <point x="796" y="0" type="line"/>
+      <point x="984" y="1082" type="line"/>
+      <point x="654" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="-37" y="0" type="line"/>
+      <point x="565" y="0" type="line"/>
+      <point x="611" y="260" type="line"/>
+      <point x="8" y="260" type="line"/>
+    </contour>
+    <contour>
+      <point x="82" y="465" type="line"/>
+      <point x="646" y="465" type="line"/>
+      <point x="691" y="725" type="line"/>
+      <point x="128" y="725" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:58 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-BlackItalic.ufo/lib.plist
+++ b/sources/Roboto-BlackItalic.ufo/lib.plist
@@ -6898,6 +6898,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/Roboto-Italic.ufo/fontinfo.plist
+++ b/sources/Roboto-Italic.ufo/fontinfo.plist
@@ -375,7 +375,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-Italic.ufo/glyphs/contents.plist
+++ b/sources/Roboto-Italic.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/Roboto-Italic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Italic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="1058"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="3" y="0" type="line"/>
+      <point x="394" y="0" type="line" smooth="yes"/>
+      <point x="685" y="0"/>
+      <point x="912" y="158"/>
+      <point x="912" y="459" type="curve" smooth="yes"/>
+      <point x="912" y="621"/>
+      <point x="818" y="715"/>
+      <point x="693" y="752" type="curve"/>
+      <point x="693" y="762" type="line"/>
+      <point x="883" y="799"/>
+      <point x="1008" y="930"/>
+      <point x="1008" y="1130" type="curve" smooth="yes"/>
+      <point x="1008" y="1356"/>
+      <point x="853" y="1456"/>
+      <point x="617" y="1456" type="curve" smooth="yes"/>
+      <point x="312" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="126" y="-201" type="line"/>
+      <point x="244" y="-201" type="line"/>
+      <point x="310" y="115" type="line"/>
+      <point x="191" y="115" type="line"/>
+    </contour>
+    <contour>
+      <point x="388" y="-201" type="line"/>
+      <point x="507" y="-201" type="line"/>
+      <point x="572" y="115" type="line"/>
+      <point x="453" y="115" type="line"/>
+    </contour>
+    <contour>
+      <point x="220" y="156" type="line"/>
+      <point x="331" y="688" type="line"/>
+      <point x="466" y="688" type="line" smooth="yes"/>
+      <point x="650" y="688"/>
+      <point x="720" y="588"/>
+      <point x="720" y="459" type="curve" smooth="yes"/>
+      <point x="720" y="266"/>
+      <point x="597" y="156"/>
+      <point x="402" y="156" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="363" y="840" type="line"/>
+      <point x="460" y="1299" type="line"/>
+      <point x="595" y="1299" type="line" smooth="yes"/>
+      <point x="748" y="1299"/>
+      <point x="818" y="1229"/>
+      <point x="818" y="1106" type="curve" smooth="yes"/>
+      <point x="818" y="924"/>
+      <point x="679" y="840"/>
+      <point x="507" y="840" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="457" y="1348" type="line"/>
+      <point x="576" y="1348" type="line"/>
+      <point x="642" y="1663" type="line"/>
+      <point x="523" y="1663" type="line"/>
+    </contour>
+    <contour>
+      <point x="720" y="1348" type="line"/>
+      <point x="838" y="1348" type="line"/>
+      <point x="904" y="1663" type="line"/>
+      <point x="785" y="1663" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="1169"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="309" y="0" type="line"/>
+      <point x="1016" y="0" type="line"/>
+      <point x="1037" y="123" type="line"/>
+      <point x="461" y="123" type="line"/>
+      <point x="501" y="367" type="line"/>
+      <point x="566" y="369"/>
+      <point x="640" y="385"/>
+      <point x="708" y="414" type="curve"/>
+      <point x="726" y="520" type="line"/>
+      <point x="657" y="494"/>
+      <point x="582" y="477"/>
+      <point x="519" y="475" type="curve"/>
+      <point x="631" y="1143" type="line"/>
+      <point x="699" y="1141"/>
+      <point x="755" y="1124"/>
+      <point x="808" y="1096" type="curve"/>
+      <point x="861" y="1200" type="line"/>
+      <point x="804" y="1231"/>
+      <point x="731" y="1247"/>
+      <point x="649" y="1249" type="curve"/>
+      <point x="685" y="1462" type="line"/>
+      <point x="554" y="1462" type="line"/>
+      <point x="517" y="1241" type="line"/>
+      <point x="328" y="1204"/>
+      <point x="191" y="1057"/>
+      <point x="150" y="811" type="curve" smooth="yes"/>
+      <point x="108" y="563"/>
+      <point x="190" y="414"/>
+      <point x="372" y="375" type="curve"/>
+    </contour>
+    <contour>
+      <point x="390" y="487" type="line"/>
+      <point x="279" y="524"/>
+      <point x="244" y="639"/>
+      <point x="273" y="815" type="curve" smooth="yes"/>
+      <point x="301" y="983"/>
+      <point x="374" y="1096"/>
+      <point x="499" y="1133" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="1057"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2108.glif
@@ -37,10 +37,10 @@
       <point x="289.497" y="-14.153"/>
     </contour>
     <contour>
+      <point x="495.338" y="647.093" type="line"/>
       <point x="1075.755" y="647.084" type="line"/>
       <point x="1103.795" y="804.906" type="line"/>
       <point x="523.377" y="804.914" type="line"/>
-      <point x="495.338" y="647.093" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1340"/>
+  <unicode hex="2108"/>
+  <anchor x="849.897" y="1634" name="parent_top"/>
+  <anchor x="849.897" y="1634" name="top"/>
+  <anchor x="1518.227" y="1634" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="586.673" y="-19.98" type="curve" smooth="yes"/>
+      <point x="970.195" y="-27.499"/>
+      <point x="1190.376" y="311.718"/>
+      <point x="1242.034" y="655.224" type="curve" smooth="yes"/>
+      <point x="1263.11" y="799.277" type="line" smooth="yes"/>
+      <point x="1306.495" y="1129.717"/>
+      <point x="1175.508" y="1468.782"/>
+      <point x="799.324" y="1476.341" type="curve" smooth="yes"/>
+      <point x="492.432" y="1482.508"/>
+      <point x="274.788" y="1283.028"/>
+      <point x="215.486" y="989.087" type="curve"/>
+      <point x="402.3" y="990.098" type="line"/>
+      <point x="457.171" y="1184.975"/>
+      <point x="574.394" y="1326.007"/>
+      <point x="791.403" y="1319.129" type="curve" smooth="yes"/>
+      <point x="1070.66" y="1310.278"/>
+      <point x="1105.86" y="1024.816"/>
+      <point x="1075.82" y="802.209" type="curve" smooth="yes"/>
+      <point x="1053.838" y="654.878" type="line" smooth="yes"/>
+      <point x="1015.748" y="411.85"/>
+      <point x="881.105" y="129.002"/>
+      <point x="595.554" y="136.019" type="curve" smooth="yes"/>
+      <point x="384.512" y="141.205"/>
+      <point x="313.361" y="268.392"/>
+      <point x="303.715" y="463.746" type="curve"/>
+      <point x="117.529" y="464" type="line"/>
+      <point x="127.233" y="175.996"/>
+      <point x="289.497" y="-14.153"/>
+    </contour>
+    <contour>
+      <point x="1075.755" y="647.084" type="line"/>
+      <point x="1103.795" y="804.906" type="line"/>
+      <point x="523.377" y="804.914" type="line"/>
+      <point x="495.338" y="647.093" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1636"/>
+  <unicode hex="2114"/>
+  <anchor x="994.663" y="-10" name="bottom"/>
+  <anchor x="1461.508" y="-407" name="bottom_dd"/>
+  <anchor x="755.525" y="1540" name="marktop"/>
+  <anchor x="1309.663" y="1611" name="parent_top"/>
+  <anchor x="1309.663" y="1611" name="top"/>
+  <anchor x="1810.183" y="1611" name="top0315"/>
+  <anchor x="1808.282" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1047" y="-21" type="curve" smooth="yes"/>
+      <point x="1353" y="-28"/>
+      <point x="1501" y="272"/>
+      <point x="1534" y="535" type="curve" smooth="yes"/>
+      <point x="1536" y="556" type="line" smooth="yes"/>
+      <point x="1563" y="800"/>
+      <point x="1500" y="1094"/>
+      <point x="1205" y="1103" type="curve" smooth="yes"/>
+      <point x="913" y="1111"/>
+      <point x="751" y="845"/>
+      <point x="706" y="586" type="curve"/>
+      <point x="695" y="494" type="line"/>
+      <point x="679" y="250"/>
+      <point x="768" y="-15"/>
+    </contour>
+    <contour>
+      <point x="94" y="0" type="line"/>
+      <point x="275" y="0" type="line"/>
+      <point x="542" y="1536" type="line"/>
+      <point x="360" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="551" y="0" type="line"/>
+      <point x="718" y="0" type="line"/>
+      <point x="768" y="199" type="line"/>
+      <point x="1000" y="1536" type="line"/>
+      <point x="818" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="1012" y="136" type="curve" smooth="yes"/>
+      <point x="865" y="141"/>
+      <point x="764" y="273"/>
+      <point x="769" y="417" type="curve"/>
+      <point x="808" y="660" type="line"/>
+      <point x="849" y="815"/>
+      <point x="984" y="952"/>
+      <point x="1151" y="947" type="curve" smooth="yes"/>
+      <point x="1361" y="941"/>
+      <point x="1373" y="720"/>
+      <point x="1355" y="558" type="curve" smooth="yes"/>
+      <point x="1352" y="536" type="line" smooth="yes"/>
+      <point x="1328" y="350"/>
+      <point x="1233" y="129"/>
+    </contour>
+    <contour>
+      <point x="112" y="1233" type="line"/>
+      <point x="1253" y="1233" type="line"/>
+      <point x="1279" y="1385" type="line"/>
+      <point x="138" y="1385" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="808"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="179" y="-241" type="curve" smooth="yes"/>
+      <point x="249" y="-241"/>
+      <point x="296" y="-180"/>
+      <point x="296" y="-95" type="curve" smooth="yes"/>
+      <point x="296" y="8"/>
+      <point x="204" y="99"/>
+      <point x="147" y="200" type="curve"/>
+      <point x="194" y="272"/>
+      <point x="254" y="341"/>
+      <point x="316" y="394" type="curve" smooth="yes"/>
+      <point x="384" y="452"/>
+      <point x="455" y="492"/>
+      <point x="514" y="492" type="curve" smooth="yes"/>
+      <point x="616" y="492"/>
+      <point x="624" y="359"/>
+      <point x="624" y="322" type="curve" smooth="yes"/>
+      <point x="624" y="285"/>
+      <point x="611" y="30"/>
+      <point x="447" y="30" type="curve" smooth="yes"/>
+      <point x="396" y="30"/>
+      <point x="347" y="57"/>
+      <point x="347" y="112" type="curve" smooth="yes"/>
+      <point x="347" y="119"/>
+      <point x="348" y="126"/>
+      <point x="349" y="132" type="curve"/>
+      <point x="382" y="136"/>
+      <point x="415" y="151"/>
+      <point x="415" y="194" type="curve" smooth="yes"/>
+      <point x="415" y="225"/>
+      <point x="394" y="244"/>
+      <point x="363" y="244" type="curve" smooth="yes"/>
+      <point x="315" y="244"/>
+      <point x="285" y="206"/>
+      <point x="285" y="140" type="curve" smooth="yes"/>
+      <point x="285" y="51"/>
+      <point x="349" y="-10"/>
+      <point x="455" y="-10" type="curve" smooth="yes"/>
+      <point x="633" y="-10"/>
+      <point x="726" y="159"/>
+      <point x="726" y="306" type="curve" smooth="yes"/>
+      <point x="726" y="437"/>
+      <point x="666" y="549"/>
+      <point x="544" y="549" type="curve" smooth="yes"/>
+      <point x="494" y="549"/>
+      <point x="398" y="512"/>
+      <point x="292" y="419" type="curve" smooth="yes"/>
+      <point x="240" y="373"/>
+      <point x="179" y="310"/>
+      <point x="127" y="238" type="curve"/>
+      <point x="112" y="272"/>
+      <point x="103" y="307"/>
+      <point x="103" y="345" type="curve" smooth="yes"/>
+      <point x="103" y="474"/>
+      <point x="133" y="548"/>
+      <point x="214" y="625" type="curve"/>
+      <point x="198" y="647" type="line"/>
+      <point x="139" y="610"/>
+      <point x="15" y="496"/>
+      <point x="15" y="337" type="curve" smooth="yes"/>
+      <point x="15" y="267"/>
+      <point x="39" y="206"/>
+      <point x="71" y="149" type="curve"/>
+      <point x="36" y="85"/>
+      <point x="10" y="11"/>
+      <point x="10" y="-56" type="curve" smooth="yes"/>
+      <point x="10" y="-163"/>
+      <point x="84" y="-241"/>
+    </contour>
+    <contour>
+      <point x="161" y="-199" type="curve" smooth="yes"/>
+      <point x="117" y="-199"/>
+      <point x="50" y="-145"/>
+      <point x="50" y="-51" type="curve" smooth="yes"/>
+      <point x="50" y="-4"/>
+      <point x="66" y="52"/>
+      <point x="94" y="110" type="curve"/>
+      <point x="148" y="24"/>
+      <point x="209" y="-52"/>
+      <point x="209" y="-134" type="curve" smooth="yes"/>
+      <point x="209" y="-176"/>
+      <point x="190" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="808"/>
+  <advance width="1534"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="179" y="-241" type="curve" smooth="yes"/>
-      <point x="249" y="-241"/>
-      <point x="296" y="-180"/>
-      <point x="296" y="-95" type="curve" smooth="yes"/>
-      <point x="296" y="8"/>
-      <point x="204" y="99"/>
-      <point x="147" y="200" type="curve"/>
-      <point x="194" y="272"/>
-      <point x="254" y="341"/>
-      <point x="316" y="394" type="curve" smooth="yes"/>
-      <point x="384" y="452"/>
-      <point x="455" y="492"/>
-      <point x="514" y="492" type="curve" smooth="yes"/>
-      <point x="616" y="492"/>
-      <point x="624" y="359"/>
-      <point x="624" y="322" type="curve" smooth="yes"/>
-      <point x="624" y="285"/>
-      <point x="611" y="30"/>
-      <point x="447" y="30" type="curve" smooth="yes"/>
-      <point x="396" y="30"/>
-      <point x="347" y="57"/>
-      <point x="347" y="112" type="curve" smooth="yes"/>
-      <point x="347" y="119"/>
-      <point x="348" y="126"/>
-      <point x="349" y="132" type="curve"/>
-      <point x="382" y="136"/>
-      <point x="415" y="151"/>
-      <point x="415" y="194" type="curve" smooth="yes"/>
-      <point x="415" y="225"/>
-      <point x="394" y="244"/>
-      <point x="363" y="244" type="curve" smooth="yes"/>
-      <point x="315" y="244"/>
-      <point x="285" y="206"/>
-      <point x="285" y="140" type="curve" smooth="yes"/>
-      <point x="285" y="51"/>
-      <point x="349" y="-10"/>
-      <point x="455" y="-10" type="curve" smooth="yes"/>
-      <point x="633" y="-10"/>
-      <point x="726" y="159"/>
-      <point x="726" y="306" type="curve" smooth="yes"/>
-      <point x="726" y="437"/>
-      <point x="666" y="549"/>
-      <point x="544" y="549" type="curve" smooth="yes"/>
-      <point x="494" y="549"/>
-      <point x="398" y="512"/>
-      <point x="292" y="419" type="curve" smooth="yes"/>
-      <point x="240" y="373"/>
-      <point x="179" y="310"/>
-      <point x="127" y="238" type="curve"/>
-      <point x="112" y="272"/>
-      <point x="103" y="307"/>
-      <point x="103" y="345" type="curve" smooth="yes"/>
-      <point x="103" y="474"/>
-      <point x="133" y="548"/>
-      <point x="214" y="625" type="curve"/>
-      <point x="198" y="647" type="line"/>
-      <point x="139" y="610"/>
-      <point x="15" y="496"/>
-      <point x="15" y="337" type="curve" smooth="yes"/>
-      <point x="15" y="267"/>
-      <point x="39" y="206"/>
-      <point x="71" y="149" type="curve"/>
-      <point x="36" y="85"/>
-      <point x="10" y="11"/>
-      <point x="10" y="-56" type="curve" smooth="yes"/>
-      <point x="10" y="-163"/>
-      <point x="84" y="-241"/>
+      <point x="401" y="-494" type="curve" smooth="yes"/>
+      <point x="538" y="-494"/>
+      <point x="632" y="-369"/>
+      <point x="632" y="-195" type="curve" smooth="yes"/>
+      <point x="632" y="16"/>
+      <point x="450" y="203"/>
+      <point x="337" y="410" type="curve"/>
+      <point x="432" y="557"/>
+      <point x="552" y="698"/>
+      <point x="673" y="807" type="curve" smooth="yes"/>
+      <point x="806" y="926"/>
+      <point x="948" y="1008"/>
+      <point x="1066" y="1008" type="curve" smooth="yes"/>
+      <point x="1269" y="1008"/>
+      <point x="1284" y="735"/>
+      <point x="1284" y="659" type="curve" smooth="yes"/>
+      <point x="1284" y="584"/>
+      <point x="1259" y="61"/>
+      <point x="933" y="61" type="curve" smooth="yes"/>
+      <point x="831" y="61"/>
+      <point x="733" y="117"/>
+      <point x="733" y="229" type="curve" smooth="yes"/>
+      <point x="733" y="244"/>
+      <point x="735" y="258"/>
+      <point x="739" y="270" type="curve"/>
+      <point x="804" y="279"/>
+      <point x="870" y="309"/>
+      <point x="870" y="397" type="curve" smooth="yes"/>
+      <point x="870" y="461"/>
+      <point x="827" y="500"/>
+      <point x="765" y="500" type="curve" smooth="yes"/>
+      <point x="669" y="500"/>
+      <point x="612" y="422"/>
+      <point x="612" y="287" type="curve" smooth="yes"/>
+      <point x="612" y="104"/>
+      <point x="737" y="-20"/>
+      <point x="948" y="-20" type="curve" smooth="yes"/>
+      <point x="1300" y="-20"/>
+      <point x="1486" y="326"/>
+      <point x="1486" y="627" type="curve" smooth="yes"/>
+      <point x="1486" y="895"/>
+      <point x="1365" y="1124"/>
+      <point x="1126" y="1124" type="curve" smooth="yes"/>
+      <point x="1025" y="1124"/>
+      <point x="837" y="1049"/>
+      <point x="626" y="858" type="curve" smooth="yes"/>
+      <point x="522" y="764"/>
+      <point x="401" y="635"/>
+      <point x="298" y="487" type="curve"/>
+      <point x="268" y="557"/>
+      <point x="249" y="629"/>
+      <point x="249" y="707" type="curve" smooth="yes"/>
+      <point x="249" y="971"/>
+      <point x="309" y="1122"/>
+      <point x="468" y="1280" type="curve"/>
+      <point x="438" y="1325" type="line"/>
+      <point x="321" y="1249"/>
+      <point x="75" y="1016"/>
+      <point x="75" y="690" type="curve" smooth="yes"/>
+      <point x="75" y="547"/>
+      <point x="122" y="422"/>
+      <point x="186" y="305" type="curve"/>
+      <point x="116" y="174"/>
+      <point x="65" y="23"/>
+      <point x="65" y="-115" type="curve" smooth="yes"/>
+      <point x="65" y="-334"/>
+      <point x="210" y="-494"/>
     </contour>
     <contour>
-      <point x="161" y="-199" type="curve" smooth="yes"/>
-      <point x="117" y="-199"/>
-      <point x="50" y="-145"/>
-      <point x="50" y="-51" type="curve" smooth="yes"/>
-      <point x="50" y="-4"/>
-      <point x="66" y="52"/>
-      <point x="94" y="110" type="curve"/>
-      <point x="148" y="24"/>
-      <point x="209" y="-52"/>
-      <point x="209" y="-134" type="curve" smooth="yes"/>
-      <point x="209" y="-176"/>
-      <point x="190" y="-199"/>
+      <point x="366" y="-408" type="curve" smooth="yes"/>
+      <point x="276" y="-408"/>
+      <point x="145" y="-297"/>
+      <point x="145" y="-104" type="curve" smooth="yes"/>
+      <point x="145" y="-8"/>
+      <point x="178" y="106"/>
+      <point x="233" y="225" type="curve"/>
+      <point x="337" y="49"/>
+      <point x="460" y="-106"/>
+      <point x="460" y="-274" type="curve" smooth="yes"/>
+      <point x="460" y="-360"/>
+      <point x="423" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2127.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1321"/>
+  <advance width="1351"/>
   <unicode hex="2127"/>
-  <anchor x="849.311" y="1444" name="top"/>
+  <anchor x="828" y="1444" name="top"/>
   <outline>
     <contour>
-      <point x="620" y="-22" type="curve" smooth="yes"/>
-      <point x="984" y="-30"/>
-      <point x="1207" y="285"/>
-      <point x="1256" y="614" type="curve" smooth="yes"/>
-      <point x="1272" y="728" type="line" smooth="yes"/>
-      <point x="1308" y="998"/>
-      <point x="1214" y="1372"/>
-      <point x="905" y="1431" type="curve"/>
-      <point x="892" y="1290" type="line"/>
-      <point x="1126" y="1232"/>
-      <point x="1106" y="914"/>
-      <point x="1082" y="729" type="curve" smooth="yes"/>
-      <point x="1065" y="612" type="line" smooth="yes"/>
-      <point x="1030" y="377"/>
-      <point x="899" y="125"/>
-      <point x="628" y="134" type="curve" smooth="yes"/>
-      <point x="370" y="142"/>
-      <point x="338" y="403"/>
-      <point x="365" y="610" type="curve" smooth="yes"/>
-      <point x="382" y="728" type="line" smooth="yes"/>
-      <point x="416" y="960"/>
-      <point x="512" y="1236"/>
-      <point x="770" y="1292" type="curve"/>
-      <point x="785" y="1434" type="line"/>
-      <point x="446" y="1387"/>
-      <point x="239" y="1041"/>
-      <point x="191" y="728" type="curve" smooth="yes"/>
-      <point x="175" y="614" type="line" smooth="yes"/>
-      <point x="135" y="305"/>
-      <point x="272" y="-14"/>
+      <point x="599" y="-22" type="curve" smooth="yes"/>
+      <point x="963" y="-30"/>
+      <point x="1186" y="285"/>
+      <point x="1235" y="614" type="curve" smooth="yes"/>
+      <point x="1251" y="728" type="line" smooth="yes"/>
+      <point x="1287" y="998"/>
+      <point x="1193" y="1372"/>
+      <point x="884" y="1431" type="curve"/>
+      <point x="871" y="1290" type="line"/>
+      <point x="1105" y="1232"/>
+      <point x="1085" y="914"/>
+      <point x="1061" y="729" type="curve" smooth="yes"/>
+      <point x="1044" y="612" type="line" smooth="yes"/>
+      <point x="1009" y="377"/>
+      <point x="878" y="125"/>
+      <point x="607" y="134" type="curve" smooth="yes"/>
+      <point x="349" y="142"/>
+      <point x="317" y="403"/>
+      <point x="344" y="610" type="curve" smooth="yes"/>
+      <point x="361" y="728" type="line" smooth="yes"/>
+      <point x="395" y="960"/>
+      <point x="491" y="1236"/>
+      <point x="749" y="1292" type="curve"/>
+      <point x="764" y="1434" type="line"/>
+      <point x="425" y="1387"/>
+      <point x="218" y="1041"/>
+      <point x="170" y="728" type="curve" smooth="yes"/>
+      <point x="154" y="614" type="line" smooth="yes"/>
+      <point x="114" y="305"/>
+      <point x="251" y="-14"/>
     </contour>
     <contour>
-      <point x="297" y="1297" type="line"/>
-      <point x="767" y="1297" type="line"/>
-      <point x="795" y="1454" type="line"/>
-      <point x="325" y="1454" type="line"/>
+      <point x="276" y="1297" type="line"/>
+      <point x="746" y="1297" type="line"/>
+      <point x="774" y="1454" type="line"/>
+      <point x="304" y="1454" type="line"/>
     </contour>
     <contour>
-      <point x="890" y="1297" type="line"/>
-      <point x="1368" y="1297" type="line"/>
-      <point x="1396" y="1454" type="line"/>
-      <point x="918" y="1454" type="line"/>
+      <point x="869" y="1297" type="line"/>
+      <point x="1347" y="1297" type="line"/>
+      <point x="1375" y="1454" type="line"/>
+      <point x="897" y="1454" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1321"/>
+  <unicode hex="2127"/>
+  <anchor x="849.311" y="1444" name="top"/>
+  <outline>
+    <contour>
+      <point x="620" y="-22" type="curve" smooth="yes"/>
+      <point x="984" y="-30"/>
+      <point x="1207" y="285"/>
+      <point x="1256" y="614" type="curve" smooth="yes"/>
+      <point x="1272" y="728" type="line" smooth="yes"/>
+      <point x="1308" y="998"/>
+      <point x="1214" y="1372"/>
+      <point x="905" y="1431" type="curve"/>
+      <point x="892" y="1290" type="line"/>
+      <point x="1126" y="1232"/>
+      <point x="1106" y="914"/>
+      <point x="1082" y="729" type="curve" smooth="yes"/>
+      <point x="1065" y="612" type="line" smooth="yes"/>
+      <point x="1030" y="377"/>
+      <point x="899" y="125"/>
+      <point x="628" y="134" type="curve" smooth="yes"/>
+      <point x="370" y="142"/>
+      <point x="338" y="403"/>
+      <point x="365" y="610" type="curve" smooth="yes"/>
+      <point x="382" y="728" type="line" smooth="yes"/>
+      <point x="416" y="960"/>
+      <point x="512" y="1236"/>
+      <point x="770" y="1292" type="curve"/>
+      <point x="785" y="1434" type="line"/>
+      <point x="446" y="1387"/>
+      <point x="239" y="1041"/>
+      <point x="191" y="728" type="curve" smooth="yes"/>
+      <point x="175" y="614" type="line" smooth="yes"/>
+      <point x="135" y="305"/>
+      <point x="272" y="-14"/>
+    </contour>
+    <contour>
+      <point x="297" y="1297" type="line"/>
+      <point x="767" y="1297" type="line"/>
+      <point x="795" y="1454" type="line"/>
+      <point x="325" y="1454" type="line"/>
+    </contour>
+    <contour>
+      <point x="890" y="1297" type="line"/>
+      <point x="1368" y="1297" type="line"/>
+      <point x="1396" y="1454" type="line"/>
+      <point x="918" y="1454" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="645"/>
+  <unicode hex="2129"/>
+  <anchor x="241.229" y="-199" name="bottom"/>
+  <anchor x="-117.671" y="-199" name="bottom0315"/>
+  <anchor x="241.229" y="-199" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="188" y="-12" type="line"/>
+      <point x="369" y="-12" type="line"/>
+      <point x="503" y="793" type="line"/>
+      <point x="517" y="940"/>
+      <point x="465" y="1079"/>
+      <point x="299" y="1081" type="curve" smooth="yes"/>
+      <point x="254" y="1082"/>
+      <point x="209" y="1076"/>
+      <point x="166" y="1063" type="curve"/>
+      <point x="154" y="912" type="line"/>
+      <point x="182" y="917"/>
+      <point x="211" y="922"/>
+      <point x="240" y="922" type="curve" smooth="yes"/>
+      <point x="318" y="920"/>
+      <point x="331" y="865"/>
+      <point x="324" y="796" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="483"/>
+  <unicode hex="2139"/>
+  <anchor x="139.589" y="10" name="bottom"/>
+  <anchor x="309.068" y="-407" name="bottom_dd"/>
+  <anchor x="416.252" y="1600" name="parent_top"/>
+  <anchor x="278.02" y="654" name="rhotichook"/>
+  <anchor x="416.252" y="1600" name="top"/>
+  <anchor x="655.842" y="1600" name="top0315"/>
+  <anchor x="655.842" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2139.glif
@@ -2,13 +2,13 @@
 <glyph name="uni2139" format="2">
   <advance width="483"/>
   <unicode hex="2139"/>
-  <anchor x="139.589" y="10" name="bottom"/>
-  <anchor x="309.068" y="-407" name="bottom_dd"/>
-  <anchor x="416.252" y="1600" name="parent_top"/>
-  <anchor x="278.02" y="654" name="rhotichook"/>
-  <anchor x="416.252" y="1600" name="top"/>
-  <anchor x="655.842" y="1600" name="top0315"/>
-  <anchor x="655.842" y="1600" name="top_dd"/>
+  <anchor x="139.589" y="10.0" name="bottom"/>
+  <anchor x="309.068" y="-407.0" name="bottom_dd"/>
+  <anchor x="416.252" y="1600.0" name="parent_top"/>
+  <anchor x="278.02" y="654.0" name="rhotichook"/>
+  <anchor x="416.252" y="1600.0" name="top"/>
+  <anchor x="655.842" y="1600.0" name="top0315"/>
+  <anchor x="655.842" y="1600.0" name="top_dd"/>
   <outline>
     <component base="i"/>
   </outline>
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni213A_.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni213A" format="2">
-  <advance width="1749"/>
+  <advance width="1754"/>
   <unicode hex="213A"/>
-  <anchor x="1644.58" y="706.715" name="bottom"/>
-  <anchor x="1927.7" y="1387.292" name="bottom_dd"/>
-  <anchor x="10.397" y="703.004" name="parent_top"/>
-  <anchor x="10.397" y="703.004" name="top"/>
-  <anchor x="-109.026" y="1380.286" name="top0315"/>
-  <anchor x="-109.026" y="1380.286" name="top_dd"/>
+  <anchor x="1630" y="707" name="bottom"/>
+  <anchor x="1913" y="1387" name="bottom_dd"/>
+  <anchor x="-5" y="703" name="parent_top"/>
+  <anchor x="-5" y="703" name="top"/>
+  <anchor x="-124" y="1380" name="top0315"/>
+  <anchor x="-124" y="1380" name="top_dd"/>
   <outline>
     <contour>
-      <point x="949" y="141" type="curve" smooth="yes"/>
-      <point x="1041" y="144" type="line" smooth="yes"/>
-      <point x="1374" y="160"/>
-      <point x="1711" y="339"/>
-      <point x="1652" y="720" type="curve" smooth="yes"/>
-      <point x="1591" y="1117"/>
-      <point x="1205" y="1274"/>
-      <point x="843" y="1263" type="curve" smooth="yes"/>
-      <point x="751" y="1260" type="line" smooth="yes"/>
-      <point x="415" y="1244"/>
-      <point x="80" y="1069"/>
-      <point x="139" y="685" type="curve" smooth="yes"/>
-      <point x="200" y="292"/>
-      <point x="590" y="130"/>
+      <point x="708" y="79" type="curve"/>
+      <point x="800" y="79" type="line"/>
+      <point x="1267" y="79"/>
+      <point x="1542" y="321"/>
+      <point x="1600" y="666" type="curve" smooth="yes"/>
+      <point x="1660" y="1021"/>
+      <point x="1413" y="1250"/>
+      <point x="996" y="1250" type="curve"/>
+      <point x="904" y="1250" type="line"/>
+      <point x="448" y="1250"/>
+      <point x="163" y="1019"/>
+      <point x="104" y="664" type="curve" smooth="yes"/>
+      <point x="46" y="319"/>
+      <point x="292" y="79"/>
     </contour>
     <contour>
-      <point x="914" y="325" type="line" smooth="yes"/>
-      <point x="656" y="317"/>
-      <point x="344" y="410"/>
-      <point x="302" y="705" type="curve" smooth="yes"/>
-      <point x="261" y="991"/>
-      <point x="552" y="1065"/>
-      <point x="780" y="1076" type="curve" smooth="yes"/>
-      <point x="876" y="1079" type="line" smooth="yes"/>
-      <point x="1139" y="1087"/>
-      <point x="1448" y="1002"/>
-      <point x="1491" y="701" type="curve" smooth="yes"/>
-      <point x="1531" y="419"/>
-      <point x="1233" y="339"/>
-      <point x="1010" y="328" type="curve" smooth="yes"/>
+      <point x="738" y="270" type="line" smooth="yes"/>
+      <point x="392" y="270"/>
+      <point x="228" y="426"/>
+      <point x="268" y="664" type="curve" smooth="yes"/>
+      <point x="310" y="914"/>
+      <point x="524" y="1059"/>
+      <point x="870" y="1059" type="curve"/>
+      <point x="964" y="1059" type="line"/>
+      <point x="1313" y="1059"/>
+      <point x="1479" y="917"/>
+      <point x="1437" y="666" type="curve" smooth="yes"/>
+      <point x="1397" y="428"/>
+      <point x="1181" y="270"/>
+      <point x="832" y="270" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="1567" y="795" type="line"/>
-      <point x="1805" y="1154" type="line"/>
-      <point x="1671" y="1270" type="line"/>
-      <point x="1430" y="906" type="line"/>
+      <point x="1553" y="761" type="line"/>
+      <point x="1903" y="1125" type="line"/>
+      <point x="1805" y="1255" type="line"/>
+      <point x="1450" y="885" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1749"/>
+  <unicode hex="213A"/>
+  <anchor x="1644.58" y="706.715" name="bottom"/>
+  <anchor x="1927.7" y="1387.292" name="bottom_dd"/>
+  <anchor x="10.397" y="703.004" name="parent_top"/>
+  <anchor x="10.397" y="703.004" name="top"/>
+  <anchor x="-109.026" y="1380.286" name="top0315"/>
+  <anchor x="-109.026" y="1380.286" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="949" y="141" type="curve" smooth="yes"/>
+      <point x="1041" y="144" type="line" smooth="yes"/>
+      <point x="1374" y="160"/>
+      <point x="1711" y="339"/>
+      <point x="1652" y="720" type="curve" smooth="yes"/>
+      <point x="1591" y="1117"/>
+      <point x="1205" y="1274"/>
+      <point x="843" y="1263" type="curve" smooth="yes"/>
+      <point x="751" y="1260" type="line" smooth="yes"/>
+      <point x="415" y="1244"/>
+      <point x="80" y="1069"/>
+      <point x="139" y="685" type="curve" smooth="yes"/>
+      <point x="200" y="292"/>
+      <point x="590" y="130"/>
+    </contour>
+    <contour>
+      <point x="914" y="325" type="line" smooth="yes"/>
+      <point x="656" y="317"/>
+      <point x="344" y="410"/>
+      <point x="302" y="705" type="curve" smooth="yes"/>
+      <point x="261" y="991"/>
+      <point x="552" y="1065"/>
+      <point x="780" y="1076" type="curve" smooth="yes"/>
+      <point x="876" y="1079" type="line" smooth="yes"/>
+      <point x="1139" y="1087"/>
+      <point x="1448" y="1002"/>
+      <point x="1491" y="701" type="curve" smooth="yes"/>
+      <point x="1531" y="419"/>
+      <point x="1233" y="339"/>
+      <point x="1010" y="328" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1567" y="795" type="line"/>
+      <point x="1805" y="1154" type="line"/>
+      <point x="1671" y="1270" type="line"/>
+      <point x="1430" y="906" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1354"/>
+  <unicode hex="2141"/>
+  <anchor x="603.676" y="-172" name="bottom"/>
+  <anchor x="-97.634" y="-172" name="bottom0315"/>
+  <anchor x="-91.932" y="-139" name="bottom_dd"/>
+  <anchor x="603.676" y="-172" name="parent_bottom"/>
+  <anchor x="831.124" y="1470" name="top"/>
+  <anchor x="254.842" y="1868" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="610" y="-15" type="curve" smooth="yes"/>
+      <point x="1017" y="-23"/>
+      <point x="1232" y="309"/>
+      <point x="1285" y="676" type="curve" smooth="yes"/>
+      <point x="1301" y="789" type="line" smooth="yes"/>
+      <point x="1345" y="1129"/>
+      <point x="1205" y="1475"/>
+      <point x="819" y="1481" type="curve" smooth="yes"/>
+      <point x="628" y="1484"/>
+      <point x="408" y="1433"/>
+      <point x="290" y="1269" type="curve"/>
+      <point x="204" y="736" type="line"/>
+      <point x="718" y="736" type="line"/>
+      <point x="746" y="892" type="line"/>
+      <point x="418" y="892" type="line"/>
+      <point x="477" y="1218" type="line"/>
+      <point x="570" y="1301"/>
+      <point x="690" y="1326"/>
+      <point x="812" y="1323" type="curve" smooth="yes"/>
+      <point x="1098" y="1317"/>
+      <point x="1142" y="1018"/>
+      <point x="1112" y="790" type="curve" smooth="yes"/>
+      <point x="1095" y="674" type="line" smooth="yes"/>
+      <point x="1055" y="413"/>
+      <point x="922" y="133"/>
+      <point x="618" y="143" type="curve" smooth="yes"/>
+      <point x="438" y="149"/>
+      <point x="348" y="259"/>
+      <point x="335" y="432" type="curve"/>
+      <point x="149" y="432" type="line"/>
+      <point x="169" y="160"/>
+      <point x="332" y="-9"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="1070"/>
+  <unicode hex="2142"/>
+  <anchor x="720.829" y="-140" name="bottom"/>
+  <anchor x="-93.001" y="-140" name="bottom0315"/>
+  <anchor x="-93.692" y="-144" name="bottom_dd"/>
+  <anchor x="720.829" y="-140" name="parent_bottom"/>
+  <anchor x="649.541" y="1446" name="top"/>
+  <anchor x="253.082" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="648" y="0" type="line"/>
+      <point x="837" y="0" type="line"/>
+      <point x="1090" y="1456" type="line"/>
+      <point x="901" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="204" y="1299" type="line"/>
+      <point x="912" y="1299" type="line"/>
+      <point x="939" y="1456" type="line"/>
+      <point x="232" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="1046"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="620" y="0" type="line"/>
+      <point x="813" y="0" type="line"/>
+      <point x="1057" y="1456" type="line"/>
+      <point x="864" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="-70" y="0" type="line"/>
+      <point x="658" y="0" type="line"/>
+      <point x="684" y="157" type="line"/>
+      <point x="-44" y="157" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1194"/>
+  <unicode hex="2144"/>
+  <anchor x="500.758" y="-144" name="bottom"/>
+  <anchor x="-92.882" y="-144" name="bottom0315"/>
+  <anchor x="-92.882" y="-144" name="bottom_dd"/>
+  <anchor x="500.758" y="-144" name="parent_bottom"/>
+  <anchor x="779.946" y="1455" name="top"/>
+  <anchor x="253.892" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="-58" y="0" type="line"/>
+      <point x="167" y="0" type="line"/>
+      <point x="661" y="730" type="line"/>
+      <point x="900" y="0" type="line"/>
+      <point x="1105" y="0" type="line"/>
+      <point x="779" y="901" type="line"/>
+      <point x="876" y="1456" type="line"/>
+      <point x="688" y="1456" type="line"/>
+      <point x="595" y="922" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni214A_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214A" format="2">
-  <advance width="1379"/>
+  <advance width="1383"/>
   <unicode hex="214A"/>
   <outline>
     <contour>
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Italic.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1379"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="96" y="300" type="line"/>
+      <point x="271" y="300" type="line"/>
+      <point x="445" y="1310" type="line"/>
+      <point x="860" y="1310" type="line" smooth="yes"/>
+      <point x="1043" y="1307"/>
+      <point x="1145" y="1186"/>
+      <point x="1113" y="1003" type="curve" smooth="yes"/>
+      <point x="1080" y="812"/>
+      <point x="923" y="711"/>
+      <point x="735" y="709" type="curve" smooth="yes"/>
+      <point x="651" y="709" type="line"/>
+      <point x="630" y="563" type="line"/>
+      <point x="730" y="563" type="line" smooth="yes"/>
+      <point x="1011" y="565"/>
+      <point x="1255" y="713"/>
+      <point x="1291" y="1005" type="curve" smooth="yes"/>
+      <point x="1327" y="1287"/>
+      <point x="1135" y="1454"/>
+      <point x="864" y="1456" type="curve" smooth="yes"/>
+      <point x="294" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="541" y="0" type="line"/>
+      <point x="1230" y="0" type="line"/>
+      <point x="1254" y="145" type="line"/>
+      <point x="565" y="145" type="line"/>
+    </contour>
+    <contour>
+      <point x="437" y="0" type="line"/>
+      <point x="613" y="0" type="line"/>
+      <point x="890" y="1600" type="line"/>
+      <point x="713" y="1600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni214B_.glif
@@ -4,66 +4,66 @@
   <unicode hex="214B"/>
   <outline>
     <contour>
-      <point x="629" y="-17" type="curve" smooth="yes"/>
-      <point x="849" y="-23"/>
-      <point x="1006" y="126"/>
-      <point x="1022" y="344" type="curve" smooth="yes"/>
-      <point x="1033" y="511"/>
-      <point x="919" y="652"/>
-      <point x="832" y="783" type="curve" smooth="yes"/>
-      <point x="390" y="1459" type="line"/>
-      <point x="187" y="1459" type="line"/>
-      <point x="726" y="633" type="line" smooth="yes"/>
-      <point x="783" y="547"/>
-      <point x="856" y="447"/>
-      <point x="843" y="338" type="curve" smooth="yes"/>
-      <point x="830" y="231"/>
-      <point x="755" y="132"/>
-      <point x="640" y="132" type="curve" smooth="yes"/>
-      <point x="554" y="133"/>
-      <point x="487" y="193"/>
-      <point x="496" y="281" type="curve" smooth="yes"/>
-      <point x="506" y="384"/>
-      <point x="578" y="443"/>
-      <point x="659" y="496" type="curve" smooth="yes"/>
-      <point x="895" y="651" type="line" smooth="yes"/>
-      <point x="1052" y="752"/>
-      <point x="1234" y="869"/>
-      <point x="1250" y="1075" type="curve" smooth="yes"/>
-      <point x="1268" y="1324"/>
-      <point x="1081" y="1474"/>
-      <point x="845" y="1479" type="curve" smooth="yes"/>
-      <point x="700" y="1482"/>
-      <point x="530" y="1430"/>
-      <point x="431" y="1319" type="curve" smooth="yes"/>
-      <point x="419" y="1306"/>
-      <point x="410" y="1290"/>
-      <point x="398" y="1276" type="curve" smooth="yes"/>
-      <point x="265" y="1130"/>
-      <point x="185" y="988"/>
-      <point x="163" y="787" type="curve"/>
-      <point x="323" y="787" type="line"/>
-      <point x="359" y="1041"/>
-      <point x="549" y="1335"/>
-      <point x="837" y="1328" type="curve" smooth="yes"/>
-      <point x="987" y="1324"/>
-      <point x="1087" y="1228"/>
-      <point x="1066" y="1075" type="curve" smooth="yes"/>
-      <point x="1051" y="965"/>
-      <point x="956" y="882"/>
-      <point x="871" y="823" type="curve" smooth="yes"/>
-      <point x="556" y="608" type="line" smooth="yes"/>
-      <point x="441" y="528"/>
-      <point x="335" y="431"/>
-      <point x="326" y="282" type="curve" smooth="yes"/>
-      <point x="316" y="103"/>
-      <point x="459" y="-13"/>
+      <point x="601" y="-17" type="curve" smooth="yes"/>
+      <point x="821" y="-23"/>
+      <point x="978" y="126"/>
+      <point x="994" y="344" type="curve" smooth="yes"/>
+      <point x="1005" y="511"/>
+      <point x="891" y="652"/>
+      <point x="804" y="783" type="curve" smooth="yes"/>
+      <point x="362" y="1459" type="line"/>
+      <point x="159" y="1459" type="line"/>
+      <point x="698" y="633" type="line" smooth="yes"/>
+      <point x="755" y="547"/>
+      <point x="828" y="447"/>
+      <point x="815" y="338" type="curve" smooth="yes"/>
+      <point x="802" y="231"/>
+      <point x="727" y="132"/>
+      <point x="612" y="132" type="curve" smooth="yes"/>
+      <point x="526" y="133"/>
+      <point x="459" y="193"/>
+      <point x="468" y="281" type="curve" smooth="yes"/>
+      <point x="478" y="384"/>
+      <point x="550" y="443"/>
+      <point x="631" y="496" type="curve" smooth="yes"/>
+      <point x="867" y="651" type="line" smooth="yes"/>
+      <point x="1024" y="752"/>
+      <point x="1206" y="869"/>
+      <point x="1222" y="1075" type="curve" smooth="yes"/>
+      <point x="1240" y="1324"/>
+      <point x="1053" y="1474"/>
+      <point x="817" y="1479" type="curve" smooth="yes"/>
+      <point x="672" y="1482"/>
+      <point x="502" y="1430"/>
+      <point x="403" y="1319" type="curve" smooth="yes"/>
+      <point x="391" y="1306"/>
+      <point x="382" y="1290"/>
+      <point x="370" y="1276" type="curve" smooth="yes"/>
+      <point x="237" y="1130"/>
+      <point x="157" y="988"/>
+      <point x="135" y="787" type="curve"/>
+      <point x="295" y="787" type="line"/>
+      <point x="331" y="1041"/>
+      <point x="521" y="1335"/>
+      <point x="809" y="1328" type="curve" smooth="yes"/>
+      <point x="959" y="1324"/>
+      <point x="1059" y="1228"/>
+      <point x="1038" y="1075" type="curve" smooth="yes"/>
+      <point x="1023" y="965"/>
+      <point x="928" y="882"/>
+      <point x="843" y="823" type="curve" smooth="yes"/>
+      <point x="528" y="608" type="line" smooth="yes"/>
+      <point x="413" y="528"/>
+      <point x="307" y="431"/>
+      <point x="298" y="282" type="curve" smooth="yes"/>
+      <point x="288" y="103"/>
+      <point x="431" y="-13"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Italic.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1236"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="629" y="-17" type="curve" smooth="yes"/>
+      <point x="849" y="-23"/>
+      <point x="1006" y="126"/>
+      <point x="1022" y="344" type="curve" smooth="yes"/>
+      <point x="1033" y="511"/>
+      <point x="919" y="652"/>
+      <point x="832" y="783" type="curve" smooth="yes"/>
+      <point x="390" y="1459" type="line"/>
+      <point x="187" y="1459" type="line"/>
+      <point x="726" y="633" type="line" smooth="yes"/>
+      <point x="783" y="547"/>
+      <point x="856" y="447"/>
+      <point x="843" y="338" type="curve" smooth="yes"/>
+      <point x="830" y="231"/>
+      <point x="755" y="132"/>
+      <point x="640" y="132" type="curve" smooth="yes"/>
+      <point x="554" y="133"/>
+      <point x="487" y="193"/>
+      <point x="496" y="281" type="curve" smooth="yes"/>
+      <point x="506" y="384"/>
+      <point x="578" y="443"/>
+      <point x="659" y="496" type="curve" smooth="yes"/>
+      <point x="895" y="651" type="line" smooth="yes"/>
+      <point x="1052" y="752"/>
+      <point x="1234" y="869"/>
+      <point x="1250" y="1075" type="curve" smooth="yes"/>
+      <point x="1268" y="1324"/>
+      <point x="1081" y="1474"/>
+      <point x="845" y="1479" type="curve" smooth="yes"/>
+      <point x="700" y="1482"/>
+      <point x="530" y="1430"/>
+      <point x="431" y="1319" type="curve" smooth="yes"/>
+      <point x="419" y="1306"/>
+      <point x="410" y="1290"/>
+      <point x="398" y="1276" type="curve" smooth="yes"/>
+      <point x="265" y="1130"/>
+      <point x="185" y="988"/>
+      <point x="163" y="787" type="curve"/>
+      <point x="323" y="787" type="line"/>
+      <point x="359" y="1041"/>
+      <point x="549" y="1335"/>
+      <point x="837" y="1328" type="curve" smooth="yes"/>
+      <point x="987" y="1324"/>
+      <point x="1087" y="1228"/>
+      <point x="1066" y="1075" type="curve" smooth="yes"/>
+      <point x="1051" y="965"/>
+      <point x="956" y="882"/>
+      <point x="871" y="823" type="curve" smooth="yes"/>
+      <point x="556" y="608" type="line" smooth="yes"/>
+      <point x="441" y="528"/>
+      <point x="335" y="431"/>
+      <point x="326" y="282" type="curve" smooth="yes"/>
+      <point x="316" y="103"/>
+      <point x="459" y="-13"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="619"/>
+  <advance width="1266"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="235" y="-10" type="curve" smooth="yes"/>
-      <point x="317" y="-10"/>
-      <point x="344" y="51"/>
-      <point x="344" y="117" type="curve" smooth="yes"/>
-      <point x="344" y="140"/>
-      <point x="336" y="204"/>
-      <point x="328" y="277" type="curve"/>
-      <point x="404" y="291"/>
-      <point x="470" y="326"/>
-      <point x="512" y="375" type="curve"/>
-      <point x="521" y="361"/>
-      <point x="526" y="345"/>
-      <point x="526" y="327" type="curve" smooth="yes"/>
-      <point x="526" y="281"/>
-      <point x="479" y="238"/>
-      <point x="461" y="224" type="curve"/>
-      <point x="495" y="224" type="line"/>
-      <point x="514" y="238"/>
-      <point x="556" y="281"/>
-      <point x="556" y="326" type="curve" smooth="yes"/>
-      <point x="556" y="354"/>
-      <point x="546" y="378"/>
-      <point x="529" y="397" type="curve"/>
-      <point x="550" y="427"/>
-      <point x="562" y="462"/>
-      <point x="562" y="500" type="curve" smooth="yes"/>
-      <point x="562" y="608"/>
-      <point x="491" y="725"/>
-      <point x="382" y="725" type="curve" smooth="yes"/>
-      <point x="299" y="725"/>
-      <point x="272" y="664"/>
-      <point x="272" y="569" type="curve" smooth="yes"/>
-      <point x="272" y="548"/>
-      <point x="273" y="515"/>
-      <point x="274" y="477" type="curve"/>
-      <point x="262" y="478"/>
-      <point x="251" y="478"/>
-      <point x="241" y="478" type="curve" smooth="yes"/>
-      <point x="230" y="478"/>
-      <point x="211" y="477"/>
-      <point x="190" y="475" type="curve"/>
-      <point x="192" y="613" type="line"/>
-      <point x="207" y="635"/>
-      <point x="221" y="658"/>
-      <point x="221" y="675" type="curve" smooth="yes"/>
-      <point x="221" y="681"/>
-      <point x="220" y="708"/>
-      <point x="193" y="708" type="curve" smooth="yes"/>
-      <point x="158" y="708"/>
-      <point x="170" y="669"/>
-      <point x="154" y="669" type="curve" smooth="yes"/>
-      <point x="134" y="669"/>
-      <point x="123" y="715"/>
-      <point x="75" y="715" type="curve" smooth="yes"/>
-      <point x="52" y="715"/>
-      <point x="11" y="702"/>
-      <point x="11" y="643" type="curve" smooth="yes"/>
-      <point x="11" y="603"/>
-      <point x="38" y="572"/>
-      <point x="82" y="572" type="curve" smooth="yes"/>
-      <point x="89" y="572"/>
-      <point x="96" y="573"/>
-      <point x="101" y="574" type="curve"/>
-      <point x="100" y="592" type="line"/>
-      <point x="96" y="591"/>
-      <point x="88" y="590"/>
-      <point x="82" y="590" type="curve" smooth="yes"/>
-      <point x="64" y="590"/>
-      <point x="58" y="606"/>
-      <point x="58" y="617" type="curve" smooth="yes"/>
-      <point x="58" y="630"/>
-      <point x="67" y="644"/>
-      <point x="86" y="644" type="curve" smooth="yes"/>
-      <point x="108" y="644"/>
-      <point x="155" y="625"/>
-      <point x="172" y="615" type="curve"/>
-      <point x="156" y="471" type="line"/>
-      <point x="94" y="460"/>
-      <point x="24" y="433"/>
-      <point x="24" y="369" type="curve" smooth="yes"/>
-      <point x="24" y="315"/>
-      <point x="77" y="290"/>
-      <point x="137" y="279" type="curve"/>
-      <point x="130" y="208"/>
-      <point x="126" y="144"/>
-      <point x="126" y="117" type="curve" smooth="yes"/>
-      <point x="126" y="51"/>
-      <point x="153" y="-10"/>
+      <point x="596" y="-20" type="curve" smooth="yes"/>
+      <point x="764" y="-20"/>
+      <point x="819" y="104"/>
+      <point x="819" y="240" type="curve" smooth="yes"/>
+      <point x="819" y="287"/>
+      <point x="803" y="418"/>
+      <point x="786" y="567" type="curve"/>
+      <point x="942" y="596"/>
+      <point x="1077" y="668"/>
+      <point x="1163" y="768" type="curve"/>
+      <point x="1181" y="739"/>
+      <point x="1192" y="707"/>
+      <point x="1192" y="670" type="curve" smooth="yes"/>
+      <point x="1192" y="575"/>
+      <point x="1095" y="487"/>
+      <point x="1059" y="459" type="curve"/>
+      <point x="1128" y="459" type="line"/>
+      <point x="1167" y="487"/>
+      <point x="1253" y="575"/>
+      <point x="1253" y="668" type="curve" smooth="yes"/>
+      <point x="1253" y="725"/>
+      <point x="1233" y="774"/>
+      <point x="1198" y="813" type="curve"/>
+      <point x="1241" y="874"/>
+      <point x="1265" y="946"/>
+      <point x="1265" y="1024" type="curve" smooth="yes"/>
+      <point x="1265" y="1245"/>
+      <point x="1120" y="1485"/>
+      <point x="897" y="1485" type="curve" smooth="yes"/>
+      <point x="727" y="1485"/>
+      <point x="671" y="1360"/>
+      <point x="671" y="1165" type="curve" smooth="yes"/>
+      <point x="671" y="1122"/>
+      <point x="674" y="1055"/>
+      <point x="676" y="977" type="curve"/>
+      <point x="651" y="979"/>
+      <point x="628" y="979"/>
+      <point x="608" y="979" type="curve" smooth="yes"/>
+      <point x="585" y="979"/>
+      <point x="547" y="977"/>
+      <point x="504" y="973" type="curve"/>
+      <point x="508" y="1255" type="line"/>
+      <point x="538" y="1300"/>
+      <point x="567" y="1348"/>
+      <point x="567" y="1382" type="curve" smooth="yes"/>
+      <point x="567" y="1395"/>
+      <point x="565" y="1450"/>
+      <point x="510" y="1450" type="curve" smooth="yes"/>
+      <point x="438" y="1450"/>
+      <point x="463" y="1370"/>
+      <point x="430" y="1370" type="curve" smooth="yes"/>
+      <point x="389" y="1370"/>
+      <point x="366" y="1464"/>
+      <point x="268" y="1464" type="curve" smooth="yes"/>
+      <point x="221" y="1464"/>
+      <point x="137" y="1438"/>
+      <point x="137" y="1317" type="curve" smooth="yes"/>
+      <point x="137" y="1235"/>
+      <point x="192" y="1171"/>
+      <point x="282" y="1171" type="curve" smooth="yes"/>
+      <point x="297" y="1171"/>
+      <point x="311" y="1174"/>
+      <point x="321" y="1176" type="curve"/>
+      <point x="319" y="1212" type="line"/>
+      <point x="311" y="1210"/>
+      <point x="295" y="1208"/>
+      <point x="282" y="1208" type="curve" smooth="yes"/>
+      <point x="246" y="1208"/>
+      <point x="233" y="1241"/>
+      <point x="233" y="1264" type="curve" smooth="yes"/>
+      <point x="233" y="1290"/>
+      <point x="252" y="1319"/>
+      <point x="291" y="1319" type="curve" smooth="yes"/>
+      <point x="336" y="1319"/>
+      <point x="432" y="1280"/>
+      <point x="467" y="1260" type="curve"/>
+      <point x="434" y="965" type="line"/>
+      <point x="307" y="942"/>
+      <point x="164" y="887"/>
+      <point x="164" y="756" type="curve" smooth="yes"/>
+      <point x="164" y="645"/>
+      <point x="272" y="594"/>
+      <point x="395" y="571" type="curve"/>
+      <point x="381" y="426"/>
+      <point x="372" y="295"/>
+      <point x="372" y="240" type="curve" smooth="yes"/>
+      <point x="372" y="104"/>
+      <point x="428" y="-20"/>
     </contour>
     <contour>
-      <point x="235" y="20" type="curve" smooth="yes"/>
-      <point x="198" y="20"/>
-      <point x="178" y="58"/>
-      <point x="178" y="115" type="curve" smooth="yes"/>
-      <point x="178" y="146"/>
-      <point x="180" y="206"/>
-      <point x="182" y="273" type="curve"/>
-      <point x="207" y="270"/>
-      <point x="231" y="270"/>
-      <point x="252" y="270" type="curve" smooth="yes"/>
-      <point x="262" y="270"/>
-      <point x="273" y="270"/>
-      <point x="284" y="271" type="curve"/>
-      <point x="287" y="195"/>
-      <point x="291" y="132"/>
-      <point x="291" y="115" type="curve" smooth="yes"/>
-      <point x="291" y="58"/>
-      <point x="271" y="20"/>
+      <point x="596" y="41" type="curve" smooth="yes"/>
+      <point x="520" y="41"/>
+      <point x="479" y="119"/>
+      <point x="479" y="236" type="curve" smooth="yes"/>
+      <point x="479" y="299"/>
+      <point x="483" y="422"/>
+      <point x="487" y="559" type="curve"/>
+      <point x="538" y="553"/>
+      <point x="588" y="553"/>
+      <point x="631" y="553" type="curve" smooth="yes"/>
+      <point x="651" y="553"/>
+      <point x="674" y="553"/>
+      <point x="696" y="555" type="curve"/>
+      <point x="702" y="399"/>
+      <point x="710" y="270"/>
+      <point x="710" y="236" type="curve" smooth="yes"/>
+      <point x="710" y="119"/>
+      <point x="669" y="41"/>
     </contour>
     <contour>
-      <point x="139" y="299" type="line"/>
-      <point x="59" y="318"/>
-      <point x="49" y="358"/>
-      <point x="49" y="372" type="curve" smooth="yes"/>
-      <point x="49" y="384"/>
-      <point x="55" y="434"/>
-      <point x="154" y="453" type="curve"/>
+      <point x="399" y="612" type="line"/>
+      <point x="235" y="651"/>
+      <point x="215" y="733"/>
+      <point x="215" y="762" type="curve" smooth="yes"/>
+      <point x="215" y="786"/>
+      <point x="227" y="889"/>
+      <point x="430" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="251" y="288" type="curve" smooth="yes"/>
-      <point x="224" y="288"/>
-      <point x="203" y="289"/>
-      <point x="183" y="291" type="curve"/>
-      <point x="189" y="458" type="line"/>
-      <point x="204" y="459"/>
-      <point x="221" y="460"/>
-      <point x="240" y="460" type="curve" smooth="yes"/>
-      <point x="252" y="460"/>
-      <point x="263" y="459"/>
-      <point x="275" y="459" type="curve"/>
-      <point x="283" y="289" type="line"/>
-      <point x="272" y="288"/>
-      <point x="262" y="288"/>
+      <point x="628" y="590" type="curve" smooth="yes"/>
+      <point x="573" y="590"/>
+      <point x="530" y="592"/>
+      <point x="489" y="596" type="curve"/>
+      <point x="502" y="938" type="line"/>
+      <point x="532" y="940"/>
+      <point x="567" y="942"/>
+      <point x="606" y="942" type="curve" smooth="yes"/>
+      <point x="631" y="942"/>
+      <point x="653" y="940"/>
+      <point x="678" y="940" type="curve"/>
+      <point x="694" y="592" type="line"/>
+      <point x="671" y="590"/>
+      <point x="651" y="590"/>
     </contour>
     <contour>
-      <point x="326" y="295" type="curve"/>
-      <point x="307" y="457" type="line"/>
-      <point x="367" y="452"/>
-      <point x="427" y="439"/>
-      <point x="469" y="414" type="curve"/>
-      <point x="446" y="351"/>
-      <point x="398" y="311"/>
+      <point x="782" y="604" type="curve"/>
+      <point x="743" y="936" type="line"/>
+      <point x="866" y="926"/>
+      <point x="989" y="899"/>
+      <point x="1075" y="848" type="curve"/>
+      <point x="1028" y="719"/>
+      <point x="930" y="637"/>
     </contour>
     <contour>
-      <point x="475" y="436" type="curve"/>
-      <point x="426" y="460"/>
-      <point x="360" y="471"/>
-      <point x="305" y="475" type="curve"/>
-      <point x="301" y="514"/>
-      <point x="299" y="548"/>
-      <point x="299" y="572" type="curve" smooth="yes"/>
-      <point x="299" y="636"/>
-      <point x="305" y="707"/>
-      <point x="379" y="707" type="curve" smooth="yes"/>
-      <point x="470" y="707"/>
-      <point x="486" y="593"/>
-      <point x="486" y="519" type="curve" smooth="yes"/>
-      <point x="486" y="488"/>
-      <point x="482" y="461"/>
+      <point x="1087" y="893" type="curve"/>
+      <point x="987" y="942"/>
+      <point x="852" y="965"/>
+      <point x="739" y="973" type="curve"/>
+      <point x="731" y="1053"/>
+      <point x="727" y="1122"/>
+      <point x="727" y="1171" type="curve" smooth="yes"/>
+      <point x="727" y="1303"/>
+      <point x="739" y="1448"/>
+      <point x="891" y="1448" type="curve" smooth="yes"/>
+      <point x="1077" y="1448"/>
+      <point x="1110" y="1214"/>
+      <point x="1110" y="1063" type="curve" smooth="yes"/>
+      <point x="1110" y="999"/>
+      <point x="1102" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Italic.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="619"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="235" y="-10" type="curve" smooth="yes"/>
+      <point x="317" y="-10"/>
+      <point x="344" y="51"/>
+      <point x="344" y="117" type="curve" smooth="yes"/>
+      <point x="344" y="140"/>
+      <point x="336" y="204"/>
+      <point x="328" y="277" type="curve"/>
+      <point x="404" y="291"/>
+      <point x="470" y="326"/>
+      <point x="512" y="375" type="curve"/>
+      <point x="521" y="361"/>
+      <point x="526" y="345"/>
+      <point x="526" y="327" type="curve" smooth="yes"/>
+      <point x="526" y="281"/>
+      <point x="479" y="238"/>
+      <point x="461" y="224" type="curve"/>
+      <point x="495" y="224" type="line"/>
+      <point x="514" y="238"/>
+      <point x="556" y="281"/>
+      <point x="556" y="326" type="curve" smooth="yes"/>
+      <point x="556" y="354"/>
+      <point x="546" y="378"/>
+      <point x="529" y="397" type="curve"/>
+      <point x="550" y="427"/>
+      <point x="562" y="462"/>
+      <point x="562" y="500" type="curve" smooth="yes"/>
+      <point x="562" y="608"/>
+      <point x="491" y="725"/>
+      <point x="382" y="725" type="curve" smooth="yes"/>
+      <point x="299" y="725"/>
+      <point x="272" y="664"/>
+      <point x="272" y="569" type="curve" smooth="yes"/>
+      <point x="272" y="548"/>
+      <point x="273" y="515"/>
+      <point x="274" y="477" type="curve"/>
+      <point x="262" y="478"/>
+      <point x="251" y="478"/>
+      <point x="241" y="478" type="curve" smooth="yes"/>
+      <point x="230" y="478"/>
+      <point x="211" y="477"/>
+      <point x="190" y="475" type="curve"/>
+      <point x="192" y="613" type="line"/>
+      <point x="207" y="635"/>
+      <point x="221" y="658"/>
+      <point x="221" y="675" type="curve" smooth="yes"/>
+      <point x="221" y="681"/>
+      <point x="220" y="708"/>
+      <point x="193" y="708" type="curve" smooth="yes"/>
+      <point x="158" y="708"/>
+      <point x="170" y="669"/>
+      <point x="154" y="669" type="curve" smooth="yes"/>
+      <point x="134" y="669"/>
+      <point x="123" y="715"/>
+      <point x="75" y="715" type="curve" smooth="yes"/>
+      <point x="52" y="715"/>
+      <point x="11" y="702"/>
+      <point x="11" y="643" type="curve" smooth="yes"/>
+      <point x="11" y="603"/>
+      <point x="38" y="572"/>
+      <point x="82" y="572" type="curve" smooth="yes"/>
+      <point x="89" y="572"/>
+      <point x="96" y="573"/>
+      <point x="101" y="574" type="curve"/>
+      <point x="100" y="592" type="line"/>
+      <point x="96" y="591"/>
+      <point x="88" y="590"/>
+      <point x="82" y="590" type="curve" smooth="yes"/>
+      <point x="64" y="590"/>
+      <point x="58" y="606"/>
+      <point x="58" y="617" type="curve" smooth="yes"/>
+      <point x="58" y="630"/>
+      <point x="67" y="644"/>
+      <point x="86" y="644" type="curve" smooth="yes"/>
+      <point x="108" y="644"/>
+      <point x="155" y="625"/>
+      <point x="172" y="615" type="curve"/>
+      <point x="156" y="471" type="line"/>
+      <point x="94" y="460"/>
+      <point x="24" y="433"/>
+      <point x="24" y="369" type="curve" smooth="yes"/>
+      <point x="24" y="315"/>
+      <point x="77" y="290"/>
+      <point x="137" y="279" type="curve"/>
+      <point x="130" y="208"/>
+      <point x="126" y="144"/>
+      <point x="126" y="117" type="curve" smooth="yes"/>
+      <point x="126" y="51"/>
+      <point x="153" y="-10"/>
+    </contour>
+    <contour>
+      <point x="235" y="20" type="curve" smooth="yes"/>
+      <point x="198" y="20"/>
+      <point x="178" y="58"/>
+      <point x="178" y="115" type="curve" smooth="yes"/>
+      <point x="178" y="146"/>
+      <point x="180" y="206"/>
+      <point x="182" y="273" type="curve"/>
+      <point x="207" y="270"/>
+      <point x="231" y="270"/>
+      <point x="252" y="270" type="curve" smooth="yes"/>
+      <point x="262" y="270"/>
+      <point x="273" y="270"/>
+      <point x="284" y="271" type="curve"/>
+      <point x="287" y="195"/>
+      <point x="291" y="132"/>
+      <point x="291" y="115" type="curve" smooth="yes"/>
+      <point x="291" y="58"/>
+      <point x="271" y="20"/>
+    </contour>
+    <contour>
+      <point x="139" y="299" type="line"/>
+      <point x="59" y="318"/>
+      <point x="49" y="358"/>
+      <point x="49" y="372" type="curve" smooth="yes"/>
+      <point x="49" y="384"/>
+      <point x="55" y="434"/>
+      <point x="154" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="251" y="288" type="curve" smooth="yes"/>
+      <point x="224" y="288"/>
+      <point x="203" y="289"/>
+      <point x="183" y="291" type="curve"/>
+      <point x="189" y="458" type="line"/>
+      <point x="204" y="459"/>
+      <point x="221" y="460"/>
+      <point x="240" y="460" type="curve" smooth="yes"/>
+      <point x="252" y="460"/>
+      <point x="263" y="459"/>
+      <point x="275" y="459" type="curve"/>
+      <point x="283" y="289" type="line"/>
+      <point x="272" y="288"/>
+      <point x="262" y="288"/>
+    </contour>
+    <contour>
+      <point x="326" y="295" type="curve"/>
+      <point x="307" y="457" type="line"/>
+      <point x="367" y="452"/>
+      <point x="427" y="439"/>
+      <point x="469" y="414" type="curve"/>
+      <point x="446" y="351"/>
+      <point x="398" y="311"/>
+    </contour>
+    <contour>
+      <point x="475" y="436" type="curve"/>
+      <point x="426" y="460"/>
+      <point x="360" y="471"/>
+      <point x="305" y="475" type="curve"/>
+      <point x="301" y="514"/>
+      <point x="299" y="548"/>
+      <point x="299" y="572" type="curve" smooth="yes"/>
+      <point x="299" y="636"/>
+      <point x="305" y="707"/>
+      <point x="379" y="707" type="curve" smooth="yes"/>
+      <point x="470" y="707"/>
+      <point x="486" y="593"/>
+      <point x="486" y="519" type="curve" smooth="yes"/>
+      <point x="486" y="488"/>
+      <point x="482" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:08 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Italic.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-Italic.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="984"/>
+  <unicode hex="214E"/>
+  <anchor x="361" y="10" name="bottom"/>
+  <anchor x="758" y="-407" name="bottom_dd"/>
+  <anchor x="638" y="1320" name="parent_top"/>
+  <anchor x="638" y="1320" name="top"/>
+  <anchor x="1056" y="1320" name="top0315"/>
+  <anchor x="1105" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="571" y="0" type="line"/>
+      <point x="751" y="0" type="line"/>
+      <point x="940" y="1082" type="line"/>
+      <point x="759" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="-11" y="0" type="line"/>
+      <point x="615" y="0" type="line"/>
+      <point x="642" y="153" type="line"/>
+      <point x="17" y="153" type="line"/>
+    </contour>
+    <contour>
+      <point x="155" y="513" type="line"/>
+      <point x="703" y="513" type="line"/>
+      <point x="730" y="665" type="line"/>
+      <point x="182" y="665" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:08 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Italic.ufo/lib.plist
+++ b/sources/Roboto-Italic.ufo/lib.plist
@@ -6898,6 +6898,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/Roboto-Regular.ufo/fontinfo.plist
+++ b/sources/Roboto-Regular.ufo/fontinfo.plist
@@ -373,7 +373,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-Regular.ufo/glyphs/contents.plist
+++ b/sources/Roboto-Regular.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/Roboto-Regular.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Regular.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="1107"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="169" y="0" type="line"/>
+      <point x="552" y="0" type="line" smooth="yes"/>
+      <point x="808" y="0"/>
+      <point x="991" y="150"/>
+      <point x="991" y="416" type="curve" smooth="yes"/>
+      <point x="991" y="643"/>
+      <point x="857" y="735"/>
+      <point x="688" y="766" type="curve"/>
+      <point x="688" y="776" type="line"/>
+      <point x="855" y="809"/>
+      <point x="946" y="922"/>
+      <point x="946" y="1106" type="curve" smooth="yes"/>
+      <point x="946" y="1360"/>
+      <point x="765" y="1456"/>
+      <point x="462" y="1456" type="curve" smooth="yes"/>
+      <point x="169" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="329" y="-201" type="line"/>
+      <point x="452" y="-201" type="line"/>
+      <point x="452" y="106" type="line"/>
+      <point x="329" y="106" type="line"/>
+    </contour>
+    <contour>
+      <point x="595" y="-201" type="line"/>
+      <point x="718" y="-201" type="line"/>
+      <point x="718" y="106" type="line"/>
+      <point x="595" y="106" type="line"/>
+    </contour>
+    <contour>
+      <point x="352" y="156" type="line"/>
+      <point x="352" y="686" type="line"/>
+      <point x="507" y="686" type="line" smooth="yes"/>
+      <point x="714" y="686"/>
+      <point x="798" y="584"/>
+      <point x="798" y="424" type="curve" smooth="yes"/>
+      <point x="798" y="264"/>
+      <point x="716" y="156"/>
+      <point x="520" y="156" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="352" y="840" type="line"/>
+      <point x="352" y="1299" type="line"/>
+      <point x="470" y="1299" type="line" smooth="yes"/>
+      <point x="657" y="1299"/>
+      <point x="757" y="1247"/>
+      <point x="757" y="1075" type="curve" smooth="yes"/>
+      <point x="757" y="926"/>
+      <point x="685" y="840"/>
+      <point x="497" y="840" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="329" y="1356" type="line"/>
+      <point x="452" y="1356" type="line"/>
+      <point x="452" y="1663" type="line"/>
+      <point x="329" y="1663" type="line"/>
+    </contour>
+    <contour>
+      <point x="595" y="1356" type="line"/>
+      <point x="718" y="1356" type="line"/>
+      <point x="718" y="1663" type="line"/>
+      <point x="595" y="1663" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="1172"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="414" y="0" type="line"/>
+      <point x="1121" y="0" type="line"/>
+      <point x="1121" y="123" type="line"/>
+      <point x="545" y="123" type="line"/>
+      <point x="545" y="367" type="line"/>
+      <point x="609" y="369"/>
+      <point x="681" y="385"/>
+      <point x="744" y="414" type="curve"/>
+      <point x="744" y="520" type="line"/>
+      <point x="679" y="494"/>
+      <point x="607" y="477"/>
+      <point x="545" y="475" type="curve"/>
+      <point x="545" y="1143" type="line"/>
+      <point x="613" y="1141"/>
+      <point x="672" y="1124"/>
+      <point x="730" y="1096" type="curve"/>
+      <point x="765" y="1200" type="line"/>
+      <point x="703" y="1231"/>
+      <point x="627" y="1247"/>
+      <point x="545" y="1249" type="curve"/>
+      <point x="545" y="1462" type="line"/>
+      <point x="414" y="1462" type="line"/>
+      <point x="414" y="1241" type="line"/>
+      <point x="232" y="1204"/>
+      <point x="119" y="1057"/>
+      <point x="119" y="811" type="curve" smooth="yes"/>
+      <point x="119" y="563"/>
+      <point x="226" y="414"/>
+      <point x="414" y="375" type="curve"/>
+    </contour>
+    <contour>
+      <point x="414" y="487" type="line"/>
+      <point x="296" y="524"/>
+      <point x="242" y="639"/>
+      <point x="242" y="815" type="curve" smooth="yes"/>
+      <point x="242" y="983"/>
+      <point x="296" y="1096"/>
+      <point x="414" y="1133" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="1089"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1381"/>
+  <unicode hex="2108"/>
+  <anchor x="692" y="1634" name="parent_top"/>
+  <anchor x="692" y="1634" name="top"/>
+  <anchor x="1381" y="1634" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="700" y="-20" type="curve" smooth="yes"/>
+      <point x="1042" y="-20"/>
+      <point x="1268" y="247"/>
+      <point x="1268" y="655" type="curve" smooth="yes"/>
+      <point x="1268" y="799" type="line" smooth="yes"/>
+      <point x="1268" y="1208"/>
+      <point x="1043" y="1476"/>
+      <point x="683" y="1476" type="curve" smooth="yes"/>
+      <point x="353" y="1476"/>
+      <point x="178" y="1276"/>
+      <point x="148" y="989" type="curve"/>
+      <point x="340" y="989" type="line"/>
+      <point x="369" y="1192"/>
+      <point x="458" y="1318"/>
+      <point x="683" y="1318" type="curve" smooth="yes"/>
+      <point x="941" y="1318"/>
+      <point x="1076" y="1111"/>
+      <point x="1076" y="801" type="curve" smooth="yes"/>
+      <point x="1076" y="655" type="line" smooth="yes"/>
+      <point x="1076" y="369"/>
+      <point x="959" y="137"/>
+      <point x="700" y="137" type="curve" smooth="yes"/>
+      <point x="454" y="137"/>
+      <point x="372" y="257"/>
+      <point x="340" y="463" type="curve"/>
+      <point x="148" y="463" type="line"/>
+      <point x="179" y="187"/>
+      <point x="350" y="-20"/>
+    </contour>
+    <contour>
+      <point x="503" y="647" type="line"/>
+      <point x="1100" y="647" type="line"/>
+      <point x="1100" y="805" type="line"/>
+      <point x="503" y="805" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2108.glif
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1659"/>
+  <unicode hex="2114"/>
+  <anchor x="1107" y="-10" name="bottom"/>
+  <anchor x="1659" y="-407" name="bottom_dd"/>
+  <anchor x="599" y="1540" name="marktop"/>
+  <anchor x="1143" y="1611" name="parent_top"/>
+  <anchor x="1143" y="1611" name="top"/>
+  <anchor x="1659" y="1611" name="top0315"/>
+  <anchor x="1659" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1145" y="-20" type="curve" smooth="yes"/>
+      <point x="1413" y="-20"/>
+      <point x="1566" y="213"/>
+      <point x="1566" y="529" type="curve" smooth="yes"/>
+      <point x="1566" y="550" type="line"/>
+      <point x="1566" y="880"/>
+      <point x="1415" y="1102"/>
+      <point x="1143" y="1102" type="curve" smooth="yes"/>
+      <point x="870" y="1102"/>
+      <point x="738" y="905"/>
+      <point x="706" y="586" type="curve"/>
+      <point x="706" y="494" type="line"/>
+      <point x="737" y="177"/>
+      <point x="870" y="-20"/>
+    </contour>
+    <contour>
+      <point x="192" y="0" type="line"/>
+      <point x="378" y="0" type="line"/>
+      <point x="378" y="1536" type="line"/>
+      <point x="192" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="649" y="0" type="line"/>
+      <point x="819" y="0" type="line"/>
+      <point x="835" y="210" type="line"/>
+      <point x="835" y="1536" type="line"/>
+      <point x="649" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="1099" y="137" type="curve" smooth="yes"/>
+      <point x="916" y="137"/>
+      <point x="828" y="277"/>
+      <point x="796" y="418" type="curve"/>
+      <point x="796" y="659" type="line"/>
+      <point x="826" y="806"/>
+      <point x="911" y="946"/>
+      <point x="1097" y="946" type="curve" smooth="yes"/>
+      <point x="1307" y="946"/>
+      <point x="1380" y="765"/>
+      <point x="1380" y="550" type="curve" smooth="yes"/>
+      <point x="1380" y="529" type="line"/>
+      <point x="1380" y="314"/>
+      <point x="1299" y="137"/>
+    </contour>
+    <contour>
+      <point x="1" y="1233" type="line"/>
+      <point x="1142" y="1233" type="line"/>
+      <point x="1142" y="1385" type="line"/>
+      <point x="1" y="1385" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="786"/>
+  <advance width="1610"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="205" y="-241" type="curve" smooth="yes"/>
-      <point x="272" y="-241"/>
-      <point x="318" y="-180"/>
-      <point x="318" y="-95" type="curve" smooth="yes"/>
-      <point x="318" y="8"/>
-      <point x="229" y="99"/>
-      <point x="174" y="200" type="curve"/>
-      <point x="220" y="272"/>
-      <point x="279" y="341"/>
-      <point x="338" y="394" type="curve" smooth="yes"/>
-      <point x="403" y="452"/>
-      <point x="472" y="492"/>
-      <point x="530" y="492" type="curve" smooth="yes"/>
-      <point x="629" y="492"/>
-      <point x="636" y="359"/>
-      <point x="636" y="322" type="curve" smooth="yes"/>
-      <point x="636" y="285"/>
-      <point x="624" y="30"/>
-      <point x="465" y="30" type="curve" smooth="yes"/>
-      <point x="415" y="30"/>
-      <point x="367" y="57"/>
-      <point x="367" y="112" type="curve" smooth="yes"/>
-      <point x="367" y="119"/>
-      <point x="368" y="126"/>
-      <point x="370" y="132" type="curve"/>
-      <point x="402" y="136"/>
-      <point x="434" y="151"/>
-      <point x="434" y="194" type="curve" smooth="yes"/>
-      <point x="434" y="225"/>
-      <point x="413" y="244"/>
-      <point x="383" y="244" type="curve" smooth="yes"/>
-      <point x="336" y="244"/>
-      <point x="308" y="206"/>
-      <point x="308" y="140" type="curve" smooth="yes"/>
-      <point x="308" y="51"/>
-      <point x="369" y="-10"/>
-      <point x="472" y="-10" type="curve" smooth="yes"/>
-      <point x="644" y="-10"/>
-      <point x="735" y="159"/>
-      <point x="735" y="306" type="curve" smooth="yes"/>
-      <point x="735" y="437"/>
-      <point x="676" y="549"/>
-      <point x="559" y="549" type="curve" smooth="yes"/>
-      <point x="510" y="549"/>
-      <point x="418" y="512"/>
-      <point x="315" y="419" type="curve" smooth="yes"/>
-      <point x="264" y="373"/>
-      <point x="205" y="310"/>
-      <point x="155" y="238" type="curve"/>
-      <point x="140" y="272"/>
-      <point x="131" y="307"/>
-      <point x="131" y="345" type="curve" smooth="yes"/>
-      <point x="131" y="474"/>
-      <point x="160" y="548"/>
-      <point x="238" y="625" type="curve"/>
-      <point x="223" y="647" type="line"/>
-      <point x="166" y="610"/>
-      <point x="46" y="496"/>
-      <point x="46" y="337" type="curve" smooth="yes"/>
-      <point x="46" y="267"/>
-      <point x="69" y="206"/>
-      <point x="100" y="149" type="curve"/>
-      <point x="66" y="85"/>
-      <point x="41" y="11"/>
-      <point x="41" y="-56" type="curve" smooth="yes"/>
-      <point x="41" y="-163"/>
-      <point x="112" y="-241"/>
+      <point x="420" y="-494" type="curve" smooth="yes"/>
+      <point x="557" y="-494"/>
+      <point x="651" y="-369"/>
+      <point x="651" y="-195" type="curve" smooth="yes"/>
+      <point x="651" y="16"/>
+      <point x="469" y="203"/>
+      <point x="356" y="410" type="curve"/>
+      <point x="451" y="557"/>
+      <point x="571" y="698"/>
+      <point x="692" y="807" type="curve" smooth="yes"/>
+      <point x="825" y="926"/>
+      <point x="967" y="1008"/>
+      <point x="1085" y="1008" type="curve" smooth="yes"/>
+      <point x="1288" y="1008"/>
+      <point x="1303" y="735"/>
+      <point x="1303" y="659" type="curve" smooth="yes"/>
+      <point x="1303" y="584"/>
+      <point x="1278" y="61"/>
+      <point x="952" y="61" type="curve" smooth="yes"/>
+      <point x="850" y="61"/>
+      <point x="752" y="117"/>
+      <point x="752" y="229" type="curve" smooth="yes"/>
+      <point x="752" y="244"/>
+      <point x="754" y="258"/>
+      <point x="758" y="270" type="curve"/>
+      <point x="823" y="279"/>
+      <point x="889" y="309"/>
+      <point x="889" y="397" type="curve" smooth="yes"/>
+      <point x="889" y="461"/>
+      <point x="846" y="500"/>
+      <point x="784" y="500" type="curve" smooth="yes"/>
+      <point x="688" y="500"/>
+      <point x="631" y="422"/>
+      <point x="631" y="287" type="curve" smooth="yes"/>
+      <point x="631" y="104"/>
+      <point x="756" y="-20"/>
+      <point x="967" y="-20" type="curve" smooth="yes"/>
+      <point x="1319" y="-20"/>
+      <point x="1505" y="326"/>
+      <point x="1505" y="627" type="curve" smooth="yes"/>
+      <point x="1505" y="895"/>
+      <point x="1384" y="1124"/>
+      <point x="1145" y="1124" type="curve" smooth="yes"/>
+      <point x="1044" y="1124"/>
+      <point x="856" y="1049"/>
+      <point x="645" y="858" type="curve" smooth="yes"/>
+      <point x="541" y="764"/>
+      <point x="420" y="635"/>
+      <point x="317" y="487" type="curve"/>
+      <point x="287" y="557"/>
+      <point x="268" y="629"/>
+      <point x="268" y="707" type="curve" smooth="yes"/>
+      <point x="268" y="971"/>
+      <point x="328" y="1122"/>
+      <point x="487" y="1280" type="curve"/>
+      <point x="457" y="1325" type="line"/>
+      <point x="340" y="1249"/>
+      <point x="94" y="1016"/>
+      <point x="94" y="690" type="curve" smooth="yes"/>
+      <point x="94" y="547"/>
+      <point x="141" y="422"/>
+      <point x="205" y="305" type="curve"/>
+      <point x="135" y="174"/>
+      <point x="84" y="23"/>
+      <point x="84" y="-115" type="curve" smooth="yes"/>
+      <point x="84" y="-334"/>
+      <point x="229" y="-494"/>
     </contour>
     <contour>
-      <point x="188" y="-199" type="curve" smooth="yes"/>
-      <point x="144" y="-199"/>
-      <point x="80" y="-145"/>
-      <point x="80" y="-51" type="curve" smooth="yes"/>
-      <point x="80" y="-4"/>
-      <point x="96" y="52"/>
-      <point x="123" y="110" type="curve"/>
-      <point x="174" y="24"/>
-      <point x="234" y="-52"/>
-      <point x="234" y="-134" type="curve" smooth="yes"/>
-      <point x="234" y="-176"/>
-      <point x="216" y="-199"/>
+      <point x="385" y="-408" type="curve" smooth="yes"/>
+      <point x="295" y="-408"/>
+      <point x="164" y="-297"/>
+      <point x="164" y="-104" type="curve" smooth="yes"/>
+      <point x="164" y="-8"/>
+      <point x="197" y="106"/>
+      <point x="252" y="225" type="curve"/>
+      <point x="356" y="49"/>
+      <point x="479" y="-106"/>
+      <point x="479" y="-274" type="curve" smooth="yes"/>
+      <point x="479" y="-360"/>
+      <point x="442" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="786"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="205" y="-241" type="curve" smooth="yes"/>
+      <point x="272" y="-241"/>
+      <point x="318" y="-180"/>
+      <point x="318" y="-95" type="curve" smooth="yes"/>
+      <point x="318" y="8"/>
+      <point x="229" y="99"/>
+      <point x="174" y="200" type="curve"/>
+      <point x="220" y="272"/>
+      <point x="279" y="341"/>
+      <point x="338" y="394" type="curve" smooth="yes"/>
+      <point x="403" y="452"/>
+      <point x="472" y="492"/>
+      <point x="530" y="492" type="curve" smooth="yes"/>
+      <point x="629" y="492"/>
+      <point x="636" y="359"/>
+      <point x="636" y="322" type="curve" smooth="yes"/>
+      <point x="636" y="285"/>
+      <point x="624" y="30"/>
+      <point x="465" y="30" type="curve" smooth="yes"/>
+      <point x="415" y="30"/>
+      <point x="367" y="57"/>
+      <point x="367" y="112" type="curve" smooth="yes"/>
+      <point x="367" y="119"/>
+      <point x="368" y="126"/>
+      <point x="370" y="132" type="curve"/>
+      <point x="402" y="136"/>
+      <point x="434" y="151"/>
+      <point x="434" y="194" type="curve" smooth="yes"/>
+      <point x="434" y="225"/>
+      <point x="413" y="244"/>
+      <point x="383" y="244" type="curve" smooth="yes"/>
+      <point x="336" y="244"/>
+      <point x="308" y="206"/>
+      <point x="308" y="140" type="curve" smooth="yes"/>
+      <point x="308" y="51"/>
+      <point x="369" y="-10"/>
+      <point x="472" y="-10" type="curve" smooth="yes"/>
+      <point x="644" y="-10"/>
+      <point x="735" y="159"/>
+      <point x="735" y="306" type="curve" smooth="yes"/>
+      <point x="735" y="437"/>
+      <point x="676" y="549"/>
+      <point x="559" y="549" type="curve" smooth="yes"/>
+      <point x="510" y="549"/>
+      <point x="418" y="512"/>
+      <point x="315" y="419" type="curve" smooth="yes"/>
+      <point x="264" y="373"/>
+      <point x="205" y="310"/>
+      <point x="155" y="238" type="curve"/>
+      <point x="140" y="272"/>
+      <point x="131" y="307"/>
+      <point x="131" y="345" type="curve" smooth="yes"/>
+      <point x="131" y="474"/>
+      <point x="160" y="548"/>
+      <point x="238" y="625" type="curve"/>
+      <point x="223" y="647" type="line"/>
+      <point x="166" y="610"/>
+      <point x="46" y="496"/>
+      <point x="46" y="337" type="curve" smooth="yes"/>
+      <point x="46" y="267"/>
+      <point x="69" y="206"/>
+      <point x="100" y="149" type="curve"/>
+      <point x="66" y="85"/>
+      <point x="41" y="11"/>
+      <point x="41" y="-56" type="curve" smooth="yes"/>
+      <point x="41" y="-163"/>
+      <point x="112" y="-241"/>
+    </contour>
+    <contour>
+      <point x="188" y="-199" type="curve" smooth="yes"/>
+      <point x="144" y="-199"/>
+      <point x="80" y="-145"/>
+      <point x="80" y="-51" type="curve" smooth="yes"/>
+      <point x="80" y="-4"/>
+      <point x="96" y="52"/>
+      <point x="123" y="110" type="curve"/>
+      <point x="174" y="24"/>
+      <point x="234" y="-52"/>
+      <point x="234" y="-134" type="curve" smooth="yes"/>
+      <point x="234" y="-176"/>
+      <point x="216" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1362"/>
+  <unicode hex="2127"/>
+  <anchor x="683" y="1446" name="top"/>
+  <outline>
+    <contour>
+      <point x="693" y="-20" type="curve" smooth="yes"/>
+      <point x="1023" y="-20"/>
+      <point x="1248" y="238"/>
+      <point x="1248" y="616" type="curve"/>
+      <point x="1248" y="730" type="line"/>
+      <point x="1248" y="1068"/>
+      <point x="1039" y="1399"/>
+      <point x="752" y="1434" type="curve"/>
+      <point x="752" y="1293" type="line"/>
+      <point x="931" y="1258"/>
+      <point x="1053" y="1072"/>
+      <point x="1053" y="730" type="curve"/>
+      <point x="1053" y="614" type="line"/>
+      <point x="1053" y="303"/>
+      <point x="914" y="137"/>
+      <point x="693" y="137" type="curve" smooth="yes"/>
+      <point x="469" y="137"/>
+      <point x="329" y="303"/>
+      <point x="329" y="614" type="curve"/>
+      <point x="329" y="730" type="line"/>
+      <point x="329" y="1070"/>
+      <point x="447" y="1257"/>
+      <point x="624" y="1293" type="curve"/>
+      <point x="624" y="1434" type="line"/>
+      <point x="341" y="1397"/>
+      <point x="134" y="1067"/>
+      <point x="134" y="730" type="curve"/>
+      <point x="134" y="616" type="line"/>
+      <point x="134" y="238"/>
+      <point x="361" y="-20"/>
+    </contour>
+    <contour>
+      <point x="141" y="1299" type="line"/>
+      <point x="624" y="1299" type="line"/>
+      <point x="624" y="1456" type="line"/>
+      <point x="141" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="752" y="1299" type="line"/>
+      <point x="1244" y="1299" type="line"/>
+      <point x="1244" y="1456" type="line"/>
+      <point x="752" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2127.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1362"/>
+  <advance width="1342"/>
   <unicode hex="2127"/>
-  <anchor x="683" y="1446" name="top"/>
+  <anchor x="663" y="1446" name="top"/>
   <outline>
     <contour>
-      <point x="693" y="-20" type="curve" smooth="yes"/>
-      <point x="1023" y="-20"/>
-      <point x="1248" y="238"/>
-      <point x="1248" y="616" type="curve"/>
-      <point x="1248" y="730" type="line"/>
-      <point x="1248" y="1068"/>
-      <point x="1039" y="1399"/>
-      <point x="752" y="1434" type="curve"/>
-      <point x="752" y="1293" type="line"/>
-      <point x="931" y="1258"/>
-      <point x="1053" y="1072"/>
-      <point x="1053" y="730" type="curve"/>
-      <point x="1053" y="614" type="line"/>
-      <point x="1053" y="303"/>
-      <point x="914" y="137"/>
-      <point x="693" y="137" type="curve" smooth="yes"/>
-      <point x="469" y="137"/>
-      <point x="329" y="303"/>
-      <point x="329" y="614" type="curve"/>
-      <point x="329" y="730" type="line"/>
-      <point x="329" y="1070"/>
-      <point x="447" y="1257"/>
-      <point x="624" y="1293" type="curve"/>
-      <point x="624" y="1434" type="line"/>
-      <point x="341" y="1397"/>
-      <point x="134" y="1067"/>
-      <point x="134" y="730" type="curve"/>
-      <point x="134" y="616" type="line"/>
-      <point x="134" y="238"/>
-      <point x="361" y="-20"/>
+      <point x="673" y="-20" type="curve" smooth="yes"/>
+      <point x="1003" y="-20"/>
+      <point x="1228" y="238"/>
+      <point x="1228" y="616" type="curve"/>
+      <point x="1228" y="730" type="line"/>
+      <point x="1228" y="1068"/>
+      <point x="1019" y="1399"/>
+      <point x="732" y="1434" type="curve"/>
+      <point x="732" y="1293" type="line"/>
+      <point x="911" y="1258"/>
+      <point x="1033" y="1072"/>
+      <point x="1033" y="730" type="curve"/>
+      <point x="1033" y="614" type="line"/>
+      <point x="1033" y="303"/>
+      <point x="894" y="137"/>
+      <point x="673" y="137" type="curve" smooth="yes"/>
+      <point x="449" y="137"/>
+      <point x="309" y="303"/>
+      <point x="309" y="614" type="curve"/>
+      <point x="309" y="730" type="line"/>
+      <point x="309" y="1070"/>
+      <point x="427" y="1257"/>
+      <point x="604" y="1293" type="curve"/>
+      <point x="604" y="1434" type="line"/>
+      <point x="321" y="1397"/>
+      <point x="114" y="1067"/>
+      <point x="114" y="730" type="curve"/>
+      <point x="114" y="616" type="line"/>
+      <point x="114" y="238"/>
+      <point x="341" y="-20"/>
     </contour>
     <contour>
-      <point x="141" y="1299" type="line"/>
-      <point x="624" y="1299" type="line"/>
-      <point x="624" y="1456" type="line"/>
-      <point x="141" y="1456" type="line"/>
+      <point x="121" y="1299" type="line"/>
+      <point x="604" y="1299" type="line"/>
+      <point x="604" y="1456" type="line"/>
+      <point x="121" y="1456" type="line"/>
     </contour>
     <contour>
-      <point x="752" y="1299" type="line"/>
-      <point x="1244" y="1299" type="line"/>
-      <point x="1244" y="1456" type="line"/>
-      <point x="752" y="1456" type="line"/>
+      <point x="732" y="1299" type="line"/>
+      <point x="1224" y="1299" type="line"/>
+      <point x="1224" y="1456" type="line"/>
+      <point x="732" y="1456" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2129.glif
@@ -14,8 +14,8 @@
       <point x="356" y="1082"/>
       <point x="219" y="1082" type="curve" smooth="yes"/>
       <point x="153" y="1082"/>
-      <point x="105" y="1070"/>
-      <point x="76" y="1061" type="curve"/>
+      <point x="106" y="1070"/>
+      <point x="77" y="1061" type="curve"/>
       <point x="77" y="911" type="line"/>
       <point x="94" y="915"/>
       <point x="133" y="923"/>
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="664"/>
+  <unicode hex="2129"/>
+  <anchor x="370" y="-200" name="bottom"/>
+  <anchor x="0" y="-200" name="bottom0315"/>
+  <anchor x="370" y="-200" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="283" y="-13" type="line"/>
+      <point x="469" y="-13" type="line"/>
+      <point x="469" y="792" type="line"/>
+      <point x="469" y="1009"/>
+      <point x="356" y="1082"/>
+      <point x="219" y="1082" type="curve" smooth="yes"/>
+      <point x="153" y="1082"/>
+      <point x="105" y="1070"/>
+      <point x="76" y="1061" type="curve"/>
+      <point x="77" y="911" type="line"/>
+      <point x="94" y="915"/>
+      <point x="133" y="923"/>
+      <point x="164" y="923" type="curve" smooth="yes"/>
+      <point x="226" y="923"/>
+      <point x="283" y="904"/>
+      <point x="283" y="793" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="498"/>
+  <unicode hex="2139"/>
+  <anchor x="249" y="10" name="bottom"/>
+  <anchor x="498" y="-407" name="bottom_dd"/>
+  <anchor x="251" y="1600" name="parent_top"/>
+  <anchor x="277" y="654" name="rhotichook"/>
+  <anchor x="251" y="1600" name="top"/>
+  <anchor x="498" y="1600" name="top0315"/>
+  <anchor x="498" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2139.glif
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1814"/>
+  <unicode hex="213A"/>
+  <anchor x="1578" y="667" name="bottom"/>
+  <anchor x="1975" y="1378" name="bottom_dd"/>
+  <anchor x="-32" y="669" name="parent_top"/>
+  <anchor x="-32" y="669" name="top"/>
+  <anchor x="-32" y="1378" name="top0315"/>
+  <anchor x="-32" y="1378" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="794" y="79" type="curve"/>
+      <point x="886" y="79" type="line"/>
+      <point x="1323" y="79"/>
+      <point x="1588" y="321"/>
+      <point x="1588" y="666" type="curve" smooth="yes"/>
+      <point x="1588" y="1021"/>
+      <point x="1323" y="1250"/>
+      <point x="886" y="1250" type="curve"/>
+      <point x="794" y="1250" type="line"/>
+      <point x="358" y="1250"/>
+      <point x="92" y="1019"/>
+      <point x="92" y="664" type="curve" smooth="yes"/>
+      <point x="92" y="319"/>
+      <point x="358" y="79"/>
+    </contour>
+    <contour>
+      <point x="792" y="270" type="line" smooth="yes"/>
+      <point x="446" y="270"/>
+      <point x="256" y="426"/>
+      <point x="256" y="664" type="curve" smooth="yes"/>
+      <point x="256" y="914"/>
+      <point x="446" y="1059"/>
+      <point x="792" y="1059" type="curve"/>
+      <point x="886" y="1059" type="line"/>
+      <point x="1235" y="1059"/>
+      <point x="1425" y="917"/>
+      <point x="1425" y="666" type="curve" smooth="yes"/>
+      <point x="1425" y="428"/>
+      <point x="1235" y="270"/>
+      <point x="886" y="270" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1525" y="761" type="line"/>
+      <point x="1814" y="1125" type="line"/>
+      <point x="1694" y="1255" type="line"/>
+      <point x="1401" y="885" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni213A_.glif
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1395"/>
+  <unicode hex="2141"/>
+  <anchor x="723" y="-177" name="bottom"/>
+  <anchor x="0" y="-177" name="bottom0315"/>
+  <anchor x="0" y="-144" name="bottom_dd"/>
+  <anchor x="723" y="-177" name="parent_bottom"/>
+  <anchor x="665" y="1465" name="top"/>
+  <anchor x="0" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="687" y="-20" type="curve" smooth="yes"/>
+      <point x="1063" y="-20"/>
+      <point x="1273" y="237"/>
+      <point x="1273" y="671" type="curve" smooth="yes"/>
+      <point x="1273" y="784" type="line" smooth="yes"/>
+      <point x="1273" y="1220"/>
+      <point x="1020" y="1476"/>
+      <point x="665" y="1476" type="curve" smooth="yes"/>
+      <point x="339" y="1476"/>
+      <point x="205" y="1344"/>
+      <point x="150" y="1264" type="curve"/>
+      <point x="150" y="731" type="line"/>
+      <point x="679" y="731" type="line"/>
+      <point x="679" y="887" type="line"/>
+      <point x="342" y="887" type="line"/>
+      <point x="342" y="1213" type="line"/>
+      <point x="380" y="1257"/>
+      <point x="458" y="1319"/>
+      <point x="664" y="1319" type="curve" smooth="yes"/>
+      <point x="913" y="1319"/>
+      <point x="1079" y="1120"/>
+      <point x="1079" y="784" type="curve" smooth="yes"/>
+      <point x="1079" y="669" type="line" smooth="yes"/>
+      <point x="1079" y="342"/>
+      <point x="957" y="138"/>
+      <point x="687" y="138" type="curve" smooth="yes"/>
+      <point x="464" y="138"/>
+      <point x="370" y="269"/>
+      <point x="343" y="426" type="curve"/>
+      <point x="150" y="426" type="line"/>
+      <point x="187" y="168"/>
+      <point x="354" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="1103"/>
+  <unicode hex="2142"/>
+  <anchor x="839" y="-140" name="bottom"/>
+  <anchor x="0" y="-140" name="bottom0315"/>
+  <anchor x="0" y="-144" name="bottom_dd"/>
+  <anchor x="839" y="-140" name="parent_bottom"/>
+  <anchor x="483" y="1446" name="top"/>
+  <anchor x="0" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="741" y="0" type="line"/>
+      <point x="934" y="0" type="line"/>
+      <point x="934" y="1456" type="line"/>
+      <point x="741" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="51" y="1299" type="line"/>
+      <point x="779" y="1299" type="line"/>
+      <point x="779" y="1456" type="line"/>
+      <point x="51" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="1103"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="741" y="0" type="line"/>
+      <point x="934" y="0" type="line"/>
+      <point x="934" y="1456" type="line"/>
+      <point x="741" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="51" y="0" type="line"/>
+      <point x="779" y="0" type="line"/>
+      <point x="779" y="157" type="line"/>
+      <point x="51" y="157" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1230"/>
+  <unicode hex="2144"/>
+  <anchor x="612" y="-144" name="bottom"/>
+  <anchor x="0" y="-144" name="bottom0315"/>
+  <anchor x="0" y="-144" name="bottom_dd"/>
+  <anchor x="612" y="-144" name="parent_bottom"/>
+  <anchor x="615" y="1455" name="top"/>
+  <anchor x="0" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="18" y="0" type="line"/>
+      <point x="237" y="0" type="line"/>
+      <point x="616" y="731" type="line"/>
+      <point x="994" y="0" type="line"/>
+      <point x="1215" y="0" type="line"/>
+      <point x="713" y="912" type="line"/>
+      <point x="713" y="1456" type="line"/>
+      <point x="520" y="1456" type="line"/>
+      <point x="520" y="912" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1366"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="155" y="300" type="line"/>
+      <point x="334" y="300" type="line"/>
+      <point x="334" y="1310" type="line"/>
+      <point x="748" y="1310" type="line"/>
+      <point x="979" y="1310"/>
+      <point x="1076" y="1169"/>
+      <point x="1076" y="1000" type="curve"/>
+      <point x="1076" y="838"/>
+      <point x="979" y="710"/>
+      <point x="748" y="710" type="curve"/>
+      <point x="641" y="710" type="line"/>
+      <point x="641" y="564" type="line"/>
+      <point x="748" y="564" type="line"/>
+      <point x="1075" y="564"/>
+      <point x="1257" y="734"/>
+      <point x="1257" y="1002" type="curve"/>
+      <point x="1257" y="1270"/>
+      <point x="1075" y="1456"/>
+      <point x="748" y="1456" type="curve"/>
+      <point x="155" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="703" y="0" type="line"/>
+      <point x="1319" y="0" type="line"/>
+      <point x="1319" y="145" type="line"/>
+      <point x="703" y="145" type="line"/>
+    </contour>
+    <contour>
+      <point x="553" y="0" type="line"/>
+      <point x="733" y="0" type="line"/>
+      <point x="733" y="1594" type="line"/>
+      <point x="553" y="1594" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni214A_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214A" format="2">
-  <advance width="1366"/>
+  <advance width="1370"/>
   <unicode hex="214A"/>
   <outline>
     <contour>
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Regular.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1274"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="689" y="-20" type="curve" smooth="yes"/>
+      <point x="909" y="-20"/>
+      <point x="1054" y="106"/>
+      <point x="1054" y="333" type="curve" smooth="yes"/>
+      <point x="1054" y="482"/>
+      <point x="945" y="604"/>
+      <point x="794" y="780" type="curve" smooth="yes"/>
+      <point x="229" y="1456" type="line"/>
+      <point x="7" y="1456" type="line"/>
+      <point x="696" y="630" type="line" smooth="yes"/>
+      <point x="797" y="515"/>
+      <point x="868" y="418"/>
+      <point x="868" y="327" type="curve" smooth="yes"/>
+      <point x="868" y="222"/>
+      <point x="807" y="131"/>
+      <point x="690" y="131" type="curve" smooth="yes"/>
+      <point x="578" y="131"/>
+      <point x="514" y="208"/>
+      <point x="514" y="287" type="curve"/>
+      <point x="514" y="388"/>
+      <point x="562" y="436"/>
+      <point x="646" y="493" type="curve"/>
+      <point x="864" y="648" type="line"/>
+      <point x="1044" y="773"/>
+      <point x="1172" y="881"/>
+      <point x="1172" y="1064" type="curve"/>
+      <point x="1172" y="1304"/>
+      <point x="992" y="1476"/>
+      <point x="702" y="1476" type="curve"/>
+      <point x="556" y="1476"/>
+      <point x="398" y="1422"/>
+      <point x="298" y="1314" type="curve" smooth="yes"/>
+      <point x="286" y="1302"/>
+      <point x="282" y="1284"/>
+      <point x="270" y="1272" type="curve" smooth="yes"/>
+      <point x="148" y="1149"/>
+      <point x="92" y="982"/>
+      <point x="92" y="784" type="curve"/>
+      <point x="258" y="784" type="line"/>
+      <point x="258" y="1107"/>
+      <point x="478" y="1324"/>
+      <point x="702" y="1324" type="curve" smooth="yes"/>
+      <point x="895" y="1324"/>
+      <point x="987" y="1206"/>
+      <point x="987" y="1064" type="curve"/>
+      <point x="987" y="1021"/>
+      <point x="974" y="925"/>
+      <point x="830" y="819" type="curve" smooth="yes"/>
+      <point x="541" y="604" type="line" smooth="yes"/>
+      <point x="424" y="517"/>
+      <point x="343" y="428"/>
+      <point x="343" y="287" type="curve"/>
+      <point x="343" y="122"/>
+      <point x="475" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni214B_.glif
@@ -63,7 +63,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Regular.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="615"/>
+  <advance width="1260"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="265" y="-10" type="curve" smooth="yes"/>
-      <point x="347" y="-10"/>
-      <point x="374" y="51"/>
-      <point x="374" y="117" type="curve" smooth="yes"/>
-      <point x="374" y="140"/>
-      <point x="366" y="204"/>
-      <point x="358" y="277" type="curve"/>
-      <point x="434" y="291"/>
-      <point x="500" y="326"/>
-      <point x="542" y="375" type="curve"/>
-      <point x="551" y="361"/>
-      <point x="556" y="345"/>
-      <point x="556" y="327" type="curve" smooth="yes"/>
-      <point x="556" y="281"/>
-      <point x="509" y="238"/>
-      <point x="491" y="224" type="curve"/>
-      <point x="525" y="224" type="line"/>
-      <point x="544" y="238"/>
-      <point x="586" y="281"/>
-      <point x="586" y="326" type="curve" smooth="yes"/>
-      <point x="586" y="354"/>
-      <point x="576" y="378"/>
-      <point x="559" y="397" type="curve"/>
-      <point x="580" y="427"/>
-      <point x="592" y="462"/>
-      <point x="592" y="500" type="curve" smooth="yes"/>
-      <point x="592" y="608"/>
-      <point x="521" y="725"/>
-      <point x="412" y="725" type="curve" smooth="yes"/>
-      <point x="329" y="725"/>
-      <point x="302" y="664"/>
-      <point x="302" y="569" type="curve" smooth="yes"/>
-      <point x="302" y="548"/>
-      <point x="303" y="515"/>
-      <point x="304" y="477" type="curve"/>
-      <point x="292" y="478"/>
-      <point x="281" y="478"/>
-      <point x="271" y="478" type="curve" smooth="yes"/>
-      <point x="260" y="478"/>
-      <point x="241" y="477"/>
-      <point x="220" y="475" type="curve"/>
-      <point x="222" y="613" type="line"/>
-      <point x="237" y="635"/>
-      <point x="251" y="658"/>
-      <point x="251" y="675" type="curve" smooth="yes"/>
-      <point x="251" y="681"/>
-      <point x="250" y="708"/>
-      <point x="223" y="708" type="curve" smooth="yes"/>
-      <point x="188" y="708"/>
-      <point x="200" y="669"/>
-      <point x="184" y="669" type="curve" smooth="yes"/>
-      <point x="164" y="669"/>
-      <point x="153" y="715"/>
-      <point x="105" y="715" type="curve" smooth="yes"/>
-      <point x="82" y="715"/>
-      <point x="41" y="702"/>
-      <point x="41" y="643" type="curve" smooth="yes"/>
-      <point x="41" y="603"/>
-      <point x="68" y="572"/>
-      <point x="112" y="572" type="curve" smooth="yes"/>
-      <point x="119" y="572"/>
-      <point x="126" y="573"/>
-      <point x="131" y="574" type="curve"/>
-      <point x="130" y="592" type="line"/>
-      <point x="126" y="591"/>
-      <point x="118" y="590"/>
-      <point x="112" y="590" type="curve" smooth="yes"/>
-      <point x="94" y="590"/>
-      <point x="88" y="606"/>
-      <point x="88" y="617" type="curve" smooth="yes"/>
-      <point x="88" y="630"/>
-      <point x="97" y="644"/>
-      <point x="116" y="644" type="curve" smooth="yes"/>
-      <point x="138" y="644"/>
-      <point x="185" y="625"/>
-      <point x="202" y="615" type="curve"/>
-      <point x="186" y="471" type="line"/>
-      <point x="124" y="460"/>
-      <point x="54" y="433"/>
-      <point x="54" y="369" type="curve" smooth="yes"/>
-      <point x="54" y="315"/>
-      <point x="107" y="290"/>
-      <point x="167" y="279" type="curve"/>
-      <point x="160" y="208"/>
-      <point x="156" y="144"/>
-      <point x="156" y="117" type="curve" smooth="yes"/>
-      <point x="156" y="51"/>
-      <point x="183" y="-10"/>
+      <point x="543" y="-20" type="curve" smooth="yes"/>
+      <point x="711" y="-20"/>
+      <point x="766" y="104"/>
+      <point x="766" y="240" type="curve" smooth="yes"/>
+      <point x="766" y="287"/>
+      <point x="750" y="418"/>
+      <point x="733" y="567" type="curve"/>
+      <point x="889" y="596"/>
+      <point x="1024" y="668"/>
+      <point x="1110" y="768" type="curve"/>
+      <point x="1128" y="739"/>
+      <point x="1139" y="707"/>
+      <point x="1139" y="670" type="curve" smooth="yes"/>
+      <point x="1139" y="575"/>
+      <point x="1042" y="487"/>
+      <point x="1006" y="459" type="curve"/>
+      <point x="1075" y="459" type="line"/>
+      <point x="1114" y="487"/>
+      <point x="1200" y="575"/>
+      <point x="1200" y="668" type="curve" smooth="yes"/>
+      <point x="1200" y="725"/>
+      <point x="1180" y="774"/>
+      <point x="1145" y="813" type="curve"/>
+      <point x="1188" y="874"/>
+      <point x="1212" y="946"/>
+      <point x="1212" y="1024" type="curve" smooth="yes"/>
+      <point x="1212" y="1245"/>
+      <point x="1067" y="1485"/>
+      <point x="844" y="1485" type="curve" smooth="yes"/>
+      <point x="674" y="1485"/>
+      <point x="618" y="1360"/>
+      <point x="618" y="1165" type="curve" smooth="yes"/>
+      <point x="618" y="1122"/>
+      <point x="621" y="1055"/>
+      <point x="623" y="977" type="curve"/>
+      <point x="598" y="979"/>
+      <point x="575" y="979"/>
+      <point x="555" y="979" type="curve" smooth="yes"/>
+      <point x="532" y="979"/>
+      <point x="494" y="977"/>
+      <point x="451" y="973" type="curve"/>
+      <point x="455" y="1255" type="line"/>
+      <point x="485" y="1300"/>
+      <point x="514" y="1348"/>
+      <point x="514" y="1382" type="curve" smooth="yes"/>
+      <point x="514" y="1395"/>
+      <point x="512" y="1450"/>
+      <point x="457" y="1450" type="curve" smooth="yes"/>
+      <point x="385" y="1450"/>
+      <point x="410" y="1370"/>
+      <point x="377" y="1370" type="curve" smooth="yes"/>
+      <point x="336" y="1370"/>
+      <point x="313" y="1464"/>
+      <point x="215" y="1464" type="curve" smooth="yes"/>
+      <point x="168" y="1464"/>
+      <point x="84" y="1438"/>
+      <point x="84" y="1317" type="curve" smooth="yes"/>
+      <point x="84" y="1235"/>
+      <point x="139" y="1171"/>
+      <point x="229" y="1171" type="curve" smooth="yes"/>
+      <point x="244" y="1171"/>
+      <point x="258" y="1174"/>
+      <point x="268" y="1176" type="curve"/>
+      <point x="266" y="1212" type="line"/>
+      <point x="258" y="1210"/>
+      <point x="242" y="1208"/>
+      <point x="229" y="1208" type="curve" smooth="yes"/>
+      <point x="193" y="1208"/>
+      <point x="180" y="1241"/>
+      <point x="180" y="1264" type="curve" smooth="yes"/>
+      <point x="180" y="1290"/>
+      <point x="199" y="1319"/>
+      <point x="238" y="1319" type="curve" smooth="yes"/>
+      <point x="283" y="1319"/>
+      <point x="379" y="1280"/>
+      <point x="414" y="1260" type="curve"/>
+      <point x="381" y="965" type="line"/>
+      <point x="254" y="942"/>
+      <point x="111" y="887"/>
+      <point x="111" y="756" type="curve" smooth="yes"/>
+      <point x="111" y="645"/>
+      <point x="219" y="594"/>
+      <point x="342" y="571" type="curve"/>
+      <point x="328" y="426"/>
+      <point x="319" y="295"/>
+      <point x="319" y="240" type="curve" smooth="yes"/>
+      <point x="319" y="104"/>
+      <point x="375" y="-20"/>
     </contour>
     <contour>
-      <point x="265" y="20" type="curve" smooth="yes"/>
-      <point x="228" y="20"/>
-      <point x="208" y="58"/>
-      <point x="208" y="115" type="curve" smooth="yes"/>
-      <point x="208" y="146"/>
-      <point x="210" y="206"/>
-      <point x="212" y="273" type="curve"/>
-      <point x="237" y="270"/>
-      <point x="261" y="270"/>
-      <point x="282" y="270" type="curve" smooth="yes"/>
-      <point x="292" y="270"/>
-      <point x="303" y="270"/>
-      <point x="314" y="271" type="curve"/>
-      <point x="317" y="195"/>
-      <point x="321" y="132"/>
-      <point x="321" y="115" type="curve" smooth="yes"/>
-      <point x="321" y="58"/>
-      <point x="301" y="20"/>
+      <point x="543" y="41" type="curve" smooth="yes"/>
+      <point x="467" y="41"/>
+      <point x="426" y="119"/>
+      <point x="426" y="236" type="curve" smooth="yes"/>
+      <point x="426" y="299"/>
+      <point x="430" y="422"/>
+      <point x="434" y="559" type="curve"/>
+      <point x="485" y="553"/>
+      <point x="535" y="553"/>
+      <point x="578" y="553" type="curve" smooth="yes"/>
+      <point x="598" y="553"/>
+      <point x="621" y="553"/>
+      <point x="643" y="555" type="curve"/>
+      <point x="649" y="399"/>
+      <point x="657" y="270"/>
+      <point x="657" y="236" type="curve" smooth="yes"/>
+      <point x="657" y="119"/>
+      <point x="616" y="41"/>
     </contour>
     <contour>
-      <point x="169" y="299" type="line"/>
-      <point x="89" y="318"/>
-      <point x="79" y="358"/>
-      <point x="79" y="372" type="curve" smooth="yes"/>
-      <point x="79" y="384"/>
-      <point x="85" y="434"/>
-      <point x="184" y="453" type="curve"/>
+      <point x="346" y="612" type="line"/>
+      <point x="182" y="651"/>
+      <point x="162" y="733"/>
+      <point x="162" y="762" type="curve" smooth="yes"/>
+      <point x="162" y="786"/>
+      <point x="174" y="889"/>
+      <point x="377" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="281" y="288" type="curve" smooth="yes"/>
-      <point x="254" y="288"/>
-      <point x="233" y="289"/>
-      <point x="213" y="291" type="curve"/>
-      <point x="219" y="458" type="line"/>
-      <point x="234" y="459"/>
-      <point x="251" y="460"/>
-      <point x="270" y="460" type="curve" smooth="yes"/>
-      <point x="282" y="460"/>
-      <point x="293" y="459"/>
-      <point x="305" y="459" type="curve"/>
-      <point x="313" y="289" type="line"/>
-      <point x="302" y="288"/>
-      <point x="292" y="288"/>
+      <point x="575" y="590" type="curve" smooth="yes"/>
+      <point x="520" y="590"/>
+      <point x="477" y="592"/>
+      <point x="436" y="596" type="curve"/>
+      <point x="449" y="938" type="line"/>
+      <point x="479" y="940"/>
+      <point x="514" y="942"/>
+      <point x="553" y="942" type="curve" smooth="yes"/>
+      <point x="578" y="942"/>
+      <point x="600" y="940"/>
+      <point x="625" y="940" type="curve"/>
+      <point x="641" y="592" type="line"/>
+      <point x="618" y="590"/>
+      <point x="598" y="590"/>
     </contour>
     <contour>
-      <point x="356" y="295" type="curve"/>
-      <point x="337" y="457" type="line"/>
-      <point x="397" y="452"/>
-      <point x="457" y="439"/>
-      <point x="499" y="414" type="curve"/>
-      <point x="476" y="351"/>
-      <point x="428" y="311"/>
+      <point x="729" y="604" type="curve"/>
+      <point x="690" y="936" type="line"/>
+      <point x="813" y="926"/>
+      <point x="936" y="899"/>
+      <point x="1022" y="848" type="curve"/>
+      <point x="975" y="719"/>
+      <point x="877" y="637"/>
     </contour>
     <contour>
-      <point x="505" y="436" type="curve"/>
-      <point x="456" y="460"/>
-      <point x="390" y="471"/>
-      <point x="335" y="475" type="curve"/>
-      <point x="331" y="514"/>
-      <point x="329" y="548"/>
-      <point x="329" y="572" type="curve" smooth="yes"/>
-      <point x="329" y="636"/>
-      <point x="335" y="707"/>
-      <point x="409" y="707" type="curve" smooth="yes"/>
-      <point x="500" y="707"/>
-      <point x="516" y="593"/>
-      <point x="516" y="519" type="curve" smooth="yes"/>
-      <point x="516" y="488"/>
-      <point x="512" y="461"/>
+      <point x="1034" y="893" type="curve"/>
+      <point x="934" y="942"/>
+      <point x="799" y="965"/>
+      <point x="686" y="973" type="curve"/>
+      <point x="678" y="1053"/>
+      <point x="674" y="1122"/>
+      <point x="674" y="1171" type="curve" smooth="yes"/>
+      <point x="674" y="1303"/>
+      <point x="686" y="1448"/>
+      <point x="838" y="1448" type="curve" smooth="yes"/>
+      <point x="1024" y="1448"/>
+      <point x="1057" y="1214"/>
+      <point x="1057" y="1063" type="curve" smooth="yes"/>
+      <point x="1057" y="999"/>
+      <point x="1049" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Regular.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="615"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="265" y="-10" type="curve" smooth="yes"/>
+      <point x="347" y="-10"/>
+      <point x="374" y="51"/>
+      <point x="374" y="117" type="curve" smooth="yes"/>
+      <point x="374" y="140"/>
+      <point x="366" y="204"/>
+      <point x="358" y="277" type="curve"/>
+      <point x="434" y="291"/>
+      <point x="500" y="326"/>
+      <point x="542" y="375" type="curve"/>
+      <point x="551" y="361"/>
+      <point x="556" y="345"/>
+      <point x="556" y="327" type="curve" smooth="yes"/>
+      <point x="556" y="281"/>
+      <point x="509" y="238"/>
+      <point x="491" y="224" type="curve"/>
+      <point x="525" y="224" type="line"/>
+      <point x="544" y="238"/>
+      <point x="586" y="281"/>
+      <point x="586" y="326" type="curve" smooth="yes"/>
+      <point x="586" y="354"/>
+      <point x="576" y="378"/>
+      <point x="559" y="397" type="curve"/>
+      <point x="580" y="427"/>
+      <point x="592" y="462"/>
+      <point x="592" y="500" type="curve" smooth="yes"/>
+      <point x="592" y="608"/>
+      <point x="521" y="725"/>
+      <point x="412" y="725" type="curve" smooth="yes"/>
+      <point x="329" y="725"/>
+      <point x="302" y="664"/>
+      <point x="302" y="569" type="curve" smooth="yes"/>
+      <point x="302" y="548"/>
+      <point x="303" y="515"/>
+      <point x="304" y="477" type="curve"/>
+      <point x="292" y="478"/>
+      <point x="281" y="478"/>
+      <point x="271" y="478" type="curve" smooth="yes"/>
+      <point x="260" y="478"/>
+      <point x="241" y="477"/>
+      <point x="220" y="475" type="curve"/>
+      <point x="222" y="613" type="line"/>
+      <point x="237" y="635"/>
+      <point x="251" y="658"/>
+      <point x="251" y="675" type="curve" smooth="yes"/>
+      <point x="251" y="681"/>
+      <point x="250" y="708"/>
+      <point x="223" y="708" type="curve" smooth="yes"/>
+      <point x="188" y="708"/>
+      <point x="200" y="669"/>
+      <point x="184" y="669" type="curve" smooth="yes"/>
+      <point x="164" y="669"/>
+      <point x="153" y="715"/>
+      <point x="105" y="715" type="curve" smooth="yes"/>
+      <point x="82" y="715"/>
+      <point x="41" y="702"/>
+      <point x="41" y="643" type="curve" smooth="yes"/>
+      <point x="41" y="603"/>
+      <point x="68" y="572"/>
+      <point x="112" y="572" type="curve" smooth="yes"/>
+      <point x="119" y="572"/>
+      <point x="126" y="573"/>
+      <point x="131" y="574" type="curve"/>
+      <point x="130" y="592" type="line"/>
+      <point x="126" y="591"/>
+      <point x="118" y="590"/>
+      <point x="112" y="590" type="curve" smooth="yes"/>
+      <point x="94" y="590"/>
+      <point x="88" y="606"/>
+      <point x="88" y="617" type="curve" smooth="yes"/>
+      <point x="88" y="630"/>
+      <point x="97" y="644"/>
+      <point x="116" y="644" type="curve" smooth="yes"/>
+      <point x="138" y="644"/>
+      <point x="185" y="625"/>
+      <point x="202" y="615" type="curve"/>
+      <point x="186" y="471" type="line"/>
+      <point x="124" y="460"/>
+      <point x="54" y="433"/>
+      <point x="54" y="369" type="curve" smooth="yes"/>
+      <point x="54" y="315"/>
+      <point x="107" y="290"/>
+      <point x="167" y="279" type="curve"/>
+      <point x="160" y="208"/>
+      <point x="156" y="144"/>
+      <point x="156" y="117" type="curve" smooth="yes"/>
+      <point x="156" y="51"/>
+      <point x="183" y="-10"/>
+    </contour>
+    <contour>
+      <point x="265" y="20" type="curve" smooth="yes"/>
+      <point x="228" y="20"/>
+      <point x="208" y="58"/>
+      <point x="208" y="115" type="curve" smooth="yes"/>
+      <point x="208" y="146"/>
+      <point x="210" y="206"/>
+      <point x="212" y="273" type="curve"/>
+      <point x="237" y="270"/>
+      <point x="261" y="270"/>
+      <point x="282" y="270" type="curve" smooth="yes"/>
+      <point x="292" y="270"/>
+      <point x="303" y="270"/>
+      <point x="314" y="271" type="curve"/>
+      <point x="317" y="195"/>
+      <point x="321" y="132"/>
+      <point x="321" y="115" type="curve" smooth="yes"/>
+      <point x="321" y="58"/>
+      <point x="301" y="20"/>
+    </contour>
+    <contour>
+      <point x="169" y="299" type="line"/>
+      <point x="89" y="318"/>
+      <point x="79" y="358"/>
+      <point x="79" y="372" type="curve" smooth="yes"/>
+      <point x="79" y="384"/>
+      <point x="85" y="434"/>
+      <point x="184" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="281" y="288" type="curve" smooth="yes"/>
+      <point x="254" y="288"/>
+      <point x="233" y="289"/>
+      <point x="213" y="291" type="curve"/>
+      <point x="219" y="458" type="line"/>
+      <point x="234" y="459"/>
+      <point x="251" y="460"/>
+      <point x="270" y="460" type="curve" smooth="yes"/>
+      <point x="282" y="460"/>
+      <point x="293" y="459"/>
+      <point x="305" y="459" type="curve"/>
+      <point x="313" y="289" type="line"/>
+      <point x="302" y="288"/>
+      <point x="292" y="288"/>
+    </contour>
+    <contour>
+      <point x="356" y="295" type="curve"/>
+      <point x="337" y="457" type="line"/>
+      <point x="397" y="452"/>
+      <point x="457" y="439"/>
+      <point x="499" y="414" type="curve"/>
+      <point x="476" y="351"/>
+      <point x="428" y="311"/>
+    </contour>
+    <contour>
+      <point x="505" y="436" type="curve"/>
+      <point x="456" y="460"/>
+      <point x="390" y="471"/>
+      <point x="335" y="475" type="curve"/>
+      <point x="331" y="514"/>
+      <point x="329" y="548"/>
+      <point x="329" y="572" type="curve" smooth="yes"/>
+      <point x="329" y="636"/>
+      <point x="335" y="707"/>
+      <point x="409" y="707" type="curve" smooth="yes"/>
+      <point x="500" y="707"/>
+      <point x="516" y="593"/>
+      <point x="516" y="519" type="curve" smooth="yes"/>
+      <point x="516" y="488"/>
+      <point x="512" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:19 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Regular.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-Regular.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="1014"/>
+  <unicode hex="214E"/>
+  <anchor x="550" y="10" name="bottom"/>
+  <anchor x="1033" y="-407" name="bottom_dd"/>
+  <anchor x="602" y="1320" name="parent_top"/>
+  <anchor x="602" y="1320" name="top"/>
+  <anchor x="1033" y="1320" name="top0315"/>
+  <anchor x="1033" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="660" y="0" type="line"/>
+      <point x="845" y="0" type="line"/>
+      <point x="845" y="1082" type="line"/>
+      <point x="660" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="61" y="0" type="line"/>
+      <point x="704" y="0" type="line"/>
+      <point x="704" y="153" type="line"/>
+      <point x="61" y="153" type="line"/>
+    </contour>
+    <contour>
+      <point x="140" y="513" type="line"/>
+      <point x="704" y="513" type="line"/>
+      <point x="704" y="665" type="line"/>
+      <point x="140" y="665" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:19 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Regular.ufo/lib.plist
+++ b/sources/Roboto-Regular.ufo/lib.plist
@@ -6898,6 +6898,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/Roboto-Thin.ufo/fontinfo.plist
+++ b/sources/Roboto-Thin.ufo/fontinfo.plist
@@ -337,7 +337,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-Thin.ufo/glyphs/contents.plist
+++ b/sources/Roboto-Thin.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/Roboto-Thin.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="1078"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="200" y="0" type="line"/>
+      <point x="507" y="0" type="line" smooth="yes"/>
+      <point x="769" y="0"/>
+      <point x="968" y="115"/>
+      <point x="968" y="416" type="curve" smooth="yes"/>
+      <point x="968" y="610"/>
+      <point x="886" y="737"/>
+      <point x="660" y="768" type="curve"/>
+      <point x="660" y="772" type="line"/>
+      <point x="847" y="801"/>
+      <point x="933" y="938"/>
+      <point x="933" y="1118" type="curve" smooth="yes"/>
+      <point x="933" y="1335"/>
+      <point x="796" y="1456"/>
+      <point x="478" y="1456" type="curve" smooth="yes"/>
+      <point x="200" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="370" y="-201" type="line"/>
+      <point x="419" y="-201" type="line"/>
+      <point x="419" y="41" type="line"/>
+      <point x="370" y="41" type="line"/>
+    </contour>
+    <contour>
+      <point x="626" y="-201" type="line"/>
+      <point x="675" y="-201" type="line"/>
+      <point x="675" y="41" type="line"/>
+      <point x="626" y="41" type="line"/>
+    </contour>
+    <contour>
+      <point x="255" y="51" type="line"/>
+      <point x="255" y="743" type="line"/>
+      <point x="490" y="743" type="line" smooth="yes"/>
+      <point x="744" y="743"/>
+      <point x="908" y="678"/>
+      <point x="908" y="414" type="curve" smooth="yes"/>
+      <point x="908" y="162"/>
+      <point x="755" y="51"/>
+      <point x="513" y="51" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="255" y="795" type="line"/>
+      <point x="255" y="1405" type="line"/>
+      <point x="474" y="1405" type="line" smooth="yes"/>
+      <point x="749" y="1405"/>
+      <point x="873" y="1313"/>
+      <point x="873" y="1110" type="curve" smooth="yes"/>
+      <point x="873" y="897"/>
+      <point x="746" y="795"/>
+      <point x="497" y="795" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="370" y="1421" type="line"/>
+      <point x="419" y="1421" type="line"/>
+      <point x="419" y="1669" type="line"/>
+      <point x="370" y="1669" type="line"/>
+    </contour>
+    <contour>
+      <point x="626" y="1421" type="line"/>
+      <point x="675" y="1421" type="line"/>
+      <point x="675" y="1669" type="line"/>
+      <point x="626" y="1669" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="1106"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="408" y="0" type="line"/>
+      <point x="1051" y="0" type="line"/>
+      <point x="1051" y="51" type="line"/>
+      <point x="461" y="51" type="line"/>
+      <point x="461" y="424" type="line"/>
+      <point x="535" y="426"/>
+      <point x="588" y="440"/>
+      <point x="629" y="457" type="curve"/>
+      <point x="629" y="512" type="line"/>
+      <point x="582" y="492"/>
+      <point x="529" y="479"/>
+      <point x="461" y="477" type="curve"/>
+      <point x="461" y="1159" type="line"/>
+      <point x="520" y="1157"/>
+      <point x="567" y="1147"/>
+      <point x="621" y="1128" type="curve"/>
+      <point x="635" y="1180" type="line"/>
+      <point x="586" y="1200"/>
+      <point x="533" y="1212"/>
+      <point x="461" y="1212" type="curve"/>
+      <point x="461" y="1462" type="line"/>
+      <point x="408" y="1462" type="line"/>
+      <point x="408" y="1210" type="line"/>
+      <point x="230" y="1190"/>
+      <point x="133" y="1044"/>
+      <point x="133" y="817" type="curve" smooth="yes"/>
+      <point x="133" y="582"/>
+      <point x="225" y="440"/>
+      <point x="408" y="426" type="curve"/>
+    </contour>
+    <contour>
+      <point x="408" y="479" type="line"/>
+      <point x="260" y="494"/>
+      <point x="195" y="618"/>
+      <point x="195" y="819" type="curve" smooth="yes"/>
+      <point x="195" y="1024"/>
+      <point x="268" y="1139"/>
+      <point x="408" y="1157" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="1121"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2108.glif
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1325"/>
+  <unicode hex="2108"/>
+  <anchor x="692" y="1634" name="parent_top"/>
+  <anchor x="692" y="1634" name="top"/>
+  <anchor x="1325" y="1634" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="654" y="-20" type="curve" smooth="yes"/>
+      <point x="974" y="-20"/>
+      <point x="1181" y="239"/>
+      <point x="1181" y="619" type="curve" smooth="yes"/>
+      <point x="1181" y="837" type="line" smooth="yes"/>
+      <point x="1181" y="1217"/>
+      <point x="974" y="1476"/>
+      <point x="654" y="1476" type="curve" smooth="yes"/>
+      <point x="362" y="1476"/>
+      <point x="165" y="1323"/>
+      <point x="135" y="1012" type="curve"/>
+      <point x="189" y="1012" type="line"/>
+      <point x="219" y="1279"/>
+      <point x="378" y="1422"/>
+      <point x="654" y="1422" type="curve" smooth="yes"/>
+      <point x="937" y="1422"/>
+      <point x="1127" y="1190"/>
+      <point x="1127" y="839" type="curve" smooth="yes"/>
+      <point x="1127" y="619" type="line" smooth="yes"/>
+      <point x="1127" y="266"/>
+      <point x="937" y="34"/>
+      <point x="654" y="34" type="curve" smooth="yes"/>
+      <point x="384" y="34"/>
+      <point x="219" y="161"/>
+      <point x="189" y="446" type="curve"/>
+      <point x="135" y="446" type="line"/>
+      <point x="165" y="131"/>
+      <point x="362" y="-20"/>
+    </contour>
+    <contour>
+      <point x="485" y="710" type="line"/>
+      <point x="1134" y="710" type="line"/>
+      <point x="1134" y="764" type="line"/>
+      <point x="485" y="764" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1630"/>
+  <unicode hex="2114"/>
+  <anchor x="1093" y="-10" name="bottom"/>
+  <anchor x="1630" y="-407" name="bottom_dd"/>
+  <anchor x="510" y="1503" name="marktop"/>
+  <anchor x="1086" y="1612" name="parent_top"/>
+  <anchor x="1086" y="1612" name="top"/>
+  <anchor x="1630" y="1612" name="top0315"/>
+  <anchor x="1630" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1102" y="-20" type="curve" smooth="yes"/>
+      <point x="1358" y="-20"/>
+      <point x="1508" y="201"/>
+      <point x="1508" y="531" type="curve" smooth="yes"/>
+      <point x="1508" y="552" type="line"/>
+      <point x="1508" y="893"/>
+      <point x="1357" y="1102"/>
+      <point x="1100" y="1102" type="curve" smooth="yes"/>
+      <point x="865" y="1102"/>
+      <point x="728" y="948"/>
+      <point x="681" y="745" type="curve"/>
+      <point x="681" y="304" type="line"/>
+      <point x="715" y="133"/>
+      <point x="858" y="-20"/>
+    </contour>
+    <contour>
+      <point x="221" y="0" type="line"/>
+      <point x="275" y="0" type="line"/>
+      <point x="275" y="1536" type="line"/>
+      <point x="221" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="679" y="0" type="line"/>
+      <point x="733" y="0" type="line"/>
+      <point x="733" y="210" type="line"/>
+      <point x="733" y="1536" type="line"/>
+      <point x="679" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="1103" y="34" type="curve" smooth="yes"/>
+      <point x="876" y="34"/>
+      <point x="753" y="166"/>
+      <point x="717" y="329" type="curve"/>
+      <point x="717" y="709" type="line"/>
+      <point x="746" y="843"/>
+      <point x="829" y="1048"/>
+      <point x="1101" y="1048" type="curve" smooth="yes"/>
+      <point x="1339" y="1048"/>
+      <point x="1452" y="839"/>
+      <point x="1452" y="552" type="curve" smooth="yes"/>
+      <point x="1452" y="531" type="line"/>
+      <point x="1452" y="243"/>
+      <point x="1339" y="34"/>
+    </contour>
+    <contour>
+      <point x="61" y="1281" type="line"/>
+      <point x="1096" y="1281" type="line"/>
+      <point x="1096" y="1335" type="line"/>
+      <point x="61" y="1335" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="786"/>
+  <advance width="1610"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="205" y="-241" type="curve" smooth="yes"/>
-      <point x="272" y="-241"/>
-      <point x="318" y="-180"/>
-      <point x="318" y="-95" type="curve" smooth="yes"/>
-      <point x="318" y="8"/>
-      <point x="229" y="99"/>
-      <point x="174" y="200" type="curve"/>
-      <point x="220" y="272"/>
-      <point x="279" y="341"/>
-      <point x="338" y="394" type="curve" smooth="yes"/>
-      <point x="403" y="452"/>
-      <point x="472" y="492"/>
-      <point x="530" y="492" type="curve" smooth="yes"/>
-      <point x="629" y="492"/>
-      <point x="636" y="359"/>
-      <point x="636" y="322" type="curve" smooth="yes"/>
-      <point x="636" y="285"/>
-      <point x="624" y="30"/>
-      <point x="465" y="30" type="curve" smooth="yes"/>
-      <point x="415" y="30"/>
-      <point x="367" y="57"/>
-      <point x="367" y="112" type="curve" smooth="yes"/>
-      <point x="367" y="119"/>
-      <point x="368" y="126"/>
-      <point x="370" y="132" type="curve"/>
-      <point x="402" y="136"/>
-      <point x="434" y="151"/>
-      <point x="434" y="194" type="curve" smooth="yes"/>
-      <point x="434" y="225"/>
-      <point x="413" y="244"/>
-      <point x="383" y="244" type="curve" smooth="yes"/>
-      <point x="336" y="244"/>
-      <point x="308" y="206"/>
-      <point x="308" y="140" type="curve" smooth="yes"/>
-      <point x="308" y="51"/>
-      <point x="369" y="-10"/>
-      <point x="472" y="-10" type="curve" smooth="yes"/>
-      <point x="644" y="-10"/>
-      <point x="735" y="159"/>
-      <point x="735" y="306" type="curve" smooth="yes"/>
-      <point x="735" y="437"/>
-      <point x="676" y="549"/>
-      <point x="559" y="549" type="curve" smooth="yes"/>
-      <point x="510" y="549"/>
-      <point x="418" y="512"/>
-      <point x="315" y="419" type="curve" smooth="yes"/>
-      <point x="264" y="373"/>
-      <point x="205" y="310"/>
-      <point x="155" y="238" type="curve"/>
-      <point x="140" y="272"/>
-      <point x="131" y="307"/>
-      <point x="131" y="345" type="curve" smooth="yes"/>
-      <point x="131" y="474"/>
-      <point x="160" y="548"/>
-      <point x="238" y="625" type="curve"/>
-      <point x="223" y="647" type="line"/>
-      <point x="166" y="610"/>
-      <point x="46" y="496"/>
-      <point x="46" y="337" type="curve" smooth="yes"/>
-      <point x="46" y="267"/>
-      <point x="69" y="206"/>
-      <point x="100" y="149" type="curve"/>
-      <point x="66" y="85"/>
-      <point x="41" y="11"/>
-      <point x="41" y="-56" type="curve" smooth="yes"/>
-      <point x="41" y="-163"/>
-      <point x="112" y="-241"/>
+      <point x="420" y="-494" type="curve" smooth="yes"/>
+      <point x="557" y="-494"/>
+      <point x="651" y="-369"/>
+      <point x="651" y="-195" type="curve" smooth="yes"/>
+      <point x="651" y="16"/>
+      <point x="469" y="203"/>
+      <point x="356" y="410" type="curve"/>
+      <point x="451" y="557"/>
+      <point x="571" y="698"/>
+      <point x="692" y="807" type="curve" smooth="yes"/>
+      <point x="825" y="926"/>
+      <point x="967" y="1008"/>
+      <point x="1085" y="1008" type="curve" smooth="yes"/>
+      <point x="1288" y="1008"/>
+      <point x="1303" y="735"/>
+      <point x="1303" y="659" type="curve" smooth="yes"/>
+      <point x="1303" y="584"/>
+      <point x="1278" y="61"/>
+      <point x="952" y="61" type="curve" smooth="yes"/>
+      <point x="850" y="61"/>
+      <point x="752" y="117"/>
+      <point x="752" y="229" type="curve" smooth="yes"/>
+      <point x="752" y="244"/>
+      <point x="754" y="258"/>
+      <point x="758" y="270" type="curve"/>
+      <point x="823" y="279"/>
+      <point x="889" y="309"/>
+      <point x="889" y="397" type="curve" smooth="yes"/>
+      <point x="889" y="461"/>
+      <point x="846" y="500"/>
+      <point x="784" y="500" type="curve" smooth="yes"/>
+      <point x="688" y="500"/>
+      <point x="631" y="422"/>
+      <point x="631" y="287" type="curve" smooth="yes"/>
+      <point x="631" y="104"/>
+      <point x="756" y="-20"/>
+      <point x="967" y="-20" type="curve" smooth="yes"/>
+      <point x="1319" y="-20"/>
+      <point x="1505" y="326"/>
+      <point x="1505" y="627" type="curve" smooth="yes"/>
+      <point x="1505" y="895"/>
+      <point x="1384" y="1124"/>
+      <point x="1145" y="1124" type="curve" smooth="yes"/>
+      <point x="1044" y="1124"/>
+      <point x="856" y="1049"/>
+      <point x="645" y="858" type="curve" smooth="yes"/>
+      <point x="541" y="764"/>
+      <point x="420" y="635"/>
+      <point x="317" y="487" type="curve"/>
+      <point x="287" y="557"/>
+      <point x="268" y="629"/>
+      <point x="268" y="707" type="curve" smooth="yes"/>
+      <point x="268" y="971"/>
+      <point x="328" y="1122"/>
+      <point x="487" y="1280" type="curve"/>
+      <point x="457" y="1325" type="line"/>
+      <point x="340" y="1249"/>
+      <point x="94" y="1016"/>
+      <point x="94" y="690" type="curve" smooth="yes"/>
+      <point x="94" y="547"/>
+      <point x="141" y="422"/>
+      <point x="205" y="305" type="curve"/>
+      <point x="135" y="174"/>
+      <point x="84" y="23"/>
+      <point x="84" y="-115" type="curve" smooth="yes"/>
+      <point x="84" y="-334"/>
+      <point x="229" y="-494"/>
     </contour>
     <contour>
-      <point x="188" y="-199" type="curve" smooth="yes"/>
-      <point x="144" y="-199"/>
-      <point x="80" y="-145"/>
-      <point x="80" y="-51" type="curve" smooth="yes"/>
-      <point x="80" y="-4"/>
-      <point x="96" y="52"/>
-      <point x="123" y="110" type="curve"/>
-      <point x="174" y="24"/>
-      <point x="234" y="-52"/>
-      <point x="234" y="-134" type="curve" smooth="yes"/>
-      <point x="234" y="-176"/>
-      <point x="216" y="-199"/>
+      <point x="385" y="-408" type="curve" smooth="yes"/>
+      <point x="295" y="-408"/>
+      <point x="164" y="-297"/>
+      <point x="164" y="-104" type="curve" smooth="yes"/>
+      <point x="164" y="-8"/>
+      <point x="197" y="106"/>
+      <point x="252" y="225" type="curve"/>
+      <point x="356" y="49"/>
+      <point x="479" y="-106"/>
+      <point x="479" y="-274" type="curve" smooth="yes"/>
+      <point x="479" y="-360"/>
+      <point x="442" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="786"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="205" y="-241" type="curve" smooth="yes"/>
+      <point x="272" y="-241"/>
+      <point x="318" y="-180"/>
+      <point x="318" y="-95" type="curve" smooth="yes"/>
+      <point x="318" y="8"/>
+      <point x="229" y="99"/>
+      <point x="174" y="200" type="curve"/>
+      <point x="220" y="272"/>
+      <point x="279" y="341"/>
+      <point x="338" y="394" type="curve" smooth="yes"/>
+      <point x="403" y="452"/>
+      <point x="472" y="492"/>
+      <point x="530" y="492" type="curve" smooth="yes"/>
+      <point x="629" y="492"/>
+      <point x="636" y="359"/>
+      <point x="636" y="322" type="curve" smooth="yes"/>
+      <point x="636" y="285"/>
+      <point x="624" y="30"/>
+      <point x="465" y="30" type="curve" smooth="yes"/>
+      <point x="415" y="30"/>
+      <point x="367" y="57"/>
+      <point x="367" y="112" type="curve" smooth="yes"/>
+      <point x="367" y="119"/>
+      <point x="368" y="126"/>
+      <point x="370" y="132" type="curve"/>
+      <point x="402" y="136"/>
+      <point x="434" y="151"/>
+      <point x="434" y="194" type="curve" smooth="yes"/>
+      <point x="434" y="225"/>
+      <point x="413" y="244"/>
+      <point x="383" y="244" type="curve" smooth="yes"/>
+      <point x="336" y="244"/>
+      <point x="308" y="206"/>
+      <point x="308" y="140" type="curve" smooth="yes"/>
+      <point x="308" y="51"/>
+      <point x="369" y="-10"/>
+      <point x="472" y="-10" type="curve" smooth="yes"/>
+      <point x="644" y="-10"/>
+      <point x="735" y="159"/>
+      <point x="735" y="306" type="curve" smooth="yes"/>
+      <point x="735" y="437"/>
+      <point x="676" y="549"/>
+      <point x="559" y="549" type="curve" smooth="yes"/>
+      <point x="510" y="549"/>
+      <point x="418" y="512"/>
+      <point x="315" y="419" type="curve" smooth="yes"/>
+      <point x="264" y="373"/>
+      <point x="205" y="310"/>
+      <point x="155" y="238" type="curve"/>
+      <point x="140" y="272"/>
+      <point x="131" y="307"/>
+      <point x="131" y="345" type="curve" smooth="yes"/>
+      <point x="131" y="474"/>
+      <point x="160" y="548"/>
+      <point x="238" y="625" type="curve"/>
+      <point x="223" y="647" type="line"/>
+      <point x="166" y="610"/>
+      <point x="46" y="496"/>
+      <point x="46" y="337" type="curve" smooth="yes"/>
+      <point x="46" y="267"/>
+      <point x="69" y="206"/>
+      <point x="100" y="149" type="curve"/>
+      <point x="66" y="85"/>
+      <point x="41" y="11"/>
+      <point x="41" y="-56" type="curve" smooth="yes"/>
+      <point x="41" y="-163"/>
+      <point x="112" y="-241"/>
+    </contour>
+    <contour>
+      <point x="188" y="-199" type="curve" smooth="yes"/>
+      <point x="144" y="-199"/>
+      <point x="80" y="-145"/>
+      <point x="80" y="-51" type="curve" smooth="yes"/>
+      <point x="80" y="-4"/>
+      <point x="96" y="52"/>
+      <point x="123" y="110" type="curve"/>
+      <point x="174" y="24"/>
+      <point x="234" y="-52"/>
+      <point x="234" y="-134" type="curve" smooth="yes"/>
+      <point x="234" y="-176"/>
+      <point x="216" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2127.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1321"/>
+  <advance width="1325"/>
   <unicode hex="2127"/>
   <anchor x="656" y="1446" name="top"/>
   <outline>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1321"/>
+  <unicode hex="2127"/>
+  <anchor x="656" y="1446" name="top"/>
+  <outline>
+    <contour>
+      <point x="666" y="-20" type="curve" smooth="yes"/>
+      <point x="974" y="-20"/>
+      <point x="1183" y="229"/>
+      <point x="1183" y="607" type="curve"/>
+      <point x="1183" y="724" type="line"/>
+      <point x="1183" y="1152"/>
+      <point x="955" y="1352"/>
+      <point x="764" y="1437" type="curve"/>
+      <point x="764" y="1378" type="line"/>
+      <point x="928" y="1296"/>
+      <point x="1129" y="1126"/>
+      <point x="1129" y="724" type="curve"/>
+      <point x="1129" y="605" type="line"/>
+      <point x="1129" y="285"/>
+      <point x="950" y="34"/>
+      <point x="666" y="34" type="curve" smooth="yes"/>
+      <point x="382" y="34"/>
+      <point x="201" y="285"/>
+      <point x="201" y="605" type="curve"/>
+      <point x="201" y="724" type="line"/>
+      <point x="201" y="1124"/>
+      <point x="395" y="1295"/>
+      <point x="560" y="1378" type="curve"/>
+      <point x="560" y="1437" type="line"/>
+      <point x="373" y="1350"/>
+      <point x="147" y="1151"/>
+      <point x="147" y="724" type="curve"/>
+      <point x="147" y="607" type="line"/>
+      <point x="147" y="229"/>
+      <point x="359" y="-20"/>
+    </contour>
+    <contour>
+      <point x="126" y="1402" type="line"/>
+      <point x="560" y="1402" type="line"/>
+      <point x="560" y="1456" type="line"/>
+      <point x="126" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="764" y="1402" type="line"/>
+      <point x="1199" y="1402" type="line"/>
+      <point x="1199" y="1456" type="line"/>
+      <point x="764" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="565"/>
+  <unicode hex="2129"/>
+  <anchor x="369" y="-195" name="bottom"/>
+  <anchor x="0" y="-195" name="bottom0315"/>
+  <anchor x="369" y="-195" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="340" y="-8" type="line"/>
+      <point x="395" y="-8" type="line"/>
+      <point x="395" y="803" type="line"/>
+      <point x="395" y="1020"/>
+      <point x="312" y="1082"/>
+      <point x="174" y="1082" type="curve" smooth="yes"/>
+      <point x="146" y="1082"/>
+      <point x="90" y="1080"/>
+      <point x="61" y="1070" type="curve"/>
+      <point x="70" y="1019" type="line"/>
+      <point x="107" y="1024"/>
+      <point x="136" y="1028"/>
+      <point x="177" y="1028" type="curve" smooth="yes"/>
+      <point x="264" y="1028"/>
+      <point x="340" y="993"/>
+      <point x="340" y="803" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2139.glif
@@ -1,0 +1,37 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="422"/>
+  <unicode hex="2139"/>
+  <anchor x="210" y="10" name="bottom"/>
+  <anchor x="422" y="-407" name="bottom_dd"/>
+  <anchor x="218" y="1600" name="parent_top"/>
+  <anchor x="212" y="654" name="rhotichook"/>
+  <anchor x="218" y="1600" name="top"/>
+  <anchor x="422" y="1600" name="top0315"/>
+  <anchor x="422" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i" identifier="09313FF8"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+      <key>public.objectLibs</key>
+      <dict>
+        <key>09313FF8</key>
+        <dict>
+          <key>com.schriftgestaltung.alignment</key>
+          <integer>-1</integer>
+        </dict>
+      </dict>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2139.glif
@@ -10,28 +10,33 @@
   <anchor x="422" y="1600" name="top0315"/>
   <anchor x="422" y="1600" name="top_dd"/>
   <outline>
-    <component base="i" identifier="09313FF8"/>
+    <component base="i"/>
   </outline>
   <lib>
     <dict>
+      <key>com.schriftgestaltung.Glyphs.ComponentInfo</key>
+      <array>
+        <dict>
+          <key>alignment</key>
+          <integer>-1</integer>
+          <key>index</key>
+          <integer>0</integer>
+          <key>name</key>
+          <string>i</string>
+        </dict>
+      </array>
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
-      <key>public.objectLibs</key>
-      <dict>
-        <key>09313FF8</key>
-        <dict>
-          <key>com.schriftgestaltung.alignment</key>
-          <integer>-1</integer>
-        </dict>
-      </dict>
     </dict>
   </lib>
 </glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni213A_.glif
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1829"/>
+  <unicode hex="213A"/>
+  <anchor x="1576" y="686" name="bottom"/>
+  <anchor x="1973" y="1352" name="bottom_dd"/>
+  <anchor x="-34" y="688" name="parent_top"/>
+  <anchor x="-34" y="688" name="top"/>
+  <anchor x="-34" y="1352" name="top0315"/>
+  <anchor x="-34" y="1352" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="729" y="121" type="curve"/>
+      <point x="947" y="121" type="line"/>
+      <point x="1327" y="121"/>
+      <point x="1586" y="337"/>
+      <point x="1586" y="671" type="curve" smooth="yes"/>
+      <point x="1586" y="1006"/>
+      <point x="1327" y="1219"/>
+      <point x="947" y="1219" type="curve"/>
+      <point x="729" y="1219" type="line"/>
+      <point x="349" y="1219"/>
+      <point x="90" y="1004"/>
+      <point x="90" y="669" type="curve" smooth="yes"/>
+      <point x="90" y="335"/>
+      <point x="349" y="121"/>
+    </contour>
+    <contour>
+      <point x="727" y="176" type="line" smooth="yes"/>
+      <point x="386" y="176"/>
+      <point x="144" y="357"/>
+      <point x="144" y="669" type="curve" smooth="yes"/>
+      <point x="144" y="983"/>
+      <point x="386" y="1165"/>
+      <point x="727" y="1165" type="curve"/>
+      <point x="947" y="1165" type="line"/>
+      <point x="1290" y="1165"/>
+      <point x="1532" y="985"/>
+      <point x="1532" y="671" type="curve" smooth="yes"/>
+      <point x="1532" y="359"/>
+      <point x="1290" y="176"/>
+      <point x="947" y="176" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1541" y="841" type="line"/>
+      <point x="1829" y="1140" type="line"/>
+      <point x="1794" y="1179" type="line"/>
+      <point x="1503" y="882" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1406"/>
+  <unicode hex="2141"/>
+  <anchor x="703" y="-177" name="bottom"/>
+  <anchor x="0" y="-177" name="bottom0315"/>
+  <anchor x="0" y="-144" name="bottom_dd"/>
+  <anchor x="703" y="-177" name="parent_bottom"/>
+  <anchor x="677" y="1456" name="top"/>
+  <anchor x="0" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="694" y="-20" type="curve" smooth="yes"/>
+      <point x="1015" y="-20"/>
+      <point x="1238" y="231"/>
+      <point x="1238" y="598" type="curve" smooth="yes"/>
+      <point x="1238" y="836" type="line" smooth="yes"/>
+      <point x="1238" y="1216"/>
+      <point x="1009" y="1476"/>
+      <point x="677" y="1476" type="curve" smooth="yes"/>
+      <point x="393" y="1476"/>
+      <point x="227" y="1366"/>
+      <point x="180" y="1300" type="curve"/>
+      <point x="180" y="796" type="line"/>
+      <point x="679" y="796" type="line"/>
+      <point x="679" y="851" type="line"/>
+      <point x="234" y="851" type="line"/>
+      <point x="234" y="1275" type="line"/>
+      <point x="279" y="1334"/>
+      <point x="439" y="1422"/>
+      <point x="677" y="1422" type="curve" smooth="yes"/>
+      <point x="985" y="1422"/>
+      <point x="1184" y="1179"/>
+      <point x="1184" y="836" type="curve" smooth="yes"/>
+      <point x="1184" y="596" type="line" smooth="yes"/>
+      <point x="1184" y="268"/>
+      <point x="991" y="34"/>
+      <point x="694" y="34" type="curve" smooth="yes"/>
+      <point x="391" y="34"/>
+      <point x="266" y="204"/>
+      <point x="236" y="394" type="curve"/>
+      <point x="182" y="394" type="line"/>
+      <point x="209" y="161"/>
+      <point x="379" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="1057"/>
+  <unicode hex="2142"/>
+  <anchor x="825" y="-93" name="bottom"/>
+  <anchor x="0" y="-93" name="bottom0315"/>
+  <anchor x="0" y="-144" name="bottom_dd"/>
+  <anchor x="825" y="-93" name="parent_bottom"/>
+  <anchor x="432" y="1446" name="top"/>
+  <anchor x="0" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="802" y="0" type="line"/>
+      <point x="857" y="0" type="line"/>
+      <point x="857" y="1456" type="line"/>
+      <point x="802" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="55" y="1402" type="line"/>
+      <point x="837" y="1402" type="line"/>
+      <point x="837" y="1456" type="line"/>
+      <point x="55" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="1057"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="802" y="0" type="line"/>
+      <point x="857" y="0" type="line"/>
+      <point x="857" y="1456" type="line"/>
+      <point x="802" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="55" y="0" type="line"/>
+      <point x="837" y="0" type="line"/>
+      <point x="837" y="54" type="line"/>
+      <point x="55" y="54" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1223"/>
+  <unicode hex="2144"/>
+  <anchor x="615" y="-145" name="bottom"/>
+  <anchor x="0" y="-145" name="bottom0315"/>
+  <anchor x="0" y="-144" name="bottom_dd"/>
+  <anchor x="615" y="-145" name="parent_bottom"/>
+  <anchor x="611" y="1446" name="top"/>
+  <anchor x="0" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="38" y="0" type="line"/>
+      <point x="104" y="0" type="line"/>
+      <point x="614" y="854" type="line"/>
+      <point x="1118" y="0" type="line"/>
+      <point x="1190" y="0" type="line"/>
+      <point x="641" y="903" type="line"/>
+      <point x="641" y="1456" type="line"/>
+      <point x="587" y="1456" type="line"/>
+      <point x="587" y="903" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni214A_.glif
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Thin.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1208"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="185" y="300" type="line"/>
+      <point x="239" y="300" type="line"/>
+      <point x="239" y="1402" type="line"/>
+      <point x="640" y="1402" type="line"/>
+      <point x="934" y="1402"/>
+      <point x="1056" y="1235"/>
+      <point x="1056" y="1029" type="curve"/>
+      <point x="1056" y="831"/>
+      <point x="934" y="669"/>
+      <point x="640" y="669" type="curve"/>
+      <point x="558" y="669" type="line"/>
+      <point x="558" y="615" type="line"/>
+      <point x="640" y="615" type="line"/>
+      <point x="951" y="615"/>
+      <point x="1110" y="774"/>
+      <point x="1110" y="1031" type="curve"/>
+      <point x="1110" y="1287"/>
+      <point x="950" y="1456"/>
+      <point x="640" y="1456" type="curve"/>
+      <point x="185" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="551" y="0" type="line"/>
+      <point x="1153" y="0" type="line"/>
+      <point x="1153" y="54" type="line"/>
+      <point x="551" y="54" type="line"/>
+    </contour>
+    <contour>
+      <point x="531" y="0" type="line"/>
+      <point x="586" y="0" type="line"/>
+      <point x="586" y="1589" type="line"/>
+      <point x="531" y="1589" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1247"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="685" y="-20" type="curve" smooth="yes"/>
+      <point x="873" y="-20"/>
+      <point x="990" y="108"/>
+      <point x="990" y="290" type="curve" smooth="yes"/>
+      <point x="990" y="439"/>
+      <point x="906" y="564"/>
+      <point x="759" y="732" type="curve" smooth="yes"/>
+      <point x="118" y="1457" type="line"/>
+      <point x="51" y="1457" type="line"/>
+      <point x="778" y="631" type="line" smooth="yes"/>
+      <point x="886" y="506"/>
+      <point x="935" y="391"/>
+      <point x="935" y="288" type="curve" smooth="yes"/>
+      <point x="935" y="150"/>
+      <point x="848" y="34"/>
+      <point x="685" y="34" type="curve" smooth="yes"/>
+      <point x="541" y="34"/>
+      <point x="465" y="134"/>
+      <point x="465" y="244" type="curve" smooth="yes"/>
+      <point x="465" y="342"/>
+      <point x="541" y="430"/>
+      <point x="626" y="497" type="curve" smooth="yes"/>
+      <point x="876" y="695" type="line"/>
+      <point x="1014" y="811"/>
+      <point x="1132" y="939"/>
+      <point x="1132" y="1105" type="curve"/>
+      <point x="1132" y="1333"/>
+      <point x="967" y="1477"/>
+      <point x="698" y="1477" type="curve"/>
+      <point x="522" y="1477"/>
+      <point x="382" y="1392"/>
+      <point x="270" y="1276" type="curve" smooth="yes"/>
+      <point x="259" y="1265"/>
+      <point x="264" y="1271"/>
+      <point x="254" y="1258" type="curve" smooth="yes"/>
+      <point x="165" y="1146"/>
+      <point x="108" y="1007"/>
+      <point x="108" y="825" type="curve"/>
+      <point x="163" y="825" type="line"/>
+      <point x="163" y="1183"/>
+      <point x="420" y="1423"/>
+      <point x="698" y="1423" type="curve" smooth="yes"/>
+      <point x="957" y="1423"/>
+      <point x="1078" y="1270"/>
+      <point x="1078" y="1105" type="curve"/>
+      <point x="1078" y="1017"/>
+      <point x="1044" y="906"/>
+      <point x="845" y="734" type="curve" smooth="yes"/>
+      <point x="601" y="539" type="line" smooth="yes"/>
+      <point x="526" y="478"/>
+      <point x="409" y="367"/>
+      <point x="409" y="244" type="curve" smooth="yes"/>
+      <point x="409" y="99"/>
+      <point x="507" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni214B_.glif
@@ -63,7 +63,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Thin.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="615"/>
+  <advance width="1260"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="265" y="-10" type="curve" smooth="yes"/>
-      <point x="347" y="-10"/>
-      <point x="374" y="51"/>
-      <point x="374" y="117" type="curve" smooth="yes"/>
-      <point x="374" y="140"/>
-      <point x="366" y="204"/>
-      <point x="358" y="277" type="curve"/>
-      <point x="434" y="291"/>
-      <point x="500" y="326"/>
-      <point x="542" y="375" type="curve"/>
-      <point x="551" y="361"/>
-      <point x="556" y="345"/>
-      <point x="556" y="327" type="curve" smooth="yes"/>
-      <point x="556" y="281"/>
-      <point x="509" y="238"/>
-      <point x="491" y="224" type="curve"/>
-      <point x="525" y="224" type="line"/>
-      <point x="544" y="238"/>
-      <point x="586" y="281"/>
-      <point x="586" y="326" type="curve" smooth="yes"/>
-      <point x="586" y="354"/>
-      <point x="576" y="378"/>
-      <point x="559" y="397" type="curve"/>
-      <point x="580" y="427"/>
-      <point x="592" y="462"/>
-      <point x="592" y="500" type="curve" smooth="yes"/>
-      <point x="592" y="608"/>
-      <point x="521" y="725"/>
-      <point x="412" y="725" type="curve" smooth="yes"/>
-      <point x="329" y="725"/>
-      <point x="302" y="664"/>
-      <point x="302" y="569" type="curve" smooth="yes"/>
-      <point x="302" y="548"/>
-      <point x="303" y="515"/>
-      <point x="304" y="477" type="curve"/>
-      <point x="292" y="478"/>
-      <point x="281" y="478"/>
-      <point x="271" y="478" type="curve" smooth="yes"/>
-      <point x="260" y="478"/>
-      <point x="241" y="477"/>
-      <point x="220" y="475" type="curve"/>
-      <point x="222" y="613" type="line"/>
-      <point x="237" y="635"/>
-      <point x="251" y="658"/>
-      <point x="251" y="675" type="curve" smooth="yes"/>
-      <point x="251" y="681"/>
-      <point x="250" y="708"/>
-      <point x="223" y="708" type="curve" smooth="yes"/>
-      <point x="188" y="708"/>
-      <point x="200" y="669"/>
-      <point x="184" y="669" type="curve" smooth="yes"/>
-      <point x="164" y="669"/>
-      <point x="153" y="715"/>
-      <point x="105" y="715" type="curve" smooth="yes"/>
-      <point x="82" y="715"/>
-      <point x="41" y="702"/>
-      <point x="41" y="643" type="curve" smooth="yes"/>
-      <point x="41" y="603"/>
-      <point x="68" y="572"/>
-      <point x="112" y="572" type="curve" smooth="yes"/>
-      <point x="119" y="572"/>
-      <point x="126" y="573"/>
-      <point x="131" y="574" type="curve"/>
-      <point x="130" y="592" type="line"/>
-      <point x="126" y="591"/>
-      <point x="118" y="590"/>
-      <point x="112" y="590" type="curve" smooth="yes"/>
-      <point x="94" y="590"/>
-      <point x="88" y="606"/>
-      <point x="88" y="617" type="curve" smooth="yes"/>
-      <point x="88" y="630"/>
-      <point x="97" y="644"/>
-      <point x="116" y="644" type="curve" smooth="yes"/>
-      <point x="138" y="644"/>
-      <point x="185" y="625"/>
-      <point x="202" y="615" type="curve"/>
-      <point x="186" y="471" type="line"/>
-      <point x="124" y="460"/>
-      <point x="54" y="433"/>
-      <point x="54" y="369" type="curve" smooth="yes"/>
-      <point x="54" y="315"/>
-      <point x="107" y="290"/>
-      <point x="167" y="279" type="curve"/>
-      <point x="160" y="208"/>
-      <point x="156" y="144"/>
-      <point x="156" y="117" type="curve" smooth="yes"/>
-      <point x="156" y="51"/>
-      <point x="183" y="-10"/>
+      <point x="543" y="-20" type="curve" smooth="yes"/>
+      <point x="711" y="-20"/>
+      <point x="766" y="104"/>
+      <point x="766" y="240" type="curve" smooth="yes"/>
+      <point x="766" y="287"/>
+      <point x="750" y="418"/>
+      <point x="733" y="567" type="curve"/>
+      <point x="889" y="596"/>
+      <point x="1024" y="668"/>
+      <point x="1110" y="768" type="curve"/>
+      <point x="1128" y="739"/>
+      <point x="1139" y="707"/>
+      <point x="1139" y="670" type="curve" smooth="yes"/>
+      <point x="1139" y="575"/>
+      <point x="1042" y="487"/>
+      <point x="1006" y="459" type="curve"/>
+      <point x="1075" y="459" type="line"/>
+      <point x="1114" y="487"/>
+      <point x="1200" y="575"/>
+      <point x="1200" y="668" type="curve" smooth="yes"/>
+      <point x="1200" y="725"/>
+      <point x="1180" y="774"/>
+      <point x="1145" y="813" type="curve"/>
+      <point x="1188" y="874"/>
+      <point x="1212" y="946"/>
+      <point x="1212" y="1024" type="curve" smooth="yes"/>
+      <point x="1212" y="1245"/>
+      <point x="1067" y="1485"/>
+      <point x="844" y="1485" type="curve" smooth="yes"/>
+      <point x="674" y="1485"/>
+      <point x="618" y="1360"/>
+      <point x="618" y="1165" type="curve" smooth="yes"/>
+      <point x="618" y="1122"/>
+      <point x="621" y="1055"/>
+      <point x="623" y="977" type="curve"/>
+      <point x="598" y="979"/>
+      <point x="575" y="979"/>
+      <point x="555" y="979" type="curve" smooth="yes"/>
+      <point x="532" y="979"/>
+      <point x="494" y="977"/>
+      <point x="451" y="973" type="curve"/>
+      <point x="455" y="1255" type="line"/>
+      <point x="485" y="1300"/>
+      <point x="514" y="1348"/>
+      <point x="514" y="1382" type="curve" smooth="yes"/>
+      <point x="514" y="1395"/>
+      <point x="512" y="1450"/>
+      <point x="457" y="1450" type="curve" smooth="yes"/>
+      <point x="385" y="1450"/>
+      <point x="410" y="1370"/>
+      <point x="377" y="1370" type="curve" smooth="yes"/>
+      <point x="336" y="1370"/>
+      <point x="313" y="1464"/>
+      <point x="215" y="1464" type="curve" smooth="yes"/>
+      <point x="168" y="1464"/>
+      <point x="84" y="1438"/>
+      <point x="84" y="1317" type="curve" smooth="yes"/>
+      <point x="84" y="1235"/>
+      <point x="139" y="1171"/>
+      <point x="229" y="1171" type="curve" smooth="yes"/>
+      <point x="244" y="1171"/>
+      <point x="258" y="1174"/>
+      <point x="268" y="1176" type="curve"/>
+      <point x="266" y="1212" type="line"/>
+      <point x="258" y="1210"/>
+      <point x="242" y="1208"/>
+      <point x="229" y="1208" type="curve" smooth="yes"/>
+      <point x="193" y="1208"/>
+      <point x="180" y="1241"/>
+      <point x="180" y="1264" type="curve" smooth="yes"/>
+      <point x="180" y="1290"/>
+      <point x="199" y="1319"/>
+      <point x="238" y="1319" type="curve" smooth="yes"/>
+      <point x="283" y="1319"/>
+      <point x="379" y="1280"/>
+      <point x="414" y="1260" type="curve"/>
+      <point x="381" y="965" type="line"/>
+      <point x="254" y="942"/>
+      <point x="111" y="887"/>
+      <point x="111" y="756" type="curve" smooth="yes"/>
+      <point x="111" y="645"/>
+      <point x="219" y="594"/>
+      <point x="342" y="571" type="curve"/>
+      <point x="328" y="426"/>
+      <point x="319" y="295"/>
+      <point x="319" y="240" type="curve" smooth="yes"/>
+      <point x="319" y="104"/>
+      <point x="375" y="-20"/>
     </contour>
     <contour>
-      <point x="265" y="20" type="curve" smooth="yes"/>
-      <point x="228" y="20"/>
-      <point x="208" y="58"/>
-      <point x="208" y="115" type="curve" smooth="yes"/>
-      <point x="208" y="146"/>
-      <point x="210" y="206"/>
-      <point x="212" y="273" type="curve"/>
-      <point x="237" y="270"/>
-      <point x="261" y="270"/>
-      <point x="282" y="270" type="curve" smooth="yes"/>
-      <point x="292" y="270"/>
-      <point x="303" y="270"/>
-      <point x="314" y="271" type="curve"/>
-      <point x="317" y="195"/>
-      <point x="321" y="132"/>
-      <point x="321" y="115" type="curve" smooth="yes"/>
-      <point x="321" y="58"/>
-      <point x="301" y="20"/>
+      <point x="543" y="41" type="curve" smooth="yes"/>
+      <point x="467" y="41"/>
+      <point x="426" y="119"/>
+      <point x="426" y="236" type="curve" smooth="yes"/>
+      <point x="426" y="299"/>
+      <point x="430" y="422"/>
+      <point x="434" y="559" type="curve"/>
+      <point x="485" y="553"/>
+      <point x="535" y="553"/>
+      <point x="578" y="553" type="curve" smooth="yes"/>
+      <point x="598" y="553"/>
+      <point x="621" y="553"/>
+      <point x="643" y="555" type="curve"/>
+      <point x="649" y="399"/>
+      <point x="657" y="270"/>
+      <point x="657" y="236" type="curve" smooth="yes"/>
+      <point x="657" y="119"/>
+      <point x="616" y="41"/>
     </contour>
     <contour>
-      <point x="169" y="299" type="line"/>
-      <point x="89" y="318"/>
-      <point x="79" y="358"/>
-      <point x="79" y="372" type="curve" smooth="yes"/>
-      <point x="79" y="384"/>
-      <point x="85" y="434"/>
-      <point x="184" y="453" type="curve"/>
+      <point x="346" y="612" type="line"/>
+      <point x="182" y="651"/>
+      <point x="162" y="733"/>
+      <point x="162" y="762" type="curve" smooth="yes"/>
+      <point x="162" y="786"/>
+      <point x="174" y="889"/>
+      <point x="377" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="281" y="288" type="curve" smooth="yes"/>
-      <point x="254" y="288"/>
-      <point x="233" y="289"/>
-      <point x="213" y="291" type="curve"/>
-      <point x="219" y="458" type="line"/>
-      <point x="234" y="459"/>
-      <point x="251" y="460"/>
-      <point x="270" y="460" type="curve" smooth="yes"/>
-      <point x="282" y="460"/>
-      <point x="293" y="459"/>
-      <point x="305" y="459" type="curve"/>
-      <point x="313" y="289" type="line"/>
-      <point x="302" y="288"/>
-      <point x="292" y="288"/>
+      <point x="575" y="590" type="curve" smooth="yes"/>
+      <point x="520" y="590"/>
+      <point x="477" y="592"/>
+      <point x="436" y="596" type="curve"/>
+      <point x="449" y="938" type="line"/>
+      <point x="479" y="940"/>
+      <point x="514" y="942"/>
+      <point x="553" y="942" type="curve" smooth="yes"/>
+      <point x="578" y="942"/>
+      <point x="600" y="940"/>
+      <point x="625" y="940" type="curve"/>
+      <point x="641" y="592" type="line"/>
+      <point x="618" y="590"/>
+      <point x="598" y="590"/>
     </contour>
     <contour>
-      <point x="356" y="295" type="curve"/>
-      <point x="337" y="457" type="line"/>
-      <point x="397" y="452"/>
-      <point x="457" y="439"/>
-      <point x="499" y="414" type="curve"/>
-      <point x="476" y="351"/>
-      <point x="428" y="311"/>
+      <point x="729" y="604" type="curve"/>
+      <point x="690" y="936" type="line"/>
+      <point x="813" y="926"/>
+      <point x="936" y="899"/>
+      <point x="1022" y="848" type="curve"/>
+      <point x="975" y="719"/>
+      <point x="877" y="637"/>
     </contour>
     <contour>
-      <point x="505" y="436" type="curve"/>
-      <point x="456" y="460"/>
-      <point x="390" y="471"/>
-      <point x="335" y="475" type="curve"/>
-      <point x="331" y="514"/>
-      <point x="329" y="548"/>
-      <point x="329" y="572" type="curve" smooth="yes"/>
-      <point x="329" y="636"/>
-      <point x="335" y="707"/>
-      <point x="409" y="707" type="curve" smooth="yes"/>
-      <point x="500" y="707"/>
-      <point x="516" y="593"/>
-      <point x="516" y="519" type="curve" smooth="yes"/>
-      <point x="516" y="488"/>
-      <point x="512" y="461"/>
+      <point x="1034" y="893" type="curve"/>
+      <point x="934" y="942"/>
+      <point x="799" y="965"/>
+      <point x="686" y="973" type="curve"/>
+      <point x="678" y="1053"/>
+      <point x="674" y="1122"/>
+      <point x="674" y="1171" type="curve" smooth="yes"/>
+      <point x="674" y="1303"/>
+      <point x="686" y="1448"/>
+      <point x="838" y="1448" type="curve" smooth="yes"/>
+      <point x="1024" y="1448"/>
+      <point x="1057" y="1214"/>
+      <point x="1057" y="1063" type="curve" smooth="yes"/>
+      <point x="1057" y="999"/>
+      <point x="1049" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-Thin.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="615"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="265" y="-10" type="curve" smooth="yes"/>
+      <point x="347" y="-10"/>
+      <point x="374" y="51"/>
+      <point x="374" y="117" type="curve" smooth="yes"/>
+      <point x="374" y="140"/>
+      <point x="366" y="204"/>
+      <point x="358" y="277" type="curve"/>
+      <point x="434" y="291"/>
+      <point x="500" y="326"/>
+      <point x="542" y="375" type="curve"/>
+      <point x="551" y="361"/>
+      <point x="556" y="345"/>
+      <point x="556" y="327" type="curve" smooth="yes"/>
+      <point x="556" y="281"/>
+      <point x="509" y="238"/>
+      <point x="491" y="224" type="curve"/>
+      <point x="525" y="224" type="line"/>
+      <point x="544" y="238"/>
+      <point x="586" y="281"/>
+      <point x="586" y="326" type="curve" smooth="yes"/>
+      <point x="586" y="354"/>
+      <point x="576" y="378"/>
+      <point x="559" y="397" type="curve"/>
+      <point x="580" y="427"/>
+      <point x="592" y="462"/>
+      <point x="592" y="500" type="curve" smooth="yes"/>
+      <point x="592" y="608"/>
+      <point x="521" y="725"/>
+      <point x="412" y="725" type="curve" smooth="yes"/>
+      <point x="329" y="725"/>
+      <point x="302" y="664"/>
+      <point x="302" y="569" type="curve" smooth="yes"/>
+      <point x="302" y="548"/>
+      <point x="303" y="515"/>
+      <point x="304" y="477" type="curve"/>
+      <point x="292" y="478"/>
+      <point x="281" y="478"/>
+      <point x="271" y="478" type="curve" smooth="yes"/>
+      <point x="260" y="478"/>
+      <point x="241" y="477"/>
+      <point x="220" y="475" type="curve"/>
+      <point x="222" y="613" type="line"/>
+      <point x="237" y="635"/>
+      <point x="251" y="658"/>
+      <point x="251" y="675" type="curve" smooth="yes"/>
+      <point x="251" y="681"/>
+      <point x="250" y="708"/>
+      <point x="223" y="708" type="curve" smooth="yes"/>
+      <point x="188" y="708"/>
+      <point x="200" y="669"/>
+      <point x="184" y="669" type="curve" smooth="yes"/>
+      <point x="164" y="669"/>
+      <point x="153" y="715"/>
+      <point x="105" y="715" type="curve" smooth="yes"/>
+      <point x="82" y="715"/>
+      <point x="41" y="702"/>
+      <point x="41" y="643" type="curve" smooth="yes"/>
+      <point x="41" y="603"/>
+      <point x="68" y="572"/>
+      <point x="112" y="572" type="curve" smooth="yes"/>
+      <point x="119" y="572"/>
+      <point x="126" y="573"/>
+      <point x="131" y="574" type="curve"/>
+      <point x="130" y="592" type="line"/>
+      <point x="126" y="591"/>
+      <point x="118" y="590"/>
+      <point x="112" y="590" type="curve" smooth="yes"/>
+      <point x="94" y="590"/>
+      <point x="88" y="606"/>
+      <point x="88" y="617" type="curve" smooth="yes"/>
+      <point x="88" y="630"/>
+      <point x="97" y="644"/>
+      <point x="116" y="644" type="curve" smooth="yes"/>
+      <point x="138" y="644"/>
+      <point x="185" y="625"/>
+      <point x="202" y="615" type="curve"/>
+      <point x="186" y="471" type="line"/>
+      <point x="124" y="460"/>
+      <point x="54" y="433"/>
+      <point x="54" y="369" type="curve" smooth="yes"/>
+      <point x="54" y="315"/>
+      <point x="107" y="290"/>
+      <point x="167" y="279" type="curve"/>
+      <point x="160" y="208"/>
+      <point x="156" y="144"/>
+      <point x="156" y="117" type="curve" smooth="yes"/>
+      <point x="156" y="51"/>
+      <point x="183" y="-10"/>
+    </contour>
+    <contour>
+      <point x="265" y="20" type="curve" smooth="yes"/>
+      <point x="228" y="20"/>
+      <point x="208" y="58"/>
+      <point x="208" y="115" type="curve" smooth="yes"/>
+      <point x="208" y="146"/>
+      <point x="210" y="206"/>
+      <point x="212" y="273" type="curve"/>
+      <point x="237" y="270"/>
+      <point x="261" y="270"/>
+      <point x="282" y="270" type="curve" smooth="yes"/>
+      <point x="292" y="270"/>
+      <point x="303" y="270"/>
+      <point x="314" y="271" type="curve"/>
+      <point x="317" y="195"/>
+      <point x="321" y="132"/>
+      <point x="321" y="115" type="curve" smooth="yes"/>
+      <point x="321" y="58"/>
+      <point x="301" y="20"/>
+    </contour>
+    <contour>
+      <point x="169" y="299" type="line"/>
+      <point x="89" y="318"/>
+      <point x="79" y="358"/>
+      <point x="79" y="372" type="curve" smooth="yes"/>
+      <point x="79" y="384"/>
+      <point x="85" y="434"/>
+      <point x="184" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="281" y="288" type="curve" smooth="yes"/>
+      <point x="254" y="288"/>
+      <point x="233" y="289"/>
+      <point x="213" y="291" type="curve"/>
+      <point x="219" y="458" type="line"/>
+      <point x="234" y="459"/>
+      <point x="251" y="460"/>
+      <point x="270" y="460" type="curve" smooth="yes"/>
+      <point x="282" y="460"/>
+      <point x="293" y="459"/>
+      <point x="305" y="459" type="curve"/>
+      <point x="313" y="289" type="line"/>
+      <point x="302" y="288"/>
+      <point x="292" y="288"/>
+    </contour>
+    <contour>
+      <point x="356" y="295" type="curve"/>
+      <point x="337" y="457" type="line"/>
+      <point x="397" y="452"/>
+      <point x="457" y="439"/>
+      <point x="499" y="414" type="curve"/>
+      <point x="476" y="351"/>
+      <point x="428" y="311"/>
+    </contour>
+    <contour>
+      <point x="505" y="436" type="curve"/>
+      <point x="456" y="460"/>
+      <point x="390" y="471"/>
+      <point x="335" y="475" type="curve"/>
+      <point x="331" y="514"/>
+      <point x="329" y="548"/>
+      <point x="329" y="572" type="curve" smooth="yes"/>
+      <point x="329" y="636"/>
+      <point x="335" y="707"/>
+      <point x="409" y="707" type="curve" smooth="yes"/>
+      <point x="500" y="707"/>
+      <point x="516" y="593"/>
+      <point x="516" y="519" type="curve" smooth="yes"/>
+      <point x="516" y="488"/>
+      <point x="512" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:29 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-Thin.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-Thin.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="1045"/>
+  <unicode hex="214E"/>
+  <anchor x="541" y="10" name="bottom"/>
+  <anchor x="1075" y="-407" name="bottom_dd"/>
+  <anchor x="629" y="1320" name="parent_top"/>
+  <anchor x="629" y="1320" name="top"/>
+  <anchor x="1075" y="1320" name="top0315"/>
+  <anchor x="1075" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="791" y="0" type="line"/>
+      <point x="845" y="0" type="line"/>
+      <point x="845" y="1082" type="line"/>
+      <point x="791" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="70" y="0" type="line"/>
+      <point x="825" y="0" type="line"/>
+      <point x="825" y="55" type="line"/>
+      <point x="70" y="55" type="line"/>
+    </contour>
+    <contour>
+      <point x="158" y="545" type="line"/>
+      <point x="825" y="545" type="line"/>
+      <point x="825" y="600" type="line"/>
+      <point x="158" y="600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:29 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-Thin.ufo/lib.plist
+++ b/sources/Roboto-Thin.ufo/lib.plist
@@ -6890,6 +6890,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/Roboto-ThinItalic.ufo/fontinfo.plist
+++ b/sources/Roboto-ThinItalic.ufo/fontinfo.plist
@@ -339,7 +339,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/contents.plist
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="1027"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="33" y="0" type="line"/>
+      <point x="383" y="0" type="line" smooth="yes"/>
+      <point x="664" y="0"/>
+      <point x="887" y="141"/>
+      <point x="887" y="461" type="curve" smooth="yes"/>
+      <point x="887" y="623"/>
+      <point x="809" y="729"/>
+      <point x="660" y="766" type="curve"/>
+      <point x="662" y="770" type="line"/>
+      <point x="869" y="807"/>
+      <point x="996" y="952"/>
+      <point x="996" y="1174" type="curve" smooth="yes"/>
+      <point x="996" y="1346"/>
+      <point x="881" y="1456"/>
+      <point x="633" y="1456" type="curve" smooth="yes"/>
+      <point x="343" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="166" y="-201" type="line"/>
+      <point x="220" y="-201" type="line"/>
+      <point x="271" y="39" type="line"/>
+      <point x="218" y="39" type="line"/>
+    </contour>
+    <contour>
+      <point x="410" y="-201" type="line"/>
+      <point x="463" y="-201" type="line"/>
+      <point x="515" y="39" type="line"/>
+      <point x="461" y="39" type="line"/>
+    </contour>
+    <contour>
+      <point x="99" y="51" type="line"/>
+      <point x="246" y="743" type="line"/>
+      <point x="484" y="743" type="line" smooth="yes"/>
+      <point x="693" y="743"/>
+      <point x="832" y="664"/>
+      <point x="832" y="461" type="curve" smooth="yes"/>
+      <point x="832" y="168"/>
+      <point x="627" y="51"/>
+      <point x="408" y="51" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="256" y="795" type="line"/>
+      <point x="388" y="1405" type="line"/>
+      <point x="621" y="1405" type="line" smooth="yes"/>
+      <point x="830" y="1405"/>
+      <point x="941" y="1323"/>
+      <point x="941" y="1171" type="curve" smooth="yes"/>
+      <point x="941" y="911"/>
+      <point x="756" y="795"/>
+      <point x="500" y="795" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="512" y="1419" type="line"/>
+      <point x="566" y="1419" type="line"/>
+      <point x="617" y="1663" type="line"/>
+      <point x="564" y="1663" type="line"/>
+    </contour>
+    <contour>
+      <point x="756" y="1419" type="line"/>
+      <point x="809" y="1419" type="line"/>
+      <point x="861" y="1663" type="line"/>
+      <point x="807" y="1663" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2104.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="1101"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="303" y="0" type="line"/>
+      <point x="946" y="0" type="line"/>
+      <point x="955" y="51" type="line"/>
+      <point x="365" y="51" type="line"/>
+      <point x="427" y="424" type="line"/>
+      <point x="501" y="426"/>
+      <point x="557" y="440"/>
+      <point x="600" y="457" type="curve"/>
+      <point x="610" y="512" type="line"/>
+      <point x="559" y="492"/>
+      <point x="504" y="479"/>
+      <point x="436" y="477" type="curve"/>
+      <point x="550" y="1159" type="line"/>
+      <point x="609" y="1157"/>
+      <point x="654" y="1147"/>
+      <point x="705" y="1128" type="curve"/>
+      <point x="727" y="1180" type="line"/>
+      <point x="682" y="1200"/>
+      <point x="631" y="1212"/>
+      <point x="559" y="1212" type="curve"/>
+      <point x="601" y="1462" type="line"/>
+      <point x="548" y="1462" type="line"/>
+      <point x="505" y="1210" type="line"/>
+      <point x="324" y="1190"/>
+      <point x="203" y="1044"/>
+      <point x="165" y="817" type="curve" smooth="yes"/>
+      <point x="125" y="582"/>
+      <point x="194" y="440"/>
+      <point x="374" y="426" type="curve"/>
+    </contour>
+    <contour>
+      <point x="383" y="479" type="line"/>
+      <point x="238" y="494"/>
+      <point x="193" y="618"/>
+      <point x="227" y="819" type="curve" smooth="yes"/>
+      <point x="261" y="1024"/>
+      <point x="354" y="1139"/>
+      <point x="497" y="1157" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2107.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="1087"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1285"/>
+  <unicode hex="2108"/>
+  <anchor x="849.897" y="1634" name="parent_top"/>
+  <anchor x="849.897" y="1634" name="top"/>
+  <anchor x="1463.907" y="1634" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="532.258" y="-19.903" type="curve" smooth="yes"/>
+      <point x="884.823" y="-18.857"/>
+      <point x="1094.434" y="304.331"/>
+      <point x="1150.299" y="618.962" type="curve" smooth="yes"/>
+      <point x="1187.631" y="837.015" type="line" smooth="yes"/>
+      <point x="1236.037" y="1133.819"/>
+      <point x="1134.806" y="1475.005"/>
+      <point x="781.423" y="1475.93" type="curve" smooth="yes"/>
+      <point x="485.721" y="1476.703"/>
+      <point x="279.622" y="1290.271"/>
+      <point x="202.142" y="1012.851" type="curve"/>
+      <point x="256.529" y="1012.74" type="line"/>
+      <point x="334.841" y="1258.975"/>
+      <point x="515.494" y="1422.746"/>
+      <point x="782.048" y="1421.88" type="curve" smooth="yes"/>
+      <point x="1102.88" y="1420.837"/>
+      <point x="1178.398" y="1101.774"/>
+      <point x="1134.069" y="838.984" type="curve" smooth="yes"/>
+      <point x="1095.598" y="619.024" type="line" smooth="yes"/>
+      <point x="1043.349" y="334.885"/>
+      <point x="851.567" y="35.336"/>
+      <point x="531.62" y="34.1" type="curve" smooth="yes"/>
+      <point x="270.368" y="33.091"/>
+      <point x="142.138" y="192.029"/>
+      <point x="156.72" y="445.976" type="curve"/>
+      <point x="103.44" y="446.07" type="line"/>
+      <point x="88.847" y="164.965"/>
+      <point x="244.184" y="-20.758"/>
+    </contour>
+    <contour>
+      <point x="1121.017" y="710.25" type="line"/>
+      <point x="1128.392" y="763.746" type="line"/>
+      <point x="497.447" y="763.749" type="line"/>
+      <point x="490.073" y="710.253" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2108.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2108.glif
@@ -37,10 +37,10 @@
       <point x="244.184" y="-20.758"/>
     </contour>
     <contour>
+      <point x="490.073" y="710.253" type="line"/>
       <point x="1121.017" y="710.25" type="line"/>
       <point x="1128.392" y="763.746" type="line"/>
       <point x="497.447" y="763.749" type="line"/>
-      <point x="490.073" y="710.253" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1645"/>
+  <unicode hex="2114"/>
+  <anchor x="1018.083" y="-10" name="bottom"/>
+  <anchor x="1470.378" y="-407" name="bottom_dd"/>
+  <anchor x="699.802" y="1503" name="marktop"/>
+  <anchor x="1291.545" y="1612" name="parent_top"/>
+  <anchor x="1291.545" y="1612" name="top"/>
+  <anchor x="1819.225" y="1612" name="top0315"/>
+  <anchor x="1817.152" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1030" y="-20" type="curve" smooth="yes"/>
+      <point x="1325" y="-19"/>
+      <point x="1471" y="279"/>
+      <point x="1515" y="531" type="curve" smooth="yes"/>
+      <point x="1519" y="552" type="line" smooth="yes"/>
+      <point x="1557" y="789"/>
+      <point x="1515" y="1102"/>
+      <point x="1213" y="1102" type="curve" smooth="yes"/>
+      <point x="1006" y="1102"/>
+      <point x="804" y="946"/>
+      <point x="747" y="745" type="curve"/>
+      <point x="673" y="304" type="line"/>
+      <point x="662" y="105"/>
+      <point x="850" y="-20"/>
+    </contour>
+    <contour>
+      <point x="160" y="0" type="line"/>
+      <point x="214" y="0" type="line"/>
+      <point x="478" y="1536" type="line"/>
+      <point x="424" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="618" y="0" type="line"/>
+      <point x="672" y="0" type="line"/>
+      <point x="708" y="210" type="line"/>
+      <point x="937" y="1536" type="line"/>
+      <point x="883" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="1030" y="34" type="curve" smooth="yes"/>
+      <point x="864" y="34"/>
+      <point x="700" y="145"/>
+      <point x="712" y="329" type="curve"/>
+      <point x="779" y="709" type="line"/>
+      <point x="835" y="900"/>
+      <point x="1015" y="1048"/>
+      <point x="1214" y="1048" type="curve" smooth="yes"/>
+      <point x="1483" y="1048"/>
+      <point x="1497" y="752"/>
+      <point x="1463" y="552" type="curve" smooth="yes"/>
+      <point x="1459" y="531" type="line" smooth="yes"/>
+      <point x="1418" y="308"/>
+      <point x="1295" y="35"/>
+    </contour>
+    <contour>
+      <point x="179" y="1281" type="line"/>
+      <point x="1214" y="1281" type="line"/>
+      <point x="1221" y="1335" type="line"/>
+      <point x="186" y="1335" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2114.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="786"/>
+  <advance width="1534"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="175" y="-241" type="curve" smooth="yes"/>
-      <point x="242" y="-241"/>
-      <point x="288" y="-180"/>
-      <point x="288" y="-95" type="curve" smooth="yes"/>
-      <point x="288" y="8"/>
-      <point x="199" y="99"/>
-      <point x="144" y="200" type="curve"/>
-      <point x="190" y="272"/>
-      <point x="249" y="341"/>
-      <point x="308" y="394" type="curve" smooth="yes"/>
-      <point x="373" y="452"/>
-      <point x="442" y="492"/>
-      <point x="500" y="492" type="curve" smooth="yes"/>
-      <point x="599" y="492"/>
-      <point x="606" y="359"/>
-      <point x="606" y="322" type="curve" smooth="yes"/>
-      <point x="606" y="285"/>
-      <point x="594" y="30"/>
-      <point x="435" y="30" type="curve" smooth="yes"/>
-      <point x="385" y="30"/>
-      <point x="337" y="57"/>
-      <point x="337" y="112" type="curve" smooth="yes"/>
-      <point x="337" y="119"/>
-      <point x="338" y="126"/>
-      <point x="340" y="132" type="curve"/>
-      <point x="372" y="136"/>
-      <point x="404" y="151"/>
-      <point x="404" y="194" type="curve" smooth="yes"/>
-      <point x="404" y="225"/>
-      <point x="383" y="244"/>
-      <point x="353" y="244" type="curve" smooth="yes"/>
-      <point x="306" y="244"/>
-      <point x="278" y="206"/>
-      <point x="278" y="140" type="curve" smooth="yes"/>
-      <point x="278" y="51"/>
-      <point x="339" y="-10"/>
-      <point x="442" y="-10" type="curve" smooth="yes"/>
-      <point x="614" y="-10"/>
-      <point x="705" y="159"/>
-      <point x="705" y="306" type="curve" smooth="yes"/>
-      <point x="705" y="437"/>
-      <point x="646" y="549"/>
-      <point x="529" y="549" type="curve" smooth="yes"/>
-      <point x="480" y="549"/>
-      <point x="388" y="512"/>
-      <point x="285" y="419" type="curve" smooth="yes"/>
-      <point x="234" y="373"/>
-      <point x="175" y="310"/>
-      <point x="125" y="238" type="curve"/>
-      <point x="110" y="272"/>
-      <point x="101" y="307"/>
-      <point x="101" y="345" type="curve" smooth="yes"/>
-      <point x="101" y="474"/>
-      <point x="130" y="548"/>
-      <point x="208" y="625" type="curve"/>
-      <point x="193" y="647" type="line"/>
-      <point x="136" y="610"/>
-      <point x="16" y="496"/>
-      <point x="16" y="337" type="curve" smooth="yes"/>
-      <point x="16" y="267"/>
-      <point x="39" y="206"/>
-      <point x="70" y="149" type="curve"/>
-      <point x="36" y="85"/>
-      <point x="11" y="11"/>
-      <point x="11" y="-56" type="curve" smooth="yes"/>
-      <point x="11" y="-163"/>
-      <point x="82" y="-241"/>
+      <point x="401" y="-494" type="curve" smooth="yes"/>
+      <point x="538" y="-494"/>
+      <point x="632" y="-369"/>
+      <point x="632" y="-195" type="curve" smooth="yes"/>
+      <point x="632" y="16"/>
+      <point x="450" y="203"/>
+      <point x="337" y="410" type="curve"/>
+      <point x="432" y="557"/>
+      <point x="552" y="698"/>
+      <point x="673" y="807" type="curve" smooth="yes"/>
+      <point x="806" y="926"/>
+      <point x="948" y="1008"/>
+      <point x="1066" y="1008" type="curve" smooth="yes"/>
+      <point x="1269" y="1008"/>
+      <point x="1284" y="735"/>
+      <point x="1284" y="659" type="curve" smooth="yes"/>
+      <point x="1284" y="584"/>
+      <point x="1259" y="61"/>
+      <point x="933" y="61" type="curve" smooth="yes"/>
+      <point x="831" y="61"/>
+      <point x="733" y="117"/>
+      <point x="733" y="229" type="curve" smooth="yes"/>
+      <point x="733" y="244"/>
+      <point x="735" y="258"/>
+      <point x="739" y="270" type="curve"/>
+      <point x="804" y="279"/>
+      <point x="870" y="309"/>
+      <point x="870" y="397" type="curve" smooth="yes"/>
+      <point x="870" y="461"/>
+      <point x="827" y="500"/>
+      <point x="765" y="500" type="curve" smooth="yes"/>
+      <point x="669" y="500"/>
+      <point x="612" y="422"/>
+      <point x="612" y="287" type="curve" smooth="yes"/>
+      <point x="612" y="104"/>
+      <point x="737" y="-20"/>
+      <point x="948" y="-20" type="curve" smooth="yes"/>
+      <point x="1300" y="-20"/>
+      <point x="1486" y="326"/>
+      <point x="1486" y="627" type="curve" smooth="yes"/>
+      <point x="1486" y="895"/>
+      <point x="1365" y="1124"/>
+      <point x="1126" y="1124" type="curve" smooth="yes"/>
+      <point x="1025" y="1124"/>
+      <point x="837" y="1049"/>
+      <point x="626" y="858" type="curve" smooth="yes"/>
+      <point x="522" y="764"/>
+      <point x="401" y="635"/>
+      <point x="298" y="487" type="curve"/>
+      <point x="268" y="557"/>
+      <point x="249" y="629"/>
+      <point x="249" y="707" type="curve" smooth="yes"/>
+      <point x="249" y="971"/>
+      <point x="309" y="1122"/>
+      <point x="468" y="1280" type="curve"/>
+      <point x="438" y="1325" type="line"/>
+      <point x="321" y="1249"/>
+      <point x="75" y="1016"/>
+      <point x="75" y="690" type="curve" smooth="yes"/>
+      <point x="75" y="547"/>
+      <point x="122" y="422"/>
+      <point x="186" y="305" type="curve"/>
+      <point x="116" y="174"/>
+      <point x="65" y="23"/>
+      <point x="65" y="-115" type="curve" smooth="yes"/>
+      <point x="65" y="-334"/>
+      <point x="210" y="-494"/>
     </contour>
     <contour>
-      <point x="158" y="-199" type="curve" smooth="yes"/>
-      <point x="114" y="-199"/>
-      <point x="50" y="-145"/>
-      <point x="50" y="-51" type="curve" smooth="yes"/>
-      <point x="50" y="-4"/>
-      <point x="66" y="52"/>
-      <point x="93" y="110" type="curve"/>
-      <point x="144" y="24"/>
-      <point x="204" y="-52"/>
-      <point x="204" y="-134" type="curve" smooth="yes"/>
-      <point x="204" y="-176"/>
-      <point x="186" y="-199"/>
+      <point x="366" y="-408" type="curve" smooth="yes"/>
+      <point x="276" y="-408"/>
+      <point x="145" y="-297"/>
+      <point x="145" y="-104" type="curve" smooth="yes"/>
+      <point x="145" y="-8"/>
+      <point x="178" y="106"/>
+      <point x="233" y="225" type="curve"/>
+      <point x="337" y="49"/>
+      <point x="460" y="-106"/>
+      <point x="460" y="-274" type="curve" smooth="yes"/>
+      <point x="460" y="-360"/>
+      <point x="423" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2118.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="786"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="175" y="-241" type="curve" smooth="yes"/>
+      <point x="242" y="-241"/>
+      <point x="288" y="-180"/>
+      <point x="288" y="-95" type="curve" smooth="yes"/>
+      <point x="288" y="8"/>
+      <point x="199" y="99"/>
+      <point x="144" y="200" type="curve"/>
+      <point x="190" y="272"/>
+      <point x="249" y="341"/>
+      <point x="308" y="394" type="curve" smooth="yes"/>
+      <point x="373" y="452"/>
+      <point x="442" y="492"/>
+      <point x="500" y="492" type="curve" smooth="yes"/>
+      <point x="599" y="492"/>
+      <point x="606" y="359"/>
+      <point x="606" y="322" type="curve" smooth="yes"/>
+      <point x="606" y="285"/>
+      <point x="594" y="30"/>
+      <point x="435" y="30" type="curve" smooth="yes"/>
+      <point x="385" y="30"/>
+      <point x="337" y="57"/>
+      <point x="337" y="112" type="curve" smooth="yes"/>
+      <point x="337" y="119"/>
+      <point x="338" y="126"/>
+      <point x="340" y="132" type="curve"/>
+      <point x="372" y="136"/>
+      <point x="404" y="151"/>
+      <point x="404" y="194" type="curve" smooth="yes"/>
+      <point x="404" y="225"/>
+      <point x="383" y="244"/>
+      <point x="353" y="244" type="curve" smooth="yes"/>
+      <point x="306" y="244"/>
+      <point x="278" y="206"/>
+      <point x="278" y="140" type="curve" smooth="yes"/>
+      <point x="278" y="51"/>
+      <point x="339" y="-10"/>
+      <point x="442" y="-10" type="curve" smooth="yes"/>
+      <point x="614" y="-10"/>
+      <point x="705" y="159"/>
+      <point x="705" y="306" type="curve" smooth="yes"/>
+      <point x="705" y="437"/>
+      <point x="646" y="549"/>
+      <point x="529" y="549" type="curve" smooth="yes"/>
+      <point x="480" y="549"/>
+      <point x="388" y="512"/>
+      <point x="285" y="419" type="curve" smooth="yes"/>
+      <point x="234" y="373"/>
+      <point x="175" y="310"/>
+      <point x="125" y="238" type="curve"/>
+      <point x="110" y="272"/>
+      <point x="101" y="307"/>
+      <point x="101" y="345" type="curve" smooth="yes"/>
+      <point x="101" y="474"/>
+      <point x="130" y="548"/>
+      <point x="208" y="625" type="curve"/>
+      <point x="193" y="647" type="line"/>
+      <point x="136" y="610"/>
+      <point x="16" y="496"/>
+      <point x="16" y="337" type="curve" smooth="yes"/>
+      <point x="16" y="267"/>
+      <point x="39" y="206"/>
+      <point x="70" y="149" type="curve"/>
+      <point x="36" y="85"/>
+      <point x="11" y="11"/>
+      <point x="11" y="-56" type="curve" smooth="yes"/>
+      <point x="11" y="-163"/>
+      <point x="82" y="-241"/>
+    </contour>
+    <contour>
+      <point x="158" y="-199" type="curve" smooth="yes"/>
+      <point x="114" y="-199"/>
+      <point x="50" y="-145"/>
+      <point x="50" y="-51" type="curve" smooth="yes"/>
+      <point x="50" y="-4"/>
+      <point x="66" y="52"/>
+      <point x="93" y="110" type="curve"/>
+      <point x="144" y="24"/>
+      <point x="204" y="-52"/>
+      <point x="204" y="-134" type="curve" smooth="yes"/>
+      <point x="204" y="-176"/>
+      <point x="186" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2127.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1281"/>
+  <advance width="1342"/>
   <unicode hex="2127"/>
-  <anchor x="821.891" y="1446" name="top"/>
+  <anchor x="798" y="1446" name="top"/>
   <outline>
     <contour>
-      <point x="583" y="-20" type="curve" smooth="yes"/>
-      <point x="928" y="-20"/>
-      <point x="1134" y="300"/>
-      <point x="1189" y="607" type="curve" smooth="yes"/>
-      <point x="1209" y="724" type="line" smooth="yes"/>
-      <point x="1255" y="1006"/>
-      <point x="1191" y="1295"/>
-      <point x="923" y="1437" type="curve"/>
-      <point x="914" y="1378" type="line"/>
-      <point x="1157" y="1245"/>
-      <point x="1198" y="978"/>
-      <point x="1155" y="724" type="curve" smooth="yes"/>
-      <point x="1134" y="605" type="line" smooth="yes"/>
-      <point x="1083" y="332"/>
-      <point x="890" y="34"/>
-      <point x="582" y="34" type="curve" smooth="yes"/>
-      <point x="273" y="34"/>
-      <point x="193" y="352"/>
-      <point x="236" y="605" type="curve" smooth="yes"/>
-      <point x="257" y="724" type="line" smooth="yes"/>
-      <point x="309" y="1010"/>
-      <point x="458" y="1244"/>
-      <point x="718" y="1378" type="curve"/>
-      <point x="726" y="1436" type="line"/>
-      <point x="430" y="1312"/>
-      <point x="257" y="1033"/>
-      <point x="202" y="724" type="curve" smooth="yes"/>
-      <point x="182" y="607" type="line" smooth="yes"/>
-      <point x="135" y="317"/>
-      <point x="237" y="-20"/>
+      <point x="559" y="-20" type="curve" smooth="yes"/>
+      <point x="904" y="-20"/>
+      <point x="1110" y="300"/>
+      <point x="1165" y="607" type="curve" smooth="yes"/>
+      <point x="1185" y="724" type="line" smooth="yes"/>
+      <point x="1231" y="1006"/>
+      <point x="1167" y="1295"/>
+      <point x="899" y="1437" type="curve"/>
+      <point x="890" y="1378" type="line"/>
+      <point x="1133" y="1245"/>
+      <point x="1174" y="978"/>
+      <point x="1131" y="724" type="curve" smooth="yes"/>
+      <point x="1110" y="605" type="line" smooth="yes"/>
+      <point x="1059" y="332"/>
+      <point x="866" y="34"/>
+      <point x="558" y="34" type="curve" smooth="yes"/>
+      <point x="249" y="34"/>
+      <point x="169" y="352"/>
+      <point x="212" y="605" type="curve" smooth="yes"/>
+      <point x="233" y="724" type="line" smooth="yes"/>
+      <point x="285" y="1010"/>
+      <point x="434" y="1244"/>
+      <point x="694" y="1378" type="curve"/>
+      <point x="702" y="1436" type="line"/>
+      <point x="406" y="1312"/>
+      <point x="233" y="1033"/>
+      <point x="178" y="724" type="curve" smooth="yes"/>
+      <point x="158" y="607" type="line" smooth="yes"/>
+      <point x="111" y="317"/>
+      <point x="213" y="-20"/>
     </contour>
     <contour>
-      <point x="300" y="1402" type="line"/>
-      <point x="723" y="1402" type="line"/>
-      <point x="730" y="1456" type="line"/>
-      <point x="308" y="1456" type="line"/>
+      <point x="276" y="1402" type="line"/>
+      <point x="699" y="1402" type="line"/>
+      <point x="706" y="1456" type="line"/>
+      <point x="284" y="1456" type="line"/>
     </contour>
     <contour>
-      <point x="919" y="1402" type="line"/>
-      <point x="1343" y="1402" type="line"/>
-      <point x="1350" y="1456" type="line"/>
-      <point x="927" y="1456" type="line"/>
+      <point x="895" y="1402" type="line"/>
+      <point x="1319" y="1402" type="line"/>
+      <point x="1326" y="1456" type="line"/>
+      <point x="903" y="1456" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2127.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1281"/>
+  <unicode hex="2127"/>
+  <anchor x="821.891" y="1446" name="top"/>
+  <outline>
+    <contour>
+      <point x="583" y="-20" type="curve" smooth="yes"/>
+      <point x="928" y="-20"/>
+      <point x="1134" y="300"/>
+      <point x="1189" y="607" type="curve" smooth="yes"/>
+      <point x="1209" y="724" type="line" smooth="yes"/>
+      <point x="1255" y="1006"/>
+      <point x="1191" y="1295"/>
+      <point x="923" y="1437" type="curve"/>
+      <point x="914" y="1378" type="line"/>
+      <point x="1157" y="1245"/>
+      <point x="1198" y="978"/>
+      <point x="1155" y="724" type="curve" smooth="yes"/>
+      <point x="1134" y="605" type="line" smooth="yes"/>
+      <point x="1083" y="332"/>
+      <point x="890" y="34"/>
+      <point x="582" y="34" type="curve" smooth="yes"/>
+      <point x="273" y="34"/>
+      <point x="193" y="352"/>
+      <point x="236" y="605" type="curve" smooth="yes"/>
+      <point x="257" y="724" type="line" smooth="yes"/>
+      <point x="309" y="1010"/>
+      <point x="458" y="1244"/>
+      <point x="718" y="1378" type="curve"/>
+      <point x="726" y="1436" type="line"/>
+      <point x="430" y="1312"/>
+      <point x="257" y="1033"/>
+      <point x="202" y="724" type="curve" smooth="yes"/>
+      <point x="182" y="607" type="line" smooth="yes"/>
+      <point x="135" y="317"/>
+      <point x="237" y="-20"/>
+    </contour>
+    <contour>
+      <point x="300" y="1402" type="line"/>
+      <point x="723" y="1402" type="line"/>
+      <point x="730" y="1456" type="line"/>
+      <point x="308" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="919" y="1402" type="line"/>
+      <point x="1343" y="1402" type="line"/>
+      <point x="1350" y="1456" type="line"/>
+      <point x="927" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="548"/>
+  <unicode hex="2129"/>
+  <anchor x="240.289" y="-196" name="bottom"/>
+  <anchor x="-117.641" y="-196" name="bottom0315"/>
+  <anchor x="240.289" y="-196" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="244" y="-9" type="line"/>
+      <point x="299" y="-9" type="line"/>
+      <point x="438" y="802" type="line" smooth="yes"/>
+      <point x="461" y="947"/>
+      <point x="438" y="1080"/>
+      <point x="268" y="1081" type="curve" smooth="yes"/>
+      <point x="231" y="1081"/>
+      <point x="195" y="1078"/>
+      <point x="159" y="1069" type="curve"/>
+      <point x="161" y="1018" type="line"/>
+      <point x="197" y="1022"/>
+      <point x="233" y="1027"/>
+      <point x="269" y="1027" type="curve" smooth="yes"/>
+      <point x="401" y="1025"/>
+      <point x="401" y="906"/>
+      <point x="384" y="802" type="curve" smooth="yes"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2129.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="409"/>
+  <unicode hex="2139"/>
+  <anchor x="101.759" y="10" name="bottom"/>
+  <anchor x="235.348" y="-407" name="bottom_dd"/>
+  <anchor x="384.242" y="1600" name="parent_top"/>
+  <anchor x="214.97" y="654" name="rhotichook"/>
+  <anchor x="384.242" y="1600" name="top"/>
+  <anchor x="582.122" y="1600" name="top0315"/>
+  <anchor x="582.122" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2139.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2139.glif
@@ -2,13 +2,13 @@
 <glyph name="uni2139" format="2">
   <advance width="409"/>
   <unicode hex="2139"/>
-  <anchor x="101.759" y="10" name="bottom"/>
-  <anchor x="235.348" y="-407" name="bottom_dd"/>
-  <anchor x="384.242" y="1600" name="parent_top"/>
-  <anchor x="214.97" y="654" name="rhotichook"/>
-  <anchor x="384.242" y="1600" name="top"/>
-  <anchor x="582.122" y="1600" name="top0315"/>
-  <anchor x="582.122" y="1600" name="top_dd"/>
+  <anchor x="101.759" y="10.0" name="bottom"/>
+  <anchor x="235.348" y="-407.0" name="bottom_dd"/>
+  <anchor x="384.242" y="1600.0" name="parent_top"/>
+  <anchor x="214.97" y="654.0" name="rhotichook"/>
+  <anchor x="384.242" y="1600.0" name="top"/>
+  <anchor x="582.122" y="1600.0" name="top0315"/>
+  <anchor x="582.122" y="1600.0" name="top_dd"/>
   <outline>
     <component base="i"/>
   </outline>
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni213A_.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni213A" format="2">
-  <advance width="1777"/>
+  <advance width="1766"/>
   <unicode hex="213A"/>
-  <anchor x="1627.58" y="679.715" name="bottom"/>
-  <anchor x="1918.28" y="1317.306" name="bottom_dd"/>
-  <anchor x="-6.603" y="676.004" name="parent_top"/>
-  <anchor x="-6.603" y="676.004" name="top"/>
-  <anchor x="-118.446" y="1310.299" name="top0315"/>
-  <anchor x="-118.446" y="1310.299" name="top_dd"/>
+  <anchor x="1682" y="686" name="bottom"/>
+  <anchor x="2190" y="1352" name="bottom_dd"/>
+  <anchor x="72" y="688" name="parent_top"/>
+  <anchor x="72" y="688" name="top"/>
+  <anchor x="183" y="1352" name="top0315"/>
+  <anchor x="183" y="1352" name="top_dd"/>
   <outline>
     <contour>
-      <point x="863" y="136" type="curve" smooth="yes"/>
-      <point x="1085" y="137" type="line" smooth="yes"/>
-      <point x="1397" y="142"/>
-      <point x="1702" y="318"/>
-      <point x="1639" y="670" type="curve" smooth="yes"/>
-      <point x="1577" y="1024"/>
-      <point x="1229" y="1188"/>
-      <point x="899" y="1188" type="curve" smooth="yes"/>
-      <point x="678" y="1187" type="line" smooth="yes"/>
-      <point x="365" y="1183"/>
-      <point x="61" y="1007"/>
-      <point x="123" y="654" type="curve" smooth="yes"/>
-      <point x="186" y="301"/>
-      <point x="534" y="137"/>
+      <point x="650" y="121" type="curve"/>
+      <point x="868" y="121" type="line"/>
+      <point x="1278" y="121"/>
+      <point x="1543" y="337"/>
+      <point x="1599" y="671" type="curve" smooth="yes"/>
+      <point x="1655" y="1006"/>
+      <point x="1432" y="1219"/>
+      <point x="1052" y="1219" type="curve"/>
+      <point x="834" y="1219" type="line"/>
+      <point x="424" y="1219"/>
+      <point x="159" y="1004"/>
+      <point x="103" y="669" type="curve" smooth="yes"/>
+      <point x="47" y="335"/>
+      <point x="280" y="121"/>
     </contour>
     <contour>
-      <point x="852" y="191" type="line" smooth="yes"/>
-      <point x="552" y="193"/>
-      <point x="233" y="342"/>
-      <point x="176" y="664" type="curve" smooth="yes"/>
-      <point x="119" y="989"/>
-      <point x="403" y="1132"/>
-      <point x="685" y="1134" type="curve" smooth="yes"/>
-      <point x="909" y="1134" type="line" smooth="yes"/>
-      <point x="1210" y="1132"/>
-      <point x="1529" y="984"/>
-      <point x="1586" y="660" type="curve" smooth="yes"/>
-      <point x="1643" y="335"/>
-      <point x="1356" y="193"/>
-      <point x="1075" y="191" type="curve" smooth="yes"/>
+      <point x="657" y="176" type="line" smooth="yes"/>
+      <point x="316" y="176"/>
+      <point x="104" y="357"/>
+      <point x="157" y="669" type="curve" smooth="yes"/>
+      <point x="209" y="983"/>
+      <point x="482" y="1165"/>
+      <point x="823" y="1165" type="curve"/>
+      <point x="1043" y="1165" type="line"/>
+      <point x="1379" y="1165"/>
+      <point x="1588" y="987"/>
+      <point x="1545" y="671" type="curve" smooth="yes"/>
+      <point x="1503" y="359"/>
+      <point x="1220" y="176"/>
+      <point x="877" y="176" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="1564" y="826" type="line"/>
-      <point x="1807" y="1118" type="line"/>
-      <point x="1767" y="1153" type="line"/>
-      <point x="1521" y="863" type="line"/>
+      <point x="1582" y="841" type="line"/>
+      <point x="1921" y="1140" type="line"/>
+      <point x="1892" y="1179" type="line"/>
+      <point x="1551" y="882" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni213A_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1777"/>
+  <unicode hex="213A"/>
+  <anchor x="1627.58" y="679.715" name="bottom"/>
+  <anchor x="1918.28" y="1317.306" name="bottom_dd"/>
+  <anchor x="-6.603" y="676.004" name="parent_top"/>
+  <anchor x="-6.603" y="676.004" name="top"/>
+  <anchor x="-118.446" y="1310.299" name="top0315"/>
+  <anchor x="-118.446" y="1310.299" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="863" y="136" type="curve" smooth="yes"/>
+      <point x="1085" y="137" type="line" smooth="yes"/>
+      <point x="1397" y="142"/>
+      <point x="1702" y="318"/>
+      <point x="1639" y="670" type="curve" smooth="yes"/>
+      <point x="1577" y="1024"/>
+      <point x="1229" y="1188"/>
+      <point x="899" y="1188" type="curve" smooth="yes"/>
+      <point x="678" y="1187" type="line" smooth="yes"/>
+      <point x="365" y="1183"/>
+      <point x="61" y="1007"/>
+      <point x="123" y="654" type="curve" smooth="yes"/>
+      <point x="186" y="301"/>
+      <point x="534" y="137"/>
+    </contour>
+    <contour>
+      <point x="852" y="191" type="line" smooth="yes"/>
+      <point x="552" y="193"/>
+      <point x="233" y="342"/>
+      <point x="176" y="664" type="curve" smooth="yes"/>
+      <point x="119" y="989"/>
+      <point x="403" y="1132"/>
+      <point x="685" y="1134" type="curve" smooth="yes"/>
+      <point x="909" y="1134" type="line" smooth="yes"/>
+      <point x="1210" y="1132"/>
+      <point x="1529" y="984"/>
+      <point x="1586" y="660" type="curve" smooth="yes"/>
+      <point x="1643" y="335"/>
+      <point x="1356" y="193"/>
+      <point x="1075" y="191" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1564" y="826" type="line"/>
+      <point x="1807" y="1118" type="line"/>
+      <point x="1767" y="1153" type="line"/>
+      <point x="1521" y="863" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1363"/>
+  <unicode hex="2141"/>
+  <anchor x="582.606" y="-177" name="bottom"/>
+  <anchor x="-99.304" y="-177" name="bottom0315"/>
+  <anchor x="-93.602" y="-144" name="bottom_dd"/>
+  <anchor x="582.606" y="-177" name="parent_bottom"/>
+  <anchor x="839.539" y="1456" name="top"/>
+  <anchor x="253.172" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="605" y="-20" type="curve" smooth="yes"/>
+      <point x="951" y="-19"/>
+      <point x="1180" y="282"/>
+      <point x="1236" y="598" type="curve" smooth="yes"/>
+      <point x="1277" y="836" type="line" smooth="yes"/>
+      <point x="1328" y="1148"/>
+      <point x="1194" y="1475"/>
+      <point x="838" y="1476" type="curve" smooth="yes"/>
+      <point x="668" y="1476"/>
+      <point x="447" y="1435"/>
+      <point x="328" y="1300" type="curve"/>
+      <point x="242" y="796" type="line"/>
+      <point x="729" y="796" type="line"/>
+      <point x="736" y="851" type="line"/>
+      <point x="306" y="851" type="line"/>
+      <point x="381" y="1275" type="line"/>
+      <point x="497" y="1385"/>
+      <point x="685" y="1422"/>
+      <point x="839" y="1422" type="curve" smooth="yes"/>
+      <point x="1166" y="1421"/>
+      <point x="1270" y="1116"/>
+      <point x="1223" y="836" type="curve" smooth="yes"/>
+      <point x="1181" y="596" type="line" smooth="yes"/>
+      <point x="1128" y="309"/>
+      <point x="919" y="34"/>
+      <point x="605" y="34" type="curve" smooth="yes"/>
+      <point x="376" y="34"/>
+      <point x="226" y="163"/>
+      <point x="227" y="394" type="curve"/>
+      <point x="174" y="394" type="line"/>
+      <point x="168" y="133"/>
+      <point x="350" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2141.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="1025"/>
+  <unicode hex="2142"/>
+  <anchor x="714.99" y="-93" name="bottom"/>
+  <anchor x="-85.26" y="-93" name="bottom0315"/>
+  <anchor x="-94.072" y="-144" name="bottom_dd"/>
+  <anchor x="714.99" y="-93" name="parent_bottom"/>
+  <anchor x="599.691" y="1446" name="top"/>
+  <anchor x="252.702" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="708" y="0" type="line"/>
+      <point x="763" y="0" type="line"/>
+      <point x="1014" y="1456" type="line"/>
+      <point x="959" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="227" y="1402" type="line"/>
+      <point x="987" y="1402" type="line"/>
+      <point x="994" y="1456" type="line"/>
+      <point x="234" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2142.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2143.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="991"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="674" y="0" type="line"/>
+      <point x="729" y="0" type="line"/>
+      <point x="973" y="1456" type="line"/>
+      <point x="918" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="-73" y="0" type="line"/>
+      <point x="709" y="0" type="line"/>
+      <point x="718" y="54" type="line"/>
+      <point x="-64" y="54" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1186"/>
+  <unicode hex="2144"/>
+  <anchor x="503.285" y="-144" name="bottom"/>
+  <anchor x="-93.265" y="-144" name="bottom0315"/>
+  <anchor x="-93.092" y="-143" name="bottom_dd"/>
+  <anchor x="503.285" y="-144" name="parent_bottom"/>
+  <anchor x="774.301" y="1447" name="top"/>
+  <anchor x="253.682" y="1864" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1018" y="0" type="line"/>
+      <point x="1087" y="0" type="line"/>
+      <point x="709" y="899" type="line"/>
+      <point x="805" y="1457" type="line"/>
+      <point x="751" y="1457" type="line"/>
+      <point x="657" y="908" type="line"/>
+      <point x="-33" y="3" type="line"/>
+      <point x="35" y="2" type="line"/>
+      <point x="677" y="853" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni2144.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni2144.glif
@@ -10,15 +10,15 @@
   <anchor x="253.682" y="1864" name="top_dd"/>
   <outline>
     <contour>
+      <point x="-33" y="3" type="line"/>
+      <point x="35" y="2" type="line"/>
+      <point x="677" y="853" type="line"/>
       <point x="1018" y="0" type="line"/>
       <point x="1087" y="0" type="line"/>
       <point x="709" y="899" type="line"/>
       <point x="805" y="1457" type="line"/>
       <point x="751" y="1457" type="line"/>
       <point x="657" y="908" type="line"/>
-      <point x="-33" y="3" type="line"/>
-      <point x="35" y="2" type="line"/>
-      <point x="677" y="853" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1263"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="126" y="300" type="line"/>
+      <point x="180" y="300" type="line"/>
+      <point x="368" y="1402" type="line"/>
+      <point x="761" y="1402" type="line" smooth="yes"/>
+      <point x="988" y="1398"/>
+      <point x="1137" y="1264"/>
+      <point x="1094" y="1029" type="curve" smooth="yes"/>
+      <point x="1050" y="794"/>
+      <point x="852" y="672"/>
+      <point x="624" y="669" type="curve" smooth="yes"/>
+      <point x="554" y="669" type="line"/>
+      <point x="548" y="615" type="line"/>
+      <point x="624" y="615" type="line" smooth="yes"/>
+      <point x="889" y="618"/>
+      <point x="1104" y="760"/>
+      <point x="1148" y="1031" type="curve" smooth="yes"/>
+      <point x="1192" y="1299"/>
+      <point x="1019" y="1453"/>
+      <point x="760" y="1456" type="curve" smooth="yes"/>
+      <point x="323" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="438" y="0" type="line"/>
+      <point x="1108" y="0" type="line"/>
+      <point x="1115" y="54" type="line"/>
+      <point x="445" y="54" type="line"/>
+    </contour>
+    <contour>
+      <point x="418" y="0" type="line"/>
+      <point x="473" y="0" type="line"/>
+      <point x="738" y="1536" type="line"/>
+      <point x="683" y="1536" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni214A_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni214A_.glif
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1210"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="612" y="-20" type="curve" smooth="yes"/>
+      <point x="793" y="-20"/>
+      <point x="927" y="116"/>
+      <point x="953" y="290" type="curve" smooth="yes"/>
+      <point x="978" y="455"/>
+      <point x="885" y="603"/>
+      <point x="795" y="732" type="curve" smooth="yes"/>
+      <point x="286" y="1457" type="line"/>
+      <point x="222" y="1457" type="line"/>
+      <point x="802" y="631" type="line" smooth="yes"/>
+      <point x="869" y="531"/>
+      <point x="919" y="410"/>
+      <point x="897" y="288" type="curve" smooth="yes"/>
+      <point x="873" y="147"/>
+      <point x="760" y="34"/>
+      <point x="612" y="34" type="curve" smooth="yes"/>
+      <point x="492" y="35"/>
+      <point x="415" y="125"/>
+      <point x="436" y="244" type="curve" smooth="yes"/>
+      <point x="456" y="353"/>
+      <point x="551" y="435"/>
+      <point x="635" y="497" type="curve" smooth="yes"/>
+      <point x="909" y="695" type="line" smooth="yes"/>
+      <point x="1044" y="797"/>
+      <point x="1192" y="928"/>
+      <point x="1218" y="1105" type="curve" smooth="yes"/>
+      <point x="1253" y="1344"/>
+      <point x="1073" y="1477"/>
+      <point x="850" y="1477" type="curve" smooth="yes"/>
+      <point x="677" y="1477"/>
+      <point x="529" y="1387"/>
+      <point x="404" y="1276" type="curve" smooth="yes"/>
+      <point x="397" y="1270"/>
+      <point x="391" y="1264"/>
+      <point x="386" y="1258" type="curve" smooth="yes"/>
+      <point x="274" y="1134"/>
+      <point x="207" y="990"/>
+      <point x="180" y="825" type="curve"/>
+      <point x="235" y="825" type="line"/>
+      <point x="289" y="1121"/>
+      <point x="524" y="1424"/>
+      <point x="850" y="1423" type="curve" smooth="yes"/>
+      <point x="1039" y="1422"/>
+      <point x="1197" y="1308"/>
+      <point x="1164" y="1105" type="curve" smooth="yes"/>
+      <point x="1138" y="948"/>
+      <point x="996" y="825"/>
+      <point x="877" y="734" type="curve" smooth="yes"/>
+      <point x="609" y="539" type="line" smooth="yes"/>
+      <point x="513" y="467"/>
+      <point x="399" y="370"/>
+      <point x="380" y="244" type="curve" smooth="yes"/>
+      <point x="357" y="92"/>
+      <point x="461" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni214B_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni214B_.glif
@@ -4,66 +4,66 @@
   <unicode hex="214B"/>
   <outline>
     <contour>
-      <point x="612" y="-20" type="curve" smooth="yes"/>
-      <point x="793" y="-20"/>
-      <point x="927" y="116"/>
-      <point x="953" y="290" type="curve" smooth="yes"/>
-      <point x="978" y="455"/>
-      <point x="885" y="603"/>
-      <point x="795" y="732" type="curve" smooth="yes"/>
-      <point x="286" y="1457" type="line"/>
-      <point x="222" y="1457" type="line"/>
-      <point x="802" y="631" type="line" smooth="yes"/>
-      <point x="869" y="531"/>
-      <point x="919" y="410"/>
-      <point x="897" y="288" type="curve" smooth="yes"/>
-      <point x="873" y="147"/>
-      <point x="760" y="34"/>
-      <point x="612" y="34" type="curve" smooth="yes"/>
-      <point x="492" y="35"/>
-      <point x="415" y="125"/>
-      <point x="436" y="244" type="curve" smooth="yes"/>
-      <point x="456" y="353"/>
-      <point x="551" y="435"/>
-      <point x="635" y="497" type="curve" smooth="yes"/>
-      <point x="909" y="695" type="line" smooth="yes"/>
-      <point x="1044" y="797"/>
-      <point x="1192" y="928"/>
-      <point x="1218" y="1105" type="curve" smooth="yes"/>
-      <point x="1253" y="1344"/>
-      <point x="1073" y="1477"/>
-      <point x="850" y="1477" type="curve" smooth="yes"/>
-      <point x="677" y="1477"/>
-      <point x="529" y="1387"/>
-      <point x="404" y="1276" type="curve" smooth="yes"/>
-      <point x="397" y="1270"/>
-      <point x="391" y="1264"/>
-      <point x="386" y="1258" type="curve" smooth="yes"/>
-      <point x="274" y="1134"/>
-      <point x="207" y="990"/>
-      <point x="180" y="825" type="curve"/>
-      <point x="235" y="825" type="line"/>
-      <point x="289" y="1121"/>
-      <point x="524" y="1424"/>
-      <point x="850" y="1423" type="curve" smooth="yes"/>
-      <point x="1039" y="1422"/>
-      <point x="1197" y="1308"/>
-      <point x="1164" y="1105" type="curve" smooth="yes"/>
-      <point x="1138" y="948"/>
-      <point x="996" y="825"/>
-      <point x="877" y="734" type="curve" smooth="yes"/>
-      <point x="609" y="539" type="line" smooth="yes"/>
-      <point x="513" y="467"/>
-      <point x="399" y="370"/>
-      <point x="380" y="244" type="curve" smooth="yes"/>
-      <point x="357" y="92"/>
-      <point x="461" y="-20"/>
+      <point x="573" y="-20" type="curve" smooth="yes"/>
+      <point x="754" y="-20"/>
+      <point x="888" y="116"/>
+      <point x="914" y="290" type="curve" smooth="yes"/>
+      <point x="939" y="455"/>
+      <point x="846" y="603"/>
+      <point x="756" y="732" type="curve" smooth="yes"/>
+      <point x="247" y="1457" type="line"/>
+      <point x="183" y="1457" type="line"/>
+      <point x="763" y="631" type="line" smooth="yes"/>
+      <point x="830" y="531"/>
+      <point x="880" y="410"/>
+      <point x="858" y="288" type="curve" smooth="yes"/>
+      <point x="834" y="147"/>
+      <point x="721" y="34"/>
+      <point x="573" y="34" type="curve" smooth="yes"/>
+      <point x="453" y="35"/>
+      <point x="376" y="125"/>
+      <point x="397" y="244" type="curve" smooth="yes"/>
+      <point x="417" y="353"/>
+      <point x="512" y="435"/>
+      <point x="596" y="497" type="curve" smooth="yes"/>
+      <point x="870" y="695" type="line" smooth="yes"/>
+      <point x="1005" y="797"/>
+      <point x="1153" y="928"/>
+      <point x="1179" y="1105" type="curve" smooth="yes"/>
+      <point x="1214" y="1344"/>
+      <point x="1034" y="1477"/>
+      <point x="811" y="1477" type="curve" smooth="yes"/>
+      <point x="638" y="1477"/>
+      <point x="490" y="1387"/>
+      <point x="365" y="1276" type="curve" smooth="yes"/>
+      <point x="358" y="1270"/>
+      <point x="352" y="1264"/>
+      <point x="347" y="1258" type="curve" smooth="yes"/>
+      <point x="235" y="1134"/>
+      <point x="168" y="990"/>
+      <point x="141" y="825" type="curve"/>
+      <point x="196" y="825" type="line"/>
+      <point x="250" y="1121"/>
+      <point x="485" y="1424"/>
+      <point x="811" y="1423" type="curve" smooth="yes"/>
+      <point x="1000" y="1422"/>
+      <point x="1158" y="1308"/>
+      <point x="1125" y="1105" type="curve" smooth="yes"/>
+      <point x="1099" y="948"/>
+      <point x="957" y="825"/>
+      <point x="838" y="734" type="curve" smooth="yes"/>
+      <point x="570" y="539" type="line" smooth="yes"/>
+      <point x="474" y="467"/>
+      <point x="360" y="370"/>
+      <point x="341" y="244" type="curve" smooth="yes"/>
+      <point x="318" y="92"/>
+      <point x="422" y="-20"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="619"/>
+  <advance width="1266"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="236" y="-10" type="curve" smooth="yes"/>
-      <point x="318" y="-10"/>
-      <point x="345" y="51"/>
-      <point x="345" y="117" type="curve" smooth="yes"/>
-      <point x="345" y="140"/>
-      <point x="337" y="204"/>
-      <point x="329" y="277" type="curve"/>
-      <point x="405" y="291"/>
-      <point x="471" y="326"/>
-      <point x="513" y="375" type="curve"/>
-      <point x="522" y="361"/>
-      <point x="527" y="345"/>
-      <point x="527" y="327" type="curve" smooth="yes"/>
-      <point x="527" y="281"/>
-      <point x="480" y="238"/>
-      <point x="462" y="224" type="curve"/>
-      <point x="496" y="224" type="line"/>
-      <point x="515" y="238"/>
-      <point x="557" y="281"/>
-      <point x="557" y="326" type="curve" smooth="yes"/>
-      <point x="557" y="354"/>
-      <point x="547" y="378"/>
-      <point x="530" y="397" type="curve"/>
-      <point x="551" y="427"/>
-      <point x="563" y="462"/>
-      <point x="563" y="500" type="curve" smooth="yes"/>
-      <point x="563" y="608"/>
-      <point x="492" y="725"/>
-      <point x="383" y="725" type="curve" smooth="yes"/>
-      <point x="300" y="725"/>
-      <point x="273" y="664"/>
-      <point x="273" y="569" type="curve" smooth="yes"/>
-      <point x="273" y="548"/>
-      <point x="274" y="515"/>
-      <point x="275" y="477" type="curve"/>
-      <point x="263" y="478"/>
-      <point x="252" y="478"/>
-      <point x="242" y="478" type="curve" smooth="yes"/>
-      <point x="231" y="478"/>
-      <point x="212" y="477"/>
-      <point x="191" y="475" type="curve"/>
-      <point x="193" y="613" type="line"/>
-      <point x="208" y="635"/>
-      <point x="222" y="658"/>
-      <point x="222" y="675" type="curve" smooth="yes"/>
-      <point x="222" y="681"/>
-      <point x="221" y="708"/>
-      <point x="194" y="708" type="curve" smooth="yes"/>
-      <point x="159" y="708"/>
-      <point x="171" y="669"/>
-      <point x="155" y="669" type="curve" smooth="yes"/>
-      <point x="135" y="669"/>
-      <point x="124" y="715"/>
-      <point x="76" y="715" type="curve" smooth="yes"/>
-      <point x="53" y="715"/>
-      <point x="12" y="702"/>
-      <point x="12" y="643" type="curve" smooth="yes"/>
-      <point x="12" y="603"/>
-      <point x="39" y="572"/>
-      <point x="83" y="572" type="curve" smooth="yes"/>
-      <point x="90" y="572"/>
-      <point x="97" y="573"/>
-      <point x="102" y="574" type="curve"/>
-      <point x="101" y="592" type="line"/>
-      <point x="97" y="591"/>
-      <point x="89" y="590"/>
-      <point x="83" y="590" type="curve" smooth="yes"/>
-      <point x="65" y="590"/>
-      <point x="59" y="606"/>
-      <point x="59" y="617" type="curve" smooth="yes"/>
-      <point x="59" y="630"/>
-      <point x="68" y="644"/>
-      <point x="87" y="644" type="curve" smooth="yes"/>
-      <point x="109" y="644"/>
-      <point x="156" y="625"/>
-      <point x="173" y="615" type="curve"/>
-      <point x="157" y="471" type="line"/>
-      <point x="95" y="460"/>
-      <point x="25" y="433"/>
-      <point x="25" y="369" type="curve" smooth="yes"/>
-      <point x="25" y="315"/>
-      <point x="78" y="290"/>
-      <point x="138" y="279" type="curve"/>
-      <point x="131" y="208"/>
-      <point x="127" y="144"/>
-      <point x="127" y="117" type="curve" smooth="yes"/>
-      <point x="127" y="51"/>
-      <point x="154" y="-10"/>
+      <point x="596" y="-20" type="curve" smooth="yes"/>
+      <point x="764" y="-20"/>
+      <point x="819" y="104"/>
+      <point x="819" y="240" type="curve" smooth="yes"/>
+      <point x="819" y="287"/>
+      <point x="803" y="418"/>
+      <point x="786" y="567" type="curve"/>
+      <point x="942" y="596"/>
+      <point x="1077" y="668"/>
+      <point x="1163" y="768" type="curve"/>
+      <point x="1181" y="739"/>
+      <point x="1192" y="707"/>
+      <point x="1192" y="670" type="curve" smooth="yes"/>
+      <point x="1192" y="575"/>
+      <point x="1095" y="487"/>
+      <point x="1059" y="459" type="curve"/>
+      <point x="1128" y="459" type="line"/>
+      <point x="1167" y="487"/>
+      <point x="1253" y="575"/>
+      <point x="1253" y="668" type="curve" smooth="yes"/>
+      <point x="1253" y="725"/>
+      <point x="1233" y="774"/>
+      <point x="1198" y="813" type="curve"/>
+      <point x="1241" y="874"/>
+      <point x="1265" y="946"/>
+      <point x="1265" y="1024" type="curve" smooth="yes"/>
+      <point x="1265" y="1245"/>
+      <point x="1120" y="1485"/>
+      <point x="897" y="1485" type="curve" smooth="yes"/>
+      <point x="727" y="1485"/>
+      <point x="671" y="1360"/>
+      <point x="671" y="1165" type="curve" smooth="yes"/>
+      <point x="671" y="1122"/>
+      <point x="674" y="1055"/>
+      <point x="676" y="977" type="curve"/>
+      <point x="651" y="979"/>
+      <point x="628" y="979"/>
+      <point x="608" y="979" type="curve" smooth="yes"/>
+      <point x="585" y="979"/>
+      <point x="547" y="977"/>
+      <point x="504" y="973" type="curve"/>
+      <point x="508" y="1255" type="line"/>
+      <point x="538" y="1300"/>
+      <point x="567" y="1348"/>
+      <point x="567" y="1382" type="curve" smooth="yes"/>
+      <point x="567" y="1395"/>
+      <point x="565" y="1450"/>
+      <point x="510" y="1450" type="curve" smooth="yes"/>
+      <point x="438" y="1450"/>
+      <point x="463" y="1370"/>
+      <point x="430" y="1370" type="curve" smooth="yes"/>
+      <point x="389" y="1370"/>
+      <point x="366" y="1464"/>
+      <point x="268" y="1464" type="curve" smooth="yes"/>
+      <point x="221" y="1464"/>
+      <point x="137" y="1438"/>
+      <point x="137" y="1317" type="curve" smooth="yes"/>
+      <point x="137" y="1235"/>
+      <point x="192" y="1171"/>
+      <point x="282" y="1171" type="curve" smooth="yes"/>
+      <point x="297" y="1171"/>
+      <point x="311" y="1174"/>
+      <point x="321" y="1176" type="curve"/>
+      <point x="319" y="1212" type="line"/>
+      <point x="311" y="1210"/>
+      <point x="295" y="1208"/>
+      <point x="282" y="1208" type="curve" smooth="yes"/>
+      <point x="246" y="1208"/>
+      <point x="233" y="1241"/>
+      <point x="233" y="1264" type="curve" smooth="yes"/>
+      <point x="233" y="1290"/>
+      <point x="252" y="1319"/>
+      <point x="291" y="1319" type="curve" smooth="yes"/>
+      <point x="336" y="1319"/>
+      <point x="432" y="1280"/>
+      <point x="467" y="1260" type="curve"/>
+      <point x="434" y="965" type="line"/>
+      <point x="307" y="942"/>
+      <point x="164" y="887"/>
+      <point x="164" y="756" type="curve" smooth="yes"/>
+      <point x="164" y="645"/>
+      <point x="272" y="594"/>
+      <point x="395" y="571" type="curve"/>
+      <point x="381" y="426"/>
+      <point x="372" y="295"/>
+      <point x="372" y="240" type="curve" smooth="yes"/>
+      <point x="372" y="104"/>
+      <point x="428" y="-20"/>
     </contour>
     <contour>
-      <point x="236" y="20" type="curve" smooth="yes"/>
-      <point x="199" y="20"/>
-      <point x="179" y="58"/>
-      <point x="179" y="115" type="curve" smooth="yes"/>
-      <point x="179" y="146"/>
-      <point x="181" y="206"/>
-      <point x="183" y="273" type="curve"/>
-      <point x="208" y="270"/>
-      <point x="232" y="270"/>
-      <point x="253" y="270" type="curve" smooth="yes"/>
-      <point x="263" y="270"/>
-      <point x="274" y="270"/>
-      <point x="285" y="271" type="curve"/>
-      <point x="288" y="195"/>
-      <point x="292" y="132"/>
-      <point x="292" y="115" type="curve" smooth="yes"/>
-      <point x="292" y="58"/>
-      <point x="272" y="20"/>
+      <point x="596" y="41" type="curve" smooth="yes"/>
+      <point x="520" y="41"/>
+      <point x="479" y="119"/>
+      <point x="479" y="236" type="curve" smooth="yes"/>
+      <point x="479" y="299"/>
+      <point x="483" y="422"/>
+      <point x="487" y="559" type="curve"/>
+      <point x="538" y="553"/>
+      <point x="588" y="553"/>
+      <point x="631" y="553" type="curve" smooth="yes"/>
+      <point x="651" y="553"/>
+      <point x="674" y="553"/>
+      <point x="696" y="555" type="curve"/>
+      <point x="702" y="399"/>
+      <point x="710" y="270"/>
+      <point x="710" y="236" type="curve" smooth="yes"/>
+      <point x="710" y="119"/>
+      <point x="669" y="41"/>
     </contour>
     <contour>
-      <point x="140" y="299" type="line"/>
-      <point x="60" y="318"/>
-      <point x="50" y="358"/>
-      <point x="50" y="372" type="curve" smooth="yes"/>
-      <point x="50" y="384"/>
-      <point x="56" y="434"/>
-      <point x="155" y="453" type="curve"/>
+      <point x="399" y="612" type="line"/>
+      <point x="235" y="651"/>
+      <point x="215" y="733"/>
+      <point x="215" y="762" type="curve" smooth="yes"/>
+      <point x="215" y="786"/>
+      <point x="227" y="889"/>
+      <point x="430" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="252" y="288" type="curve" smooth="yes"/>
-      <point x="225" y="288"/>
-      <point x="204" y="289"/>
-      <point x="184" y="291" type="curve"/>
-      <point x="190" y="458" type="line"/>
-      <point x="205" y="459"/>
-      <point x="222" y="460"/>
-      <point x="241" y="460" type="curve" smooth="yes"/>
-      <point x="253" y="460"/>
-      <point x="264" y="459"/>
-      <point x="276" y="459" type="curve"/>
-      <point x="284" y="289" type="line"/>
-      <point x="273" y="288"/>
-      <point x="263" y="288"/>
+      <point x="628" y="590" type="curve" smooth="yes"/>
+      <point x="573" y="590"/>
+      <point x="530" y="592"/>
+      <point x="489" y="596" type="curve"/>
+      <point x="502" y="938" type="line"/>
+      <point x="532" y="940"/>
+      <point x="567" y="942"/>
+      <point x="606" y="942" type="curve" smooth="yes"/>
+      <point x="631" y="942"/>
+      <point x="653" y="940"/>
+      <point x="678" y="940" type="curve"/>
+      <point x="694" y="592" type="line"/>
+      <point x="671" y="590"/>
+      <point x="651" y="590"/>
     </contour>
     <contour>
-      <point x="327" y="295" type="curve"/>
-      <point x="308" y="457" type="line"/>
-      <point x="368" y="452"/>
-      <point x="428" y="439"/>
-      <point x="470" y="414" type="curve"/>
-      <point x="447" y="351"/>
-      <point x="399" y="311"/>
+      <point x="782" y="604" type="curve"/>
+      <point x="743" y="936" type="line"/>
+      <point x="866" y="926"/>
+      <point x="989" y="899"/>
+      <point x="1075" y="848" type="curve"/>
+      <point x="1028" y="719"/>
+      <point x="930" y="637"/>
     </contour>
     <contour>
-      <point x="476" y="436" type="curve"/>
-      <point x="427" y="460"/>
-      <point x="361" y="471"/>
-      <point x="306" y="475" type="curve"/>
-      <point x="302" y="514"/>
-      <point x="300" y="548"/>
-      <point x="300" y="572" type="curve" smooth="yes"/>
-      <point x="300" y="636"/>
-      <point x="306" y="707"/>
-      <point x="380" y="707" type="curve" smooth="yes"/>
-      <point x="471" y="707"/>
-      <point x="487" y="593"/>
-      <point x="487" y="519" type="curve" smooth="yes"/>
-      <point x="487" y="488"/>
-      <point x="483" y="461"/>
+      <point x="1087" y="893" type="curve"/>
+      <point x="987" y="942"/>
+      <point x="852" y="965"/>
+      <point x="739" y="973" type="curve"/>
+      <point x="731" y="1053"/>
+      <point x="727" y="1122"/>
+      <point x="727" y="1171" type="curve" smooth="yes"/>
+      <point x="727" y="1303"/>
+      <point x="739" y="1448"/>
+      <point x="891" y="1448" type="curve" smooth="yes"/>
+      <point x="1077" y="1448"/>
+      <point x="1110" y="1214"/>
+      <point x="1110" y="1063" type="curve" smooth="yes"/>
+      <point x="1110" y="999"/>
+      <point x="1102" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="619"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="236" y="-10" type="curve" smooth="yes"/>
+      <point x="318" y="-10"/>
+      <point x="345" y="51"/>
+      <point x="345" y="117" type="curve" smooth="yes"/>
+      <point x="345" y="140"/>
+      <point x="337" y="204"/>
+      <point x="329" y="277" type="curve"/>
+      <point x="405" y="291"/>
+      <point x="471" y="326"/>
+      <point x="513" y="375" type="curve"/>
+      <point x="522" y="361"/>
+      <point x="527" y="345"/>
+      <point x="527" y="327" type="curve" smooth="yes"/>
+      <point x="527" y="281"/>
+      <point x="480" y="238"/>
+      <point x="462" y="224" type="curve"/>
+      <point x="496" y="224" type="line"/>
+      <point x="515" y="238"/>
+      <point x="557" y="281"/>
+      <point x="557" y="326" type="curve" smooth="yes"/>
+      <point x="557" y="354"/>
+      <point x="547" y="378"/>
+      <point x="530" y="397" type="curve"/>
+      <point x="551" y="427"/>
+      <point x="563" y="462"/>
+      <point x="563" y="500" type="curve" smooth="yes"/>
+      <point x="563" y="608"/>
+      <point x="492" y="725"/>
+      <point x="383" y="725" type="curve" smooth="yes"/>
+      <point x="300" y="725"/>
+      <point x="273" y="664"/>
+      <point x="273" y="569" type="curve" smooth="yes"/>
+      <point x="273" y="548"/>
+      <point x="274" y="515"/>
+      <point x="275" y="477" type="curve"/>
+      <point x="263" y="478"/>
+      <point x="252" y="478"/>
+      <point x="242" y="478" type="curve" smooth="yes"/>
+      <point x="231" y="478"/>
+      <point x="212" y="477"/>
+      <point x="191" y="475" type="curve"/>
+      <point x="193" y="613" type="line"/>
+      <point x="208" y="635"/>
+      <point x="222" y="658"/>
+      <point x="222" y="675" type="curve" smooth="yes"/>
+      <point x="222" y="681"/>
+      <point x="221" y="708"/>
+      <point x="194" y="708" type="curve" smooth="yes"/>
+      <point x="159" y="708"/>
+      <point x="171" y="669"/>
+      <point x="155" y="669" type="curve" smooth="yes"/>
+      <point x="135" y="669"/>
+      <point x="124" y="715"/>
+      <point x="76" y="715" type="curve" smooth="yes"/>
+      <point x="53" y="715"/>
+      <point x="12" y="702"/>
+      <point x="12" y="643" type="curve" smooth="yes"/>
+      <point x="12" y="603"/>
+      <point x="39" y="572"/>
+      <point x="83" y="572" type="curve" smooth="yes"/>
+      <point x="90" y="572"/>
+      <point x="97" y="573"/>
+      <point x="102" y="574" type="curve"/>
+      <point x="101" y="592" type="line"/>
+      <point x="97" y="591"/>
+      <point x="89" y="590"/>
+      <point x="83" y="590" type="curve" smooth="yes"/>
+      <point x="65" y="590"/>
+      <point x="59" y="606"/>
+      <point x="59" y="617" type="curve" smooth="yes"/>
+      <point x="59" y="630"/>
+      <point x="68" y="644"/>
+      <point x="87" y="644" type="curve" smooth="yes"/>
+      <point x="109" y="644"/>
+      <point x="156" y="625"/>
+      <point x="173" y="615" type="curve"/>
+      <point x="157" y="471" type="line"/>
+      <point x="95" y="460"/>
+      <point x="25" y="433"/>
+      <point x="25" y="369" type="curve" smooth="yes"/>
+      <point x="25" y="315"/>
+      <point x="78" y="290"/>
+      <point x="138" y="279" type="curve"/>
+      <point x="131" y="208"/>
+      <point x="127" y="144"/>
+      <point x="127" y="117" type="curve" smooth="yes"/>
+      <point x="127" y="51"/>
+      <point x="154" y="-10"/>
+    </contour>
+    <contour>
+      <point x="236" y="20" type="curve" smooth="yes"/>
+      <point x="199" y="20"/>
+      <point x="179" y="58"/>
+      <point x="179" y="115" type="curve" smooth="yes"/>
+      <point x="179" y="146"/>
+      <point x="181" y="206"/>
+      <point x="183" y="273" type="curve"/>
+      <point x="208" y="270"/>
+      <point x="232" y="270"/>
+      <point x="253" y="270" type="curve" smooth="yes"/>
+      <point x="263" y="270"/>
+      <point x="274" y="270"/>
+      <point x="285" y="271" type="curve"/>
+      <point x="288" y="195"/>
+      <point x="292" y="132"/>
+      <point x="292" y="115" type="curve" smooth="yes"/>
+      <point x="292" y="58"/>
+      <point x="272" y="20"/>
+    </contour>
+    <contour>
+      <point x="140" y="299" type="line"/>
+      <point x="60" y="318"/>
+      <point x="50" y="358"/>
+      <point x="50" y="372" type="curve" smooth="yes"/>
+      <point x="50" y="384"/>
+      <point x="56" y="434"/>
+      <point x="155" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="252" y="288" type="curve" smooth="yes"/>
+      <point x="225" y="288"/>
+      <point x="204" y="289"/>
+      <point x="184" y="291" type="curve"/>
+      <point x="190" y="458" type="line"/>
+      <point x="205" y="459"/>
+      <point x="222" y="460"/>
+      <point x="241" y="460" type="curve" smooth="yes"/>
+      <point x="253" y="460"/>
+      <point x="264" y="459"/>
+      <point x="276" y="459" type="curve"/>
+      <point x="284" y="289" type="line"/>
+      <point x="273" y="288"/>
+      <point x="263" y="288"/>
+    </contour>
+    <contour>
+      <point x="327" y="295" type="curve"/>
+      <point x="308" y="457" type="line"/>
+      <point x="368" y="452"/>
+      <point x="428" y="439"/>
+      <point x="470" y="414" type="curve"/>
+      <point x="447" y="351"/>
+      <point x="399" y="311"/>
+    </contour>
+    <contour>
+      <point x="476" y="436" type="curve"/>
+      <point x="427" y="460"/>
+      <point x="361" y="471"/>
+      <point x="306" y="475" type="curve"/>
+      <point x="302" y="514"/>
+      <point x="300" y="548"/>
+      <point x="300" y="572" type="curve" smooth="yes"/>
+      <point x="300" y="636"/>
+      <point x="306" y="707"/>
+      <point x="380" y="707" type="curve" smooth="yes"/>
+      <point x="471" y="707"/>
+      <point x="487" y="593"/>
+      <point x="487" y="519" type="curve" smooth="yes"/>
+      <point x="487" y="488"/>
+      <point x="483" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="1015"/>
+  <unicode hex="214E"/>
+  <anchor x="354.929" y="10" name="bottom"/>
+  <anchor x="800.858" y="-407" name="bottom_dd"/>
+  <anchor x="666.633" y="1320" name="parent_top"/>
+  <anchor x="666.633" y="1320" name="top"/>
+  <anchor x="1099.253" y="1320" name="top0315"/>
+  <anchor x="1147.632" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="699" y="0" type="line"/>
+      <point x="753" y="0" type="line"/>
+      <point x="939" y="1082" type="line"/>
+      <point x="885" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="0" y="0" type="line"/>
+      <point x="733" y="0" type="line"/>
+      <point x="741" y="55" type="line"/>
+      <point x="7" y="55" type="line"/>
+    </contour>
+    <contour>
+      <point x="179" y="545" type="line"/>
+      <point x="828" y="545" type="line"/>
+      <point x="835" y="600" type="line"/>
+      <point x="187" y="600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:38 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/Roboto-ThinItalic.ufo/glyphs/uni214E_.glif
+++ b/sources/Roboto-ThinItalic.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:38 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/Roboto-ThinItalic.ufo/lib.plist
+++ b/sources/Roboto-ThinItalic.ufo/lib.plist
@@ -6890,6 +6890,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-Bold.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Bold.ufo/fontinfo.plist
@@ -373,7 +373,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/contents.plist
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="958"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="117" y="0" type="line"/>
+      <point x="477" y="0" type="line" smooth="yes"/>
+      <point x="703" y="0"/>
+      <point x="862" y="137"/>
+      <point x="862" y="426" type="curve" smooth="yes"/>
+      <point x="862" y="610"/>
+      <point x="797" y="723"/>
+      <point x="645" y="766" type="curve"/>
+      <point x="645" y="776" type="line"/>
+      <point x="764" y="809"/>
+      <point x="836" y="930"/>
+      <point x="836" y="1104" type="curve" smooth="yes"/>
+      <point x="836" y="1350"/>
+      <point x="690" y="1462"/>
+      <point x="434" y="1462" type="curve" smooth="yes"/>
+      <point x="117" y="1462" type="line"/>
+    </contour>
+    <contour>
+      <point x="273" y="-201" type="line"/>
+      <point x="402" y="-201" type="line"/>
+      <point x="402" y="150" type="line"/>
+      <point x="273" y="150" type="line"/>
+    </contour>
+    <contour>
+      <point x="510" y="-201" type="line"/>
+      <point x="639" y="-201" type="line"/>
+      <point x="639" y="150" type="line"/>
+      <point x="510" y="150" type="line"/>
+    </contour>
+    <contour>
+      <point x="379" y="236" type="line"/>
+      <point x="379" y="647" type="line"/>
+      <point x="426" y="647" type="line" smooth="yes"/>
+      <point x="535" y="647"/>
+      <point x="594" y="586"/>
+      <point x="594" y="440" type="curve" smooth="yes"/>
+      <point x="594" y="305"/>
+      <point x="541" y="236"/>
+      <point x="434" y="236" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="379" y="870" type="line"/>
+      <point x="379" y="1233" type="line"/>
+      <point x="410" y="1233" type="line" smooth="yes"/>
+      <point x="518" y="1233"/>
+      <point x="572" y="1180"/>
+      <point x="572" y="1057" type="curve" smooth="yes"/>
+      <point x="572" y="934"/>
+      <point x="520" y="870"/>
+      <point x="414" y="870" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="273" y="1319" type="line"/>
+      <point x="402" y="1319" type="line"/>
+      <point x="402" y="1669" type="line"/>
+      <point x="273" y="1669" type="line"/>
+    </contour>
+    <contour>
+      <point x="510" y="1319" type="line"/>
+      <point x="639" y="1319" type="line"/>
+      <point x="639" y="1669" type="line"/>
+      <point x="510" y="1669" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="1072"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="415" y="0" type="line"/>
+      <point x="1019" y="0" type="line"/>
+      <point x="1019" y="250" type="line"/>
+      <point x="660" y="250" type="line"/>
+      <point x="660" y="362" type="line"/>
+      <point x="705" y="375"/>
+      <point x="736" y="395"/>
+      <point x="779" y="420" type="curve"/>
+      <point x="783" y="610" type="line"/>
+      <point x="732" y="582"/>
+      <point x="701" y="561"/>
+      <point x="660" y="547" type="curve"/>
+      <point x="660" y="1026" type="line"/>
+      <point x="689" y="1018"/>
+      <point x="716" y="1006"/>
+      <point x="748" y="987" type="curve"/>
+      <point x="808" y="1163" type="line"/>
+      <point x="754" y="1186"/>
+      <point x="716" y="1204"/>
+      <point x="660" y="1214" type="curve"/>
+      <point x="660" y="1462" type="line"/>
+      <point x="415" y="1462" type="line"/>
+      <point x="415" y="1212" type="line"/>
+      <point x="216" y="1171"/>
+      <point x="93" y="1026"/>
+      <point x="93" y="784" type="curve" smooth="yes"/>
+      <point x="93" y="537"/>
+      <point x="206" y="387"/>
+      <point x="415" y="354" type="curve"/>
+    </contour>
+    <contour>
+      <point x="415" y="559" type="line"/>
+      <point x="357" y="592"/>
+      <point x="316" y="662"/>
+      <point x="316" y="780" type="curve" smooth="yes"/>
+      <point x="316" y="907"/>
+      <point x="355" y="981"/>
+      <point x="415" y="1016" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="1019"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1159"/>
+  <unicode hex="2108"/>
+  <anchor x="564" y="1609" name="parent_top"/>
+  <anchor x="564" y="1609" name="top"/>
+  <anchor x="1139" y="1609" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="563" y="-21" type="curve" smooth="yes"/>
+      <point x="886" y="-21"/>
+      <point x="1081" y="249"/>
+      <point x="1081" y="680" type="curve" smooth="yes"/>
+      <point x="1081" y="773" type="line" smooth="yes"/>
+      <point x="1081" y="1205"/>
+      <point x="878" y="1476"/>
+      <point x="560" y="1476" type="curve" smooth="yes"/>
+      <point x="242" y="1476"/>
+      <point x="82" y="1259"/>
+      <point x="58" y="961" type="curve"/>
+      <point x="352" y="961" type="line"/>
+      <point x="360" y="1133"/>
+      <point x="407" y="1231"/>
+      <point x="560" y="1231" type="curve" smooth="yes"/>
+      <point x="715" y="1231"/>
+      <point x="787" y="1085"/>
+      <point x="787" y="775" type="curve" smooth="yes"/>
+      <point x="787" y="680" type="line" smooth="yes"/>
+      <point x="787" y="378"/>
+      <point x="731" y="223"/>
+      <point x="563" y="223" type="curve" smooth="yes"/>
+      <point x="419" y="223"/>
+      <point x="363" y="312"/>
+      <point x="354" y="485" type="curve"/>
+      <point x="60" y="485" type="line"/>
+      <point x="75" y="188"/>
+      <point x="253" y="-21"/>
+    </contour>
+    <contour>
+      <point x="432" y="605" type="line"/>
+      <point x="944" y="605" type="line"/>
+      <point x="944" y="850" type="line"/>
+      <point x="432" y="850" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2108.glif
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1523"/>
+  <unicode hex="2114"/>
+  <anchor x="1096" y="-10" name="bottom"/>
+  <anchor x="1503" y="-407" name="bottom_dd"/>
+  <anchor x="639" y="1500" name="marktop"/>
+  <anchor x="1104" y="1603" name="parent_top"/>
+  <anchor x="1104" y="1603" name="top"/>
+  <anchor x="1503" y="1603" name="top0315"/>
+  <anchor x="1503" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1108" y="-20" type="curve" smooth="yes"/>
+      <point x="1349" y="-20"/>
+      <point x="1456" y="156"/>
+      <point x="1456" y="506" type="curve" smooth="yes"/>
+      <point x="1456" y="577" type="line"/>
+      <point x="1456" y="922"/>
+      <point x="1350" y="1102"/>
+      <point x="1106" y="1102" type="curve" smooth="yes"/>
+      <point x="892" y="1102"/>
+      <point x="802" y="883"/>
+      <point x="772" y="594" type="curve"/>
+      <point x="772" y="489" type="line"/>
+      <point x="804" y="199"/>
+      <point x="893" y="-20"/>
+    </contour>
+    <contour>
+      <point x="152" y="0" type="line"/>
+      <point x="436" y="0" type="line"/>
+      <point x="436" y="1536" type="line"/>
+      <point x="152" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="613" y="0" type="line"/>
+      <point x="874" y="0" type="line"/>
+      <point x="895" y="252" type="line"/>
+      <point x="895" y="1536" type="line"/>
+      <point x="613" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="1027" y="216" type="curve" smooth="yes"/>
+      <point x="907" y="216"/>
+      <point x="867" y="310"/>
+      <point x="865" y="448" type="curve"/>
+      <point x="865" y="635" type="line"/>
+      <point x="868" y="772"/>
+      <point x="914" y="866"/>
+      <point x="1025" y="866" type="curve" smooth="yes"/>
+      <point x="1150" y="866"/>
+      <point x="1174" y="773"/>
+      <point x="1174" y="577" type="curve" smooth="yes"/>
+      <point x="1174" y="506" type="line"/>
+      <point x="1174" y="296"/>
+      <point x="1151" y="216"/>
+    </contour>
+    <contour>
+      <point x="-8" y="1216" type="line"/>
+      <point x="1056" y="1216" type="line"/>
+      <point x="1056" y="1399" type="line"/>
+      <point x="-8" y="1399" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="808"/>
+  <advance width="1610"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="210" y="-241" type="curve" smooth="yes"/>
-      <point x="280" y="-241"/>
-      <point x="327" y="-180"/>
-      <point x="327" y="-95" type="curve" smooth="yes"/>
-      <point x="327" y="8"/>
-      <point x="235" y="99"/>
-      <point x="178" y="200" type="curve"/>
-      <point x="225" y="272"/>
-      <point x="285" y="341"/>
-      <point x="347" y="394" type="curve" smooth="yes"/>
-      <point x="415" y="452"/>
-      <point x="486" y="492"/>
-      <point x="545" y="492" type="curve" smooth="yes"/>
-      <point x="647" y="492"/>
-      <point x="655" y="359"/>
-      <point x="655" y="322" type="curve" smooth="yes"/>
-      <point x="655" y="285"/>
-      <point x="642" y="30"/>
-      <point x="478" y="30" type="curve" smooth="yes"/>
-      <point x="427" y="30"/>
-      <point x="378" y="57"/>
-      <point x="378" y="112" type="curve" smooth="yes"/>
-      <point x="378" y="119"/>
-      <point x="379" y="126"/>
-      <point x="381" y="132" type="curve"/>
-      <point x="413" y="136"/>
-      <point x="446" y="151"/>
-      <point x="446" y="194" type="curve" smooth="yes"/>
-      <point x="446" y="225"/>
-      <point x="425" y="244"/>
-      <point x="394" y="244" type="curve" smooth="yes"/>
-      <point x="346" y="244"/>
-      <point x="316" y="206"/>
-      <point x="316" y="140" type="curve" smooth="yes"/>
-      <point x="316" y="51"/>
-      <point x="380" y="-10"/>
-      <point x="486" y="-10" type="curve" smooth="yes"/>
-      <point x="664" y="-10"/>
-      <point x="757" y="159"/>
-      <point x="757" y="306" type="curve" smooth="yes"/>
-      <point x="757" y="437"/>
-      <point x="697" y="549"/>
-      <point x="575" y="549" type="curve" smooth="yes"/>
-      <point x="525" y="549"/>
-      <point x="429" y="512"/>
-      <point x="323" y="419" type="curve" smooth="yes"/>
-      <point x="271" y="373"/>
-      <point x="210" y="310"/>
-      <point x="158" y="238" type="curve"/>
-      <point x="143" y="272"/>
-      <point x="134" y="307"/>
-      <point x="134" y="345" type="curve" smooth="yes"/>
-      <point x="134" y="474"/>
-      <point x="164" y="548"/>
-      <point x="245" y="625" type="curve"/>
-      <point x="229" y="647" type="line"/>
-      <point x="170" y="610"/>
-      <point x="46" y="496"/>
-      <point x="46" y="337" type="curve" smooth="yes"/>
-      <point x="46" y="267"/>
-      <point x="70" y="206"/>
-      <point x="102" y="149" type="curve"/>
-      <point x="67" y="85"/>
-      <point x="41" y="11"/>
-      <point x="41" y="-56" type="curve" smooth="yes"/>
-      <point x="41" y="-163"/>
-      <point x="115" y="-241"/>
+      <point x="420" y="-494" type="curve" smooth="yes"/>
+      <point x="557" y="-494"/>
+      <point x="651" y="-369"/>
+      <point x="651" y="-195" type="curve" smooth="yes"/>
+      <point x="651" y="16"/>
+      <point x="469" y="203"/>
+      <point x="356" y="410" type="curve"/>
+      <point x="451" y="557"/>
+      <point x="571" y="698"/>
+      <point x="692" y="807" type="curve" smooth="yes"/>
+      <point x="825" y="926"/>
+      <point x="967" y="1008"/>
+      <point x="1085" y="1008" type="curve" smooth="yes"/>
+      <point x="1288" y="1008"/>
+      <point x="1303" y="735"/>
+      <point x="1303" y="659" type="curve" smooth="yes"/>
+      <point x="1303" y="584"/>
+      <point x="1278" y="61"/>
+      <point x="952" y="61" type="curve" smooth="yes"/>
+      <point x="850" y="61"/>
+      <point x="752" y="117"/>
+      <point x="752" y="229" type="curve" smooth="yes"/>
+      <point x="752" y="244"/>
+      <point x="754" y="258"/>
+      <point x="758" y="270" type="curve"/>
+      <point x="823" y="279"/>
+      <point x="889" y="309"/>
+      <point x="889" y="397" type="curve" smooth="yes"/>
+      <point x="889" y="461"/>
+      <point x="846" y="500"/>
+      <point x="784" y="500" type="curve" smooth="yes"/>
+      <point x="688" y="500"/>
+      <point x="631" y="422"/>
+      <point x="631" y="287" type="curve" smooth="yes"/>
+      <point x="631" y="104"/>
+      <point x="756" y="-20"/>
+      <point x="967" y="-20" type="curve" smooth="yes"/>
+      <point x="1319" y="-20"/>
+      <point x="1505" y="326"/>
+      <point x="1505" y="627" type="curve" smooth="yes"/>
+      <point x="1505" y="895"/>
+      <point x="1384" y="1124"/>
+      <point x="1145" y="1124" type="curve" smooth="yes"/>
+      <point x="1044" y="1124"/>
+      <point x="856" y="1049"/>
+      <point x="645" y="858" type="curve" smooth="yes"/>
+      <point x="541" y="764"/>
+      <point x="420" y="635"/>
+      <point x="317" y="487" type="curve"/>
+      <point x="287" y="557"/>
+      <point x="268" y="629"/>
+      <point x="268" y="707" type="curve" smooth="yes"/>
+      <point x="268" y="971"/>
+      <point x="328" y="1122"/>
+      <point x="487" y="1280" type="curve"/>
+      <point x="457" y="1325" type="line"/>
+      <point x="340" y="1249"/>
+      <point x="94" y="1016"/>
+      <point x="94" y="690" type="curve" smooth="yes"/>
+      <point x="94" y="547"/>
+      <point x="141" y="422"/>
+      <point x="205" y="305" type="curve"/>
+      <point x="135" y="174"/>
+      <point x="84" y="23"/>
+      <point x="84" y="-115" type="curve" smooth="yes"/>
+      <point x="84" y="-334"/>
+      <point x="229" y="-494"/>
     </contour>
     <contour>
-      <point x="192" y="-199" type="curve" smooth="yes"/>
-      <point x="148" y="-199"/>
-      <point x="81" y="-145"/>
-      <point x="81" y="-51" type="curve" smooth="yes"/>
-      <point x="81" y="-4"/>
-      <point x="97" y="52"/>
-      <point x="125" y="110" type="curve"/>
-      <point x="179" y="24"/>
-      <point x="240" y="-52"/>
-      <point x="240" y="-134" type="curve" smooth="yes"/>
-      <point x="240" y="-176"/>
-      <point x="221" y="-199"/>
+      <point x="385" y="-408" type="curve" smooth="yes"/>
+      <point x="295" y="-408"/>
+      <point x="164" y="-297"/>
+      <point x="164" y="-104" type="curve" smooth="yes"/>
+      <point x="164" y="-8"/>
+      <point x="197" y="106"/>
+      <point x="252" y="225" type="curve"/>
+      <point x="356" y="49"/>
+      <point x="479" y="-106"/>
+      <point x="479" y="-274" type="curve" smooth="yes"/>
+      <point x="479" y="-360"/>
+      <point x="442" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="808"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="210" y="-241" type="curve" smooth="yes"/>
+      <point x="280" y="-241"/>
+      <point x="327" y="-180"/>
+      <point x="327" y="-95" type="curve" smooth="yes"/>
+      <point x="327" y="8"/>
+      <point x="235" y="99"/>
+      <point x="178" y="200" type="curve"/>
+      <point x="225" y="272"/>
+      <point x="285" y="341"/>
+      <point x="347" y="394" type="curve" smooth="yes"/>
+      <point x="415" y="452"/>
+      <point x="486" y="492"/>
+      <point x="545" y="492" type="curve" smooth="yes"/>
+      <point x="647" y="492"/>
+      <point x="655" y="359"/>
+      <point x="655" y="322" type="curve" smooth="yes"/>
+      <point x="655" y="285"/>
+      <point x="642" y="30"/>
+      <point x="478" y="30" type="curve" smooth="yes"/>
+      <point x="427" y="30"/>
+      <point x="378" y="57"/>
+      <point x="378" y="112" type="curve" smooth="yes"/>
+      <point x="378" y="119"/>
+      <point x="379" y="126"/>
+      <point x="381" y="132" type="curve"/>
+      <point x="413" y="136"/>
+      <point x="446" y="151"/>
+      <point x="446" y="194" type="curve" smooth="yes"/>
+      <point x="446" y="225"/>
+      <point x="425" y="244"/>
+      <point x="394" y="244" type="curve" smooth="yes"/>
+      <point x="346" y="244"/>
+      <point x="316" y="206"/>
+      <point x="316" y="140" type="curve" smooth="yes"/>
+      <point x="316" y="51"/>
+      <point x="380" y="-10"/>
+      <point x="486" y="-10" type="curve" smooth="yes"/>
+      <point x="664" y="-10"/>
+      <point x="757" y="159"/>
+      <point x="757" y="306" type="curve" smooth="yes"/>
+      <point x="757" y="437"/>
+      <point x="697" y="549"/>
+      <point x="575" y="549" type="curve" smooth="yes"/>
+      <point x="525" y="549"/>
+      <point x="429" y="512"/>
+      <point x="323" y="419" type="curve" smooth="yes"/>
+      <point x="271" y="373"/>
+      <point x="210" y="310"/>
+      <point x="158" y="238" type="curve"/>
+      <point x="143" y="272"/>
+      <point x="134" y="307"/>
+      <point x="134" y="345" type="curve" smooth="yes"/>
+      <point x="134" y="474"/>
+      <point x="164" y="548"/>
+      <point x="245" y="625" type="curve"/>
+      <point x="229" y="647" type="line"/>
+      <point x="170" y="610"/>
+      <point x="46" y="496"/>
+      <point x="46" y="337" type="curve" smooth="yes"/>
+      <point x="46" y="267"/>
+      <point x="70" y="206"/>
+      <point x="102" y="149" type="curve"/>
+      <point x="67" y="85"/>
+      <point x="41" y="11"/>
+      <point x="41" y="-56" type="curve" smooth="yes"/>
+      <point x="41" y="-163"/>
+      <point x="115" y="-241"/>
+    </contour>
+    <contour>
+      <point x="192" y="-199" type="curve" smooth="yes"/>
+      <point x="148" y="-199"/>
+      <point x="81" y="-145"/>
+      <point x="81" y="-51" type="curve" smooth="yes"/>
+      <point x="81" y="-4"/>
+      <point x="97" y="52"/>
+      <point x="125" y="110" type="curve"/>
+      <point x="179" y="24"/>
+      <point x="240" y="-52"/>
+      <point x="240" y="-134" type="curve" smooth="yes"/>
+      <point x="240" y="-176"/>
+      <point x="221" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1205"/>
+  <unicode hex="2127"/>
+  <anchor x="608" y="1445" name="top"/>
+  <outline>
+    <contour>
+      <point x="611" y="-20" type="curve" smooth="yes"/>
+      <point x="904" y="-20"/>
+      <point x="1104" y="233"/>
+      <point x="1104" y="593" type="curve"/>
+      <point x="1104" y="678" type="line"/>
+      <point x="1104" y="1036"/>
+      <point x="874" y="1320"/>
+      <point x="642" y="1350" type="curve"/>
+      <point x="642" y="1204" type="line"/>
+      <point x="730" y="1158"/>
+      <point x="775" y="1006"/>
+      <point x="775" y="678" type="curve"/>
+      <point x="775" y="591" type="line"/>
+      <point x="775" y="350"/>
+      <point x="713" y="227"/>
+      <point x="611" y="227" type="curve" smooth="yes"/>
+      <point x="506" y="227"/>
+      <point x="444" y="350"/>
+      <point x="444" y="591" type="curve"/>
+      <point x="444" y="678" type="line"/>
+      <point x="444" y="1004"/>
+      <point x="489" y="1157"/>
+      <point x="572" y="1204" type="curve"/>
+      <point x="572" y="1350" type="line"/>
+      <point x="344" y="1318"/>
+      <point x="115" y="1036"/>
+      <point x="115" y="678" type="curve"/>
+      <point x="115" y="593" type="line"/>
+      <point x="115" y="233"/>
+      <point x="317" y="-20"/>
+    </contour>
+    <contour>
+      <point x="136" y="1208" type="line"/>
+      <point x="572" y="1208" type="line"/>
+      <point x="572" y="1455" type="line"/>
+      <point x="136" y="1455" type="line"/>
+    </contour>
+    <contour>
+      <point x="642" y="1208" type="line"/>
+      <point x="1085" y="1208" type="line"/>
+      <point x="1085" y="1455" type="line"/>
+      <point x="642" y="1455" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2127.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1205"/>
+  <advance width="1209"/>
   <unicode hex="2127"/>
-  <anchor x="608" y="1445" name="top"/>
+  <anchor x="603" y="1445" name="top"/>
   <outline>
     <contour>
-      <point x="611" y="-20" type="curve" smooth="yes"/>
-      <point x="904" y="-20"/>
-      <point x="1104" y="233"/>
-      <point x="1104" y="593" type="curve"/>
-      <point x="1104" y="678" type="line"/>
-      <point x="1104" y="1036"/>
-      <point x="874" y="1320"/>
-      <point x="642" y="1350" type="curve"/>
-      <point x="642" y="1204" type="line"/>
-      <point x="730" y="1158"/>
-      <point x="775" y="1006"/>
-      <point x="775" y="678" type="curve"/>
-      <point x="775" y="591" type="line"/>
-      <point x="775" y="350"/>
-      <point x="713" y="227"/>
-      <point x="611" y="227" type="curve" smooth="yes"/>
-      <point x="506" y="227"/>
-      <point x="444" y="350"/>
-      <point x="444" y="591" type="curve"/>
-      <point x="444" y="678" type="line"/>
-      <point x="444" y="1004"/>
-      <point x="489" y="1157"/>
-      <point x="572" y="1204" type="curve"/>
-      <point x="572" y="1350" type="line"/>
-      <point x="344" y="1318"/>
-      <point x="115" y="1036"/>
-      <point x="115" y="678" type="curve"/>
-      <point x="115" y="593" type="line"/>
-      <point x="115" y="233"/>
-      <point x="317" y="-20"/>
+      <point x="606" y="-20" type="curve" smooth="yes"/>
+      <point x="899" y="-20"/>
+      <point x="1099" y="233"/>
+      <point x="1099" y="593" type="curve"/>
+      <point x="1099" y="678" type="line"/>
+      <point x="1099" y="1036"/>
+      <point x="869" y="1320"/>
+      <point x="637" y="1350" type="curve"/>
+      <point x="637" y="1204" type="line"/>
+      <point x="725" y="1158"/>
+      <point x="770" y="1006"/>
+      <point x="770" y="678" type="curve"/>
+      <point x="770" y="591" type="line"/>
+      <point x="770" y="350"/>
+      <point x="708" y="227"/>
+      <point x="606" y="227" type="curve" smooth="yes"/>
+      <point x="501" y="227"/>
+      <point x="439" y="350"/>
+      <point x="439" y="591" type="curve"/>
+      <point x="439" y="678" type="line"/>
+      <point x="439" y="1004"/>
+      <point x="484" y="1157"/>
+      <point x="567" y="1204" type="curve"/>
+      <point x="567" y="1350" type="line"/>
+      <point x="339" y="1318"/>
+      <point x="110" y="1036"/>
+      <point x="110" y="678" type="curve"/>
+      <point x="110" y="593" type="line"/>
+      <point x="110" y="233"/>
+      <point x="312" y="-20"/>
     </contour>
     <contour>
-      <point x="136" y="1208" type="line"/>
-      <point x="572" y="1208" type="line"/>
-      <point x="572" y="1455" type="line"/>
-      <point x="136" y="1455" type="line"/>
+      <point x="131" y="1208" type="line"/>
+      <point x="567" y="1208" type="line"/>
+      <point x="567" y="1455" type="line"/>
+      <point x="131" y="1455" type="line"/>
     </contour>
     <contour>
-      <point x="642" y="1208" type="line"/>
-      <point x="1085" y="1208" type="line"/>
-      <point x="1085" y="1455" type="line"/>
-      <point x="642" y="1455" type="line"/>
+      <point x="637" y="1208" type="line"/>
+      <point x="1080" y="1208" type="line"/>
+      <point x="1080" y="1455" type="line"/>
+      <point x="637" y="1455" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2129.glif
@@ -14,8 +14,8 @@
       <point x="402" y="1082"/>
       <point x="234" y="1082" type="curve" smooth="yes"/>
       <point x="168" y="1082"/>
-      <point x="120" y="1071"/>
-      <point x="77" y="1054" type="curve"/>
+      <point x="118" y="1071"/>
+      <point x="75" y="1054" type="curve"/>
       <point x="75" y="834" type="line"/>
       <point x="90" y="838"/>
       <point x="114" y="841"/>
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="640"/>
+  <unicode hex="2129"/>
+  <anchor x="354" y="-198" name="bottom"/>
+  <anchor x="20" y="-198" name="bottom0315"/>
+  <anchor x="354" y="-198" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="226" y="-12" type="line"/>
+      <point x="510" y="-12" type="line"/>
+      <point x="510" y="761" type="line"/>
+      <point x="510" y="991"/>
+      <point x="402" y="1082"/>
+      <point x="234" y="1082" type="curve" smooth="yes"/>
+      <point x="168" y="1082"/>
+      <point x="120" y="1071"/>
+      <point x="77" y="1054" type="curve"/>
+      <point x="75" y="834" type="line"/>
+      <point x="90" y="838"/>
+      <point x="114" y="841"/>
+      <point x="142" y="841" type="curve" smooth="yes"/>
+      <point x="203" y="841"/>
+      <point x="227" y="820"/>
+      <point x="227" y="729" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="517"/>
+  <unicode hex="2139"/>
+  <anchor x="258" y="10" name="bottom"/>
+  <anchor x="497" y="-407" name="bottom_dd"/>
+  <anchor x="257" y="1600" name="parent_top"/>
+  <anchor x="321" y="654" name="rhotichook"/>
+  <anchor x="257" y="1600" name="top"/>
+  <anchor x="497" y="1600" name="top0315"/>
+  <anchor x="497" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2139.glif
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1808"/>
+  <unicode hex="213A"/>
+  <anchor x="1557" y="606" name="bottom"/>
+  <anchor x="1954" y="1216" name="bottom_dd"/>
+  <anchor x="-53" y="608" name="parent_top"/>
+  <anchor x="-53" y="608" name="top"/>
+  <anchor x="-53" y="1216" name="top0315"/>
+  <anchor x="-53" y="1216" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="707" y="91" type="curve"/>
+      <point x="932" y="91" type="line"/>
+      <point x="1352" y="91"/>
+      <point x="1567" y="305"/>
+      <point x="1567" y="617" type="curve" smooth="yes"/>
+      <point x="1567" y="930"/>
+      <point x="1352" y="1141"/>
+      <point x="932" y="1141" type="curve"/>
+      <point x="707" y="1141" type="line"/>
+      <point x="287" y="1141"/>
+      <point x="71" y="929"/>
+      <point x="71" y="615" type="curve" smooth="yes"/>
+      <point x="71" y="303"/>
+      <point x="287" y="91"/>
+    </contour>
+    <contour>
+      <point x="705" y="385" type="line" smooth="yes"/>
+      <point x="428" y="385"/>
+      <point x="317" y="465"/>
+      <point x="317" y="615" type="curve" smooth="yes"/>
+      <point x="317" y="765"/>
+      <point x="428" y="847"/>
+      <point x="705" y="847" type="curve"/>
+      <point x="932" y="847" type="line"/>
+      <point x="1207" y="847"/>
+      <point x="1322" y="767"/>
+      <point x="1322" y="617" type="curve" smooth="yes"/>
+      <point x="1322" y="466"/>
+      <point x="1207" y="385"/>
+      <point x="932" y="385" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1494" y="620" type="line"/>
+      <point x="1808" y="962" type="line"/>
+      <point x="1638" y="1147" type="line"/>
+      <point x="1323" y="798" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni213A_.glif
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1199"/>
+  <unicode hex="2141"/>
+  <anchor x="596" y="-151" name="bottom"/>
+  <anchor x="8" y="-151" name="bottom0315"/>
+  <anchor x="8" y="-143" name="bottom_dd"/>
+  <anchor x="596" y="-151" name="parent_bottom"/>
+  <anchor x="569" y="1460" name="top"/>
+  <anchor x="8" y="1864" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="588" y="-20" type="curve" smooth="yes"/>
+      <point x="905" y="-20"/>
+      <point x="1104" y="182"/>
+      <point x="1104" y="606" type="curve" smooth="yes"/>
+      <point x="1104" y="853" type="line" smooth="yes"/>
+      <point x="1104" y="1276"/>
+      <point x="894" y="1477"/>
+      <point x="570" y="1477" type="curve" smooth="yes"/>
+      <point x="296" y="1477"/>
+      <point x="153" y="1358"/>
+      <point x="91" y="1292" type="curve"/>
+      <point x="91" y="691" type="line"/>
+      <point x="593" y="691" type="line"/>
+      <point x="593" y="913" type="line"/>
+      <point x="386" y="913" type="line"/>
+      <point x="386" y="1180" type="line"/>
+      <point x="411" y="1194"/>
+      <point x="449" y="1233"/>
+      <point x="553" y="1233" type="curve" smooth="yes"/>
+      <point x="727" y="1233"/>
+      <point x="809" y="1129"/>
+      <point x="809" y="853" type="curve" smooth="yes"/>
+      <point x="809" y="604" type="line" smooth="yes"/>
+      <point x="809" y="328"/>
+      <point x="734" y="224"/>
+      <point x="580" y="224" type="curve" smooth="yes"/>
+      <point x="449" y="224"/>
+      <point x="393" y="281"/>
+      <point x="377" y="464" type="curve"/>
+      <point x="92" y="464" type="line"/>
+      <point x="115" y="148"/>
+      <point x="259" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="980"/>
+  <unicode hex="2142"/>
+  <anchor x="710" y="-144" name="bottom"/>
+  <anchor x="20" y="-144" name="bottom0315"/>
+  <anchor x="20" y="-144" name="bottom_dd"/>
+  <anchor x="710" y="-144" name="parent_bottom"/>
+  <anchor x="459" y="1446" name="top"/>
+  <anchor x="20" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="568" y="0" type="line"/>
+      <point x="863" y="0" type="line"/>
+      <point x="863" y="1456" type="line"/>
+      <point x="568" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="53" y="1212" type="line"/>
+      <point x="659" y="1212" type="line"/>
+      <point x="659" y="1456" type="line"/>
+      <point x="53" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="980"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="568" y="0" type="line"/>
+      <point x="863" y="0" type="line"/>
+      <point x="863" y="1456" type="line"/>
+      <point x="568" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="53" y="0" type="line"/>
+      <point x="659" y="0" type="line"/>
+      <point x="659" y="244" type="line"/>
+      <point x="53" y="244" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1112"/>
+  <unicode hex="2144"/>
+  <anchor x="554" y="-144" name="bottom"/>
+  <anchor x="20" y="-144" name="bottom0315"/>
+  <anchor x="20" y="-144" name="bottom_dd"/>
+  <anchor x="554" y="-144" name="parent_bottom"/>
+  <anchor x="558" y="1421" name="top"/>
+  <anchor x="20" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="16" y="0" type="line"/>
+      <point x="337" y="0" type="line"/>
+      <point x="556" y="654" type="line"/>
+      <point x="776" y="0" type="line"/>
+      <point x="1096" y="0" type="line"/>
+      <point x="705" y="928" type="line"/>
+      <point x="705" y="1456" type="line"/>
+      <point x="407" y="1456" type="line"/>
+      <point x="407" y="928" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni214A_.glif
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1383"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="117" y="300" type="line"/>
+      <point x="412" y="300" type="line"/>
+      <point x="412" y="1211" type="line"/>
+      <point x="804" y="1211" type="line"/>
+      <point x="927" y="1211"/>
+      <point x="979" y="1098"/>
+      <point x="979" y="972" type="curve"/>
+      <point x="979" y="847"/>
+      <point x="927" y="757"/>
+      <point x="804" y="757" type="curve"/>
+      <point x="659" y="757" type="line"/>
+      <point x="659" y="512" type="line"/>
+      <point x="804" y="512" type="line"/>
+      <point x="1098" y="512"/>
+      <point x="1277" y="692"/>
+      <point x="1277" y="974" type="curve"/>
+      <point x="1277" y="1253"/>
+      <point x="1098" y="1456"/>
+      <point x="804" y="1456" type="curve"/>
+      <point x="117" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="734" y="0" type="line"/>
+      <point x="1330" y="0" type="line"/>
+      <point x="1330" y="244" type="line"/>
+      <point x="734" y="244" type="line"/>
+    </contour>
+    <contour>
+      <point x="530" y="0" type="line"/>
+      <point x="825" y="0" type="line"/>
+      <point x="825" y="1600" type="line"/>
+      <point x="530" y="1600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1186"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="662" y="-21" type="curve" smooth="yes"/>
+      <point x="873" y="-21"/>
+      <point x="1011" y="133"/>
+      <point x="1011" y="363" type="curve" smooth="yes"/>
+      <point x="1011" y="511"/>
+      <point x="929" y="637"/>
+      <point x="810" y="812" type="curve" smooth="yes"/>
+      <point x="355" y="1456" type="line"/>
+      <point x="35" y="1456" type="line"/>
+      <point x="604" y="658" type="line" smooth="yes"/>
+      <point x="688" y="538"/>
+      <point x="759" y="448"/>
+      <point x="759" y="359" type="curve" smooth="yes"/>
+      <point x="759" y="280"/>
+      <point x="727" y="214"/>
+      <point x="663" y="214" type="curve" smooth="yes"/>
+      <point x="603" y="214"/>
+      <point x="567" y="277"/>
+      <point x="567" y="337" type="curve"/>
+      <point x="567" y="396"/>
+      <point x="575" y="443"/>
+      <point x="645" y="497" type="curve"/>
+      <point x="882" y="679" type="line"/>
+      <point x="1020" y="792"/>
+      <point x="1114" y="891"/>
+      <point x="1114" y="1064" type="curve"/>
+      <point x="1114" y="1305"/>
+      <point x="958" y="1477"/>
+      <point x="707" y="1477" type="curve"/>
+      <point x="568" y="1477"/>
+      <point x="454" y="1429"/>
+      <point x="346" y="1327" type="curve" smooth="yes"/>
+      <point x="338" y="1321"/>
+      <point x="321" y="1304"/>
+      <point x="313" y="1298" type="curve" smooth="yes"/>
+      <point x="165" y="1165"/>
+      <point x="113" y="968"/>
+      <point x="113" y="741" type="curve"/>
+      <point x="352" y="741" type="line"/>
+      <point x="352" y="1038"/>
+      <point x="521" y="1242"/>
+      <point x="692" y="1242" type="curve" smooth="yes"/>
+      <point x="770" y="1242"/>
+      <point x="830" y="1160"/>
+      <point x="830" y="1047" type="curve"/>
+      <point x="830" y="992"/>
+      <point x="821" y="933"/>
+      <point x="780" y="869" type="curve" smooth="yes"/>
+      <point x="499" y="641" type="line" smooth="yes"/>
+      <point x="396" y="559"/>
+      <point x="334" y="455"/>
+      <point x="334" y="319" type="curve"/>
+      <point x="334" y="136"/>
+      <point x="464" y="-21"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni214B_.glif
@@ -4,66 +4,66 @@
   <unicode hex="214B"/>
   <outline>
     <contour>
-      <point x="662" y="-21" type="curve" smooth="yes"/>
-      <point x="873" y="-21"/>
-      <point x="1011" y="133"/>
-      <point x="1011" y="363" type="curve" smooth="yes"/>
-      <point x="1011" y="511"/>
-      <point x="929" y="637"/>
-      <point x="810" y="812" type="curve" smooth="yes"/>
-      <point x="355" y="1456" type="line"/>
-      <point x="35" y="1456" type="line"/>
-      <point x="604" y="658" type="line" smooth="yes"/>
-      <point x="688" y="538"/>
-      <point x="759" y="448"/>
-      <point x="759" y="359" type="curve" smooth="yes"/>
-      <point x="759" y="280"/>
-      <point x="727" y="214"/>
-      <point x="663" y="214" type="curve" smooth="yes"/>
-      <point x="603" y="214"/>
-      <point x="567" y="277"/>
-      <point x="567" y="337" type="curve"/>
-      <point x="567" y="396"/>
-      <point x="575" y="443"/>
-      <point x="645" y="497" type="curve"/>
-      <point x="882" y="679" type="line"/>
-      <point x="1020" y="792"/>
-      <point x="1114" y="891"/>
-      <point x="1114" y="1064" type="curve"/>
-      <point x="1114" y="1305"/>
-      <point x="958" y="1477"/>
-      <point x="707" y="1477" type="curve"/>
-      <point x="568" y="1477"/>
-      <point x="454" y="1429"/>
-      <point x="346" y="1327" type="curve" smooth="yes"/>
-      <point x="338" y="1321"/>
-      <point x="321" y="1304"/>
-      <point x="313" y="1298" type="curve" smooth="yes"/>
-      <point x="165" y="1165"/>
-      <point x="113" y="968"/>
-      <point x="113" y="741" type="curve"/>
-      <point x="352" y="741" type="line"/>
-      <point x="352" y="1038"/>
-      <point x="521" y="1242"/>
-      <point x="692" y="1242" type="curve" smooth="yes"/>
-      <point x="770" y="1242"/>
-      <point x="830" y="1160"/>
-      <point x="830" y="1047" type="curve"/>
-      <point x="830" y="992"/>
-      <point x="821" y="933"/>
-      <point x="780" y="869" type="curve" smooth="yes"/>
-      <point x="499" y="641" type="line" smooth="yes"/>
-      <point x="396" y="559"/>
-      <point x="334" y="455"/>
-      <point x="334" y="319" type="curve"/>
-      <point x="334" y="136"/>
-      <point x="464" y="-21"/>
+      <point x="652" y="-21" type="curve" smooth="yes"/>
+      <point x="863" y="-21"/>
+      <point x="1001" y="133"/>
+      <point x="1001" y="363" type="curve" smooth="yes"/>
+      <point x="1001" y="511"/>
+      <point x="919" y="637"/>
+      <point x="800" y="812" type="curve" smooth="yes"/>
+      <point x="345" y="1456" type="line"/>
+      <point x="25" y="1456" type="line"/>
+      <point x="594" y="658" type="line" smooth="yes"/>
+      <point x="678" y="538"/>
+      <point x="749" y="448"/>
+      <point x="749" y="359" type="curve" smooth="yes"/>
+      <point x="749" y="280"/>
+      <point x="717" y="214"/>
+      <point x="653" y="214" type="curve" smooth="yes"/>
+      <point x="593" y="214"/>
+      <point x="557" y="277"/>
+      <point x="557" y="337" type="curve"/>
+      <point x="557" y="396"/>
+      <point x="565" y="443"/>
+      <point x="635" y="497" type="curve"/>
+      <point x="872" y="679" type="line"/>
+      <point x="1010" y="792"/>
+      <point x="1104" y="891"/>
+      <point x="1104" y="1064" type="curve"/>
+      <point x="1104" y="1305"/>
+      <point x="948" y="1477"/>
+      <point x="697" y="1477" type="curve"/>
+      <point x="558" y="1477"/>
+      <point x="444" y="1429"/>
+      <point x="336" y="1327" type="curve" smooth="yes"/>
+      <point x="328" y="1321"/>
+      <point x="311" y="1304"/>
+      <point x="303" y="1298" type="curve" smooth="yes"/>
+      <point x="155" y="1165"/>
+      <point x="103" y="968"/>
+      <point x="103" y="741" type="curve"/>
+      <point x="342" y="741" type="line"/>
+      <point x="342" y="1038"/>
+      <point x="511" y="1242"/>
+      <point x="682" y="1242" type="curve" smooth="yes"/>
+      <point x="760" y="1242"/>
+      <point x="820" y="1160"/>
+      <point x="820" y="1047" type="curve"/>
+      <point x="820" y="992"/>
+      <point x="811" y="933"/>
+      <point x="770" y="869" type="curve" smooth="yes"/>
+      <point x="489" y="641" type="line" smooth="yes"/>
+      <point x="386" y="559"/>
+      <point x="324" y="455"/>
+      <point x="324" y="319" type="curve"/>
+      <point x="324" y="136"/>
+      <point x="454" y="-21"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="615"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="265" y="-10" type="curve" smooth="yes"/>
+      <point x="347" y="-10"/>
+      <point x="374" y="51"/>
+      <point x="374" y="117" type="curve" smooth="yes"/>
+      <point x="374" y="140"/>
+      <point x="366" y="204"/>
+      <point x="358" y="277" type="curve"/>
+      <point x="434" y="291"/>
+      <point x="500" y="326"/>
+      <point x="542" y="375" type="curve"/>
+      <point x="551" y="361"/>
+      <point x="556" y="345"/>
+      <point x="556" y="327" type="curve" smooth="yes"/>
+      <point x="556" y="281"/>
+      <point x="509" y="238"/>
+      <point x="491" y="224" type="curve"/>
+      <point x="525" y="224" type="line"/>
+      <point x="544" y="238"/>
+      <point x="586" y="281"/>
+      <point x="586" y="326" type="curve" smooth="yes"/>
+      <point x="586" y="354"/>
+      <point x="576" y="378"/>
+      <point x="559" y="397" type="curve"/>
+      <point x="580" y="427"/>
+      <point x="592" y="462"/>
+      <point x="592" y="500" type="curve" smooth="yes"/>
+      <point x="592" y="608"/>
+      <point x="521" y="725"/>
+      <point x="412" y="725" type="curve" smooth="yes"/>
+      <point x="329" y="725"/>
+      <point x="302" y="664"/>
+      <point x="302" y="569" type="curve" smooth="yes"/>
+      <point x="302" y="548"/>
+      <point x="303" y="515"/>
+      <point x="304" y="477" type="curve"/>
+      <point x="292" y="478"/>
+      <point x="281" y="478"/>
+      <point x="271" y="478" type="curve" smooth="yes"/>
+      <point x="260" y="478"/>
+      <point x="241" y="477"/>
+      <point x="220" y="475" type="curve"/>
+      <point x="222" y="613" type="line"/>
+      <point x="237" y="635"/>
+      <point x="251" y="658"/>
+      <point x="251" y="675" type="curve" smooth="yes"/>
+      <point x="251" y="681"/>
+      <point x="250" y="708"/>
+      <point x="223" y="708" type="curve" smooth="yes"/>
+      <point x="188" y="708"/>
+      <point x="200" y="669"/>
+      <point x="184" y="669" type="curve" smooth="yes"/>
+      <point x="164" y="669"/>
+      <point x="153" y="715"/>
+      <point x="105" y="715" type="curve" smooth="yes"/>
+      <point x="82" y="715"/>
+      <point x="41" y="702"/>
+      <point x="41" y="643" type="curve" smooth="yes"/>
+      <point x="41" y="603"/>
+      <point x="68" y="572"/>
+      <point x="112" y="572" type="curve" smooth="yes"/>
+      <point x="119" y="572"/>
+      <point x="126" y="573"/>
+      <point x="131" y="574" type="curve"/>
+      <point x="130" y="592" type="line"/>
+      <point x="126" y="591"/>
+      <point x="118" y="590"/>
+      <point x="112" y="590" type="curve" smooth="yes"/>
+      <point x="94" y="590"/>
+      <point x="88" y="606"/>
+      <point x="88" y="617" type="curve" smooth="yes"/>
+      <point x="88" y="630"/>
+      <point x="97" y="644"/>
+      <point x="116" y="644" type="curve" smooth="yes"/>
+      <point x="138" y="644"/>
+      <point x="185" y="625"/>
+      <point x="202" y="615" type="curve"/>
+      <point x="186" y="471" type="line"/>
+      <point x="124" y="460"/>
+      <point x="54" y="433"/>
+      <point x="54" y="369" type="curve" smooth="yes"/>
+      <point x="54" y="315"/>
+      <point x="107" y="290"/>
+      <point x="167" y="279" type="curve"/>
+      <point x="160" y="208"/>
+      <point x="156" y="144"/>
+      <point x="156" y="117" type="curve" smooth="yes"/>
+      <point x="156" y="51"/>
+      <point x="183" y="-10"/>
+    </contour>
+    <contour>
+      <point x="265" y="20" type="curve" smooth="yes"/>
+      <point x="228" y="20"/>
+      <point x="208" y="58"/>
+      <point x="208" y="115" type="curve" smooth="yes"/>
+      <point x="208" y="146"/>
+      <point x="210" y="206"/>
+      <point x="212" y="273" type="curve"/>
+      <point x="237" y="270"/>
+      <point x="261" y="270"/>
+      <point x="282" y="270" type="curve" smooth="yes"/>
+      <point x="292" y="270"/>
+      <point x="303" y="270"/>
+      <point x="314" y="271" type="curve"/>
+      <point x="317" y="195"/>
+      <point x="321" y="132"/>
+      <point x="321" y="115" type="curve" smooth="yes"/>
+      <point x="321" y="58"/>
+      <point x="301" y="20"/>
+    </contour>
+    <contour>
+      <point x="169" y="299" type="line"/>
+      <point x="89" y="318"/>
+      <point x="79" y="358"/>
+      <point x="79" y="372" type="curve" smooth="yes"/>
+      <point x="79" y="384"/>
+      <point x="85" y="434"/>
+      <point x="184" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="281" y="288" type="curve" smooth="yes"/>
+      <point x="254" y="288"/>
+      <point x="233" y="289"/>
+      <point x="213" y="291" type="curve"/>
+      <point x="219" y="458" type="line"/>
+      <point x="234" y="459"/>
+      <point x="251" y="460"/>
+      <point x="270" y="460" type="curve" smooth="yes"/>
+      <point x="282" y="460"/>
+      <point x="293" y="459"/>
+      <point x="305" y="459" type="curve"/>
+      <point x="313" y="289" type="line"/>
+      <point x="302" y="288"/>
+      <point x="292" y="288"/>
+    </contour>
+    <contour>
+      <point x="356" y="295" type="curve"/>
+      <point x="337" y="457" type="line"/>
+      <point x="397" y="452"/>
+      <point x="457" y="439"/>
+      <point x="499" y="414" type="curve"/>
+      <point x="476" y="351"/>
+      <point x="428" y="311"/>
+    </contour>
+    <contour>
+      <point x="504" y="436" type="curve"/>
+      <point x="455" y="460"/>
+      <point x="390" y="471"/>
+      <point x="335" y="475" type="curve"/>
+      <point x="331" y="514"/>
+      <point x="329" y="548"/>
+      <point x="329" y="572" type="curve" smooth="yes"/>
+      <point x="329" y="636"/>
+      <point x="335" y="707"/>
+      <point x="409" y="707" type="curve" smooth="yes"/>
+      <point x="500" y="707"/>
+      <point x="516" y="593"/>
+      <point x="516" y="519" type="curve" smooth="yes"/>
+      <point x="516" y="488"/>
+      <point x="511" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="615"/>
+  <advance width="1260"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="265" y="-10" type="curve" smooth="yes"/>
-      <point x="347" y="-10"/>
-      <point x="374" y="51"/>
-      <point x="374" y="117" type="curve" smooth="yes"/>
-      <point x="374" y="140"/>
-      <point x="366" y="204"/>
-      <point x="358" y="277" type="curve"/>
-      <point x="434" y="291"/>
-      <point x="500" y="326"/>
-      <point x="542" y="375" type="curve"/>
-      <point x="551" y="361"/>
-      <point x="556" y="345"/>
-      <point x="556" y="327" type="curve" smooth="yes"/>
-      <point x="556" y="281"/>
-      <point x="509" y="238"/>
-      <point x="491" y="224" type="curve"/>
-      <point x="525" y="224" type="line"/>
-      <point x="544" y="238"/>
-      <point x="586" y="281"/>
-      <point x="586" y="326" type="curve" smooth="yes"/>
-      <point x="586" y="354"/>
-      <point x="576" y="378"/>
-      <point x="559" y="397" type="curve"/>
-      <point x="580" y="427"/>
-      <point x="592" y="462"/>
-      <point x="592" y="500" type="curve" smooth="yes"/>
-      <point x="592" y="608"/>
-      <point x="521" y="725"/>
-      <point x="412" y="725" type="curve" smooth="yes"/>
-      <point x="329" y="725"/>
-      <point x="302" y="664"/>
-      <point x="302" y="569" type="curve" smooth="yes"/>
-      <point x="302" y="548"/>
-      <point x="303" y="515"/>
-      <point x="304" y="477" type="curve"/>
-      <point x="292" y="478"/>
-      <point x="281" y="478"/>
-      <point x="271" y="478" type="curve" smooth="yes"/>
-      <point x="260" y="478"/>
-      <point x="241" y="477"/>
-      <point x="220" y="475" type="curve"/>
-      <point x="222" y="613" type="line"/>
-      <point x="237" y="635"/>
-      <point x="251" y="658"/>
-      <point x="251" y="675" type="curve" smooth="yes"/>
-      <point x="251" y="681"/>
-      <point x="250" y="708"/>
-      <point x="223" y="708" type="curve" smooth="yes"/>
-      <point x="188" y="708"/>
-      <point x="200" y="669"/>
-      <point x="184" y="669" type="curve" smooth="yes"/>
-      <point x="164" y="669"/>
-      <point x="153" y="715"/>
-      <point x="105" y="715" type="curve" smooth="yes"/>
-      <point x="82" y="715"/>
-      <point x="41" y="702"/>
-      <point x="41" y="643" type="curve" smooth="yes"/>
-      <point x="41" y="603"/>
-      <point x="68" y="572"/>
-      <point x="112" y="572" type="curve" smooth="yes"/>
-      <point x="119" y="572"/>
-      <point x="126" y="573"/>
-      <point x="131" y="574" type="curve"/>
-      <point x="130" y="592" type="line"/>
-      <point x="126" y="591"/>
-      <point x="118" y="590"/>
-      <point x="112" y="590" type="curve" smooth="yes"/>
-      <point x="94" y="590"/>
-      <point x="88" y="606"/>
-      <point x="88" y="617" type="curve" smooth="yes"/>
-      <point x="88" y="630"/>
-      <point x="97" y="644"/>
-      <point x="116" y="644" type="curve" smooth="yes"/>
-      <point x="138" y="644"/>
-      <point x="185" y="625"/>
-      <point x="202" y="615" type="curve"/>
-      <point x="186" y="471" type="line"/>
-      <point x="124" y="460"/>
-      <point x="54" y="433"/>
-      <point x="54" y="369" type="curve" smooth="yes"/>
-      <point x="54" y="315"/>
-      <point x="107" y="290"/>
-      <point x="167" y="279" type="curve"/>
-      <point x="160" y="208"/>
-      <point x="156" y="144"/>
-      <point x="156" y="117" type="curve" smooth="yes"/>
-      <point x="156" y="51"/>
-      <point x="183" y="-10"/>
+      <point x="543" y="-20" type="curve" smooth="yes"/>
+      <point x="711" y="-20"/>
+      <point x="766" y="104"/>
+      <point x="766" y="240" type="curve" smooth="yes"/>
+      <point x="766" y="287"/>
+      <point x="750" y="418"/>
+      <point x="733" y="567" type="curve"/>
+      <point x="889" y="596"/>
+      <point x="1024" y="668"/>
+      <point x="1110" y="768" type="curve"/>
+      <point x="1128" y="739"/>
+      <point x="1139" y="707"/>
+      <point x="1139" y="670" type="curve" smooth="yes"/>
+      <point x="1139" y="575"/>
+      <point x="1042" y="487"/>
+      <point x="1006" y="459" type="curve"/>
+      <point x="1075" y="459" type="line"/>
+      <point x="1114" y="487"/>
+      <point x="1200" y="575"/>
+      <point x="1200" y="668" type="curve" smooth="yes"/>
+      <point x="1200" y="725"/>
+      <point x="1180" y="774"/>
+      <point x="1145" y="813" type="curve"/>
+      <point x="1188" y="874"/>
+      <point x="1212" y="946"/>
+      <point x="1212" y="1024" type="curve" smooth="yes"/>
+      <point x="1212" y="1245"/>
+      <point x="1067" y="1485"/>
+      <point x="844" y="1485" type="curve" smooth="yes"/>
+      <point x="674" y="1485"/>
+      <point x="618" y="1360"/>
+      <point x="618" y="1165" type="curve" smooth="yes"/>
+      <point x="618" y="1122"/>
+      <point x="621" y="1055"/>
+      <point x="623" y="977" type="curve"/>
+      <point x="598" y="979"/>
+      <point x="575" y="979"/>
+      <point x="555" y="979" type="curve" smooth="yes"/>
+      <point x="532" y="979"/>
+      <point x="494" y="977"/>
+      <point x="451" y="973" type="curve"/>
+      <point x="455" y="1255" type="line"/>
+      <point x="485" y="1300"/>
+      <point x="514" y="1348"/>
+      <point x="514" y="1382" type="curve" smooth="yes"/>
+      <point x="514" y="1395"/>
+      <point x="512" y="1450"/>
+      <point x="457" y="1450" type="curve" smooth="yes"/>
+      <point x="385" y="1450"/>
+      <point x="410" y="1370"/>
+      <point x="377" y="1370" type="curve" smooth="yes"/>
+      <point x="336" y="1370"/>
+      <point x="313" y="1464"/>
+      <point x="215" y="1464" type="curve" smooth="yes"/>
+      <point x="168" y="1464"/>
+      <point x="84" y="1438"/>
+      <point x="84" y="1317" type="curve" smooth="yes"/>
+      <point x="84" y="1235"/>
+      <point x="139" y="1171"/>
+      <point x="229" y="1171" type="curve" smooth="yes"/>
+      <point x="244" y="1171"/>
+      <point x="258" y="1174"/>
+      <point x="268" y="1176" type="curve"/>
+      <point x="266" y="1212" type="line"/>
+      <point x="258" y="1210"/>
+      <point x="242" y="1208"/>
+      <point x="229" y="1208" type="curve" smooth="yes"/>
+      <point x="193" y="1208"/>
+      <point x="180" y="1241"/>
+      <point x="180" y="1264" type="curve" smooth="yes"/>
+      <point x="180" y="1290"/>
+      <point x="199" y="1319"/>
+      <point x="238" y="1319" type="curve" smooth="yes"/>
+      <point x="283" y="1319"/>
+      <point x="379" y="1280"/>
+      <point x="414" y="1260" type="curve"/>
+      <point x="381" y="965" type="line"/>
+      <point x="254" y="942"/>
+      <point x="111" y="887"/>
+      <point x="111" y="756" type="curve" smooth="yes"/>
+      <point x="111" y="645"/>
+      <point x="219" y="594"/>
+      <point x="342" y="571" type="curve"/>
+      <point x="328" y="426"/>
+      <point x="319" y="295"/>
+      <point x="319" y="240" type="curve" smooth="yes"/>
+      <point x="319" y="104"/>
+      <point x="375" y="-20"/>
     </contour>
     <contour>
-      <point x="265" y="20" type="curve" smooth="yes"/>
-      <point x="228" y="20"/>
-      <point x="208" y="58"/>
-      <point x="208" y="115" type="curve" smooth="yes"/>
-      <point x="208" y="146"/>
-      <point x="210" y="206"/>
-      <point x="212" y="273" type="curve"/>
-      <point x="237" y="270"/>
-      <point x="261" y="270"/>
-      <point x="282" y="270" type="curve" smooth="yes"/>
-      <point x="292" y="270"/>
-      <point x="303" y="270"/>
-      <point x="314" y="271" type="curve"/>
-      <point x="317" y="195"/>
-      <point x="321" y="132"/>
-      <point x="321" y="115" type="curve" smooth="yes"/>
-      <point x="321" y="58"/>
-      <point x="301" y="20"/>
+      <point x="543" y="41" type="curve" smooth="yes"/>
+      <point x="467" y="41"/>
+      <point x="426" y="119"/>
+      <point x="426" y="236" type="curve" smooth="yes"/>
+      <point x="426" y="299"/>
+      <point x="430" y="422"/>
+      <point x="434" y="559" type="curve"/>
+      <point x="485" y="553"/>
+      <point x="535" y="553"/>
+      <point x="578" y="553" type="curve" smooth="yes"/>
+      <point x="598" y="553"/>
+      <point x="621" y="553"/>
+      <point x="643" y="555" type="curve"/>
+      <point x="649" y="399"/>
+      <point x="657" y="270"/>
+      <point x="657" y="236" type="curve" smooth="yes"/>
+      <point x="657" y="119"/>
+      <point x="616" y="41"/>
     </contour>
     <contour>
-      <point x="169" y="299" type="line"/>
-      <point x="89" y="318"/>
-      <point x="79" y="358"/>
-      <point x="79" y="372" type="curve" smooth="yes"/>
-      <point x="79" y="384"/>
-      <point x="85" y="434"/>
-      <point x="184" y="453" type="curve"/>
+      <point x="346" y="612" type="line"/>
+      <point x="182" y="651"/>
+      <point x="162" y="733"/>
+      <point x="162" y="762" type="curve" smooth="yes"/>
+      <point x="162" y="786"/>
+      <point x="174" y="889"/>
+      <point x="377" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="281" y="288" type="curve" smooth="yes"/>
-      <point x="254" y="288"/>
-      <point x="233" y="289"/>
-      <point x="213" y="291" type="curve"/>
-      <point x="219" y="458" type="line"/>
-      <point x="234" y="459"/>
-      <point x="251" y="460"/>
-      <point x="270" y="460" type="curve" smooth="yes"/>
-      <point x="282" y="460"/>
-      <point x="293" y="459"/>
-      <point x="305" y="459" type="curve"/>
-      <point x="313" y="289" type="line"/>
-      <point x="302" y="288"/>
-      <point x="292" y="288"/>
+      <point x="575" y="590" type="curve" smooth="yes"/>
+      <point x="520" y="590"/>
+      <point x="477" y="592"/>
+      <point x="436" y="596" type="curve"/>
+      <point x="449" y="938" type="line"/>
+      <point x="479" y="940"/>
+      <point x="514" y="942"/>
+      <point x="553" y="942" type="curve" smooth="yes"/>
+      <point x="578" y="942"/>
+      <point x="600" y="940"/>
+      <point x="625" y="940" type="curve"/>
+      <point x="641" y="592" type="line"/>
+      <point x="618" y="590"/>
+      <point x="598" y="590"/>
     </contour>
     <contour>
-      <point x="356" y="295" type="curve"/>
-      <point x="337" y="457" type="line"/>
-      <point x="397" y="452"/>
-      <point x="457" y="439"/>
-      <point x="499" y="414" type="curve"/>
-      <point x="476" y="351"/>
-      <point x="428" y="311"/>
+      <point x="729" y="604" type="curve"/>
+      <point x="690" y="936" type="line"/>
+      <point x="813" y="926"/>
+      <point x="936" y="899"/>
+      <point x="1022" y="848" type="curve"/>
+      <point x="975" y="719"/>
+      <point x="877" y="637"/>
     </contour>
     <contour>
-      <point x="504" y="436" type="curve"/>
-      <point x="455" y="460"/>
-      <point x="390" y="471"/>
-      <point x="335" y="475" type="curve"/>
-      <point x="331" y="514"/>
-      <point x="329" y="548"/>
-      <point x="329" y="572" type="curve" smooth="yes"/>
-      <point x="329" y="636"/>
-      <point x="335" y="707"/>
-      <point x="409" y="707" type="curve" smooth="yes"/>
-      <point x="500" y="707"/>
-      <point x="516" y="593"/>
-      <point x="516" y="519" type="curve" smooth="yes"/>
-      <point x="516" y="488"/>
-      <point x="511" y="461"/>
+      <point x="1034" y="893" type="curve"/>
+      <point x="934" y="942"/>
+      <point x="799" y="965"/>
+      <point x="686" y="973" type="curve"/>
+      <point x="678" y="1053"/>
+      <point x="674" y="1122"/>
+      <point x="674" y="1171" type="curve" smooth="yes"/>
+      <point x="674" y="1303"/>
+      <point x="686" y="1448"/>
+      <point x="838" y="1448" type="curve" smooth="yes"/>
+      <point x="1024" y="1448"/>
+      <point x="1057" y="1214"/>
+      <point x="1057" y="1063" type="curve" smooth="yes"/>
+      <point x="1057" y="999"/>
+      <point x="1049" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:48 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Bold.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-Bold.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="878"/>
+  <unicode hex="214E"/>
+  <anchor x="1322" y="-824" name="bottom"/>
+  <anchor x="875" y="-407" name="bottom_dd"/>
+  <anchor x="1242" y="-2134" name="parent_top"/>
+  <anchor x="1242" y="-2134" name="top"/>
+  <anchor x="875" y="-2134" name="top0315"/>
+  <anchor x="875" y="-2414" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="478" y="0" type="line"/>
+      <point x="761" y="0" type="line"/>
+      <point x="761" y="1082" type="line"/>
+      <point x="478" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="52" y="0" type="line"/>
+      <point x="554" y="0" type="line"/>
+      <point x="554" y="235" type="line"/>
+      <point x="52" y="235" type="line"/>
+    </contour>
+    <contour>
+      <point x="91" y="476" type="line"/>
+      <point x="554" y="476" type="line"/>
+      <point x="554" y="711" type="line"/>
+      <point x="91" y="711" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:48 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Bold.ufo/lib.plist
+++ b/sources/RobotoCondensed-Bold.ufo/lib.plist
@@ -6905,6 +6905,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-BoldItalic.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-BoldItalic.ufo/fontinfo.plist
@@ -375,7 +375,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/contents.plist
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="873"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="-46" y="0" type="line"/>
+      <point x="312" y="0" type="line" smooth="yes"/>
+      <point x="601" y="0"/>
+      <point x="753" y="229"/>
+      <point x="753" y="496" type="curve" smooth="yes"/>
+      <point x="753" y="627"/>
+      <point x="697" y="725"/>
+      <point x="603" y="760" type="curve"/>
+      <point x="605" y="768" type="line"/>
+      <point x="787" y="823"/>
+      <point x="869" y="989"/>
+      <point x="869" y="1155" type="curve" smooth="yes"/>
+      <point x="869" y="1378"/>
+      <point x="722" y="1462"/>
+      <point x="570" y="1462" type="curve" smooth="yes"/>
+      <point x="263" y="1462" type="line"/>
+    </contour>
+    <contour>
+      <point x="59" y="-201" type="line"/>
+      <point x="175" y="-201" type="line"/>
+      <point x="257" y="174" type="line"/>
+      <point x="140" y="174" type="line"/>
+    </contour>
+    <contour>
+      <point x="263" y="-201" type="line"/>
+      <point x="379" y="-201" type="line"/>
+      <point x="461" y="174" type="line"/>
+      <point x="345" y="174" type="line"/>
+    </contour>
+    <contour>
+      <point x="253" y="219" type="line"/>
+      <point x="345" y="655" type="line"/>
+      <point x="390" y="655" type="line" smooth="yes"/>
+      <point x="464" y="655"/>
+      <point x="497" y="604"/>
+      <point x="497" y="502" type="curve" smooth="yes"/>
+      <point x="497" y="317"/>
+      <point x="415" y="219"/>
+      <point x="314" y="219" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="390" y="864" type="line"/>
+      <point x="472" y="1247" type="line"/>
+      <point x="503" y="1247" type="line" smooth="yes"/>
+      <point x="576" y="1247"/>
+      <point x="607" y="1217"/>
+      <point x="607" y="1130" type="curve" smooth="yes"/>
+      <point x="607" y="1001"/>
+      <point x="552" y="864"/>
+      <point x="443" y="864" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="376" y="1294" type="line"/>
+      <point x="492" y="1294" type="line"/>
+      <point x="574" y="1669" type="line"/>
+      <point x="458" y="1669" type="line"/>
+    </contour>
+    <contour>
+      <point x="581" y="1294" type="line"/>
+      <point x="697" y="1294" type="line"/>
+      <point x="779" y="1669" type="line"/>
+      <point x="662" y="1669" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="1065"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="306" y="0" type="line"/>
+      <point x="910" y="0" type="line"/>
+      <point x="952" y="250" type="line"/>
+      <point x="593" y="250" type="line"/>
+      <point x="612" y="362" type="line"/>
+      <point x="659" y="375"/>
+      <point x="693" y="395"/>
+      <point x="740" y="420" type="curve"/>
+      <point x="776" y="610" type="line"/>
+      <point x="720" y="582"/>
+      <point x="686" y="561"/>
+      <point x="643" y="547" type="curve"/>
+      <point x="723" y="1026" type="line"/>
+      <point x="750" y="1018"/>
+      <point x="775" y="1006"/>
+      <point x="804" y="987" type="curve"/>
+      <point x="894" y="1163" type="line"/>
+      <point x="843" y="1186"/>
+      <point x="808" y="1204"/>
+      <point x="754" y="1214" type="curve"/>
+      <point x="796" y="1462" type="line"/>
+      <point x="551" y="1462" type="line"/>
+      <point x="509" y="1212" type="line"/>
+      <point x="303" y="1171"/>
+      <point x="156" y="1026"/>
+      <point x="115" y="784" type="curve" smooth="yes"/>
+      <point x="74" y="537"/>
+      <point x="162" y="387"/>
+      <point x="365" y="354" type="curve"/>
+    </contour>
+    <contour>
+      <point x="400" y="559" type="line"/>
+      <point x="347" y="592"/>
+      <point x="318" y="662"/>
+      <point x="338" y="780" type="curve" smooth="yes"/>
+      <point x="359" y="907"/>
+      <point x="410" y="981"/>
+      <point x="476" y="1016" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="988"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2108.glif
@@ -37,10 +37,10 @@
       <point x="161.52" y="-14.244"/>
     </contour>
     <contour>
+      <point x="419.014" y="605.095" type="line"/>
       <point x="917.38" y="605.083" type="line"/>
       <point x="960.449" y="849.903" type="line"/>
       <point x="462.083" y="849.916" type="line"/>
-      <point x="419.014" y="605.095" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1125"/>
+  <unicode hex="2108"/>
+  <anchor x="721.417" y="1609" name="parent_top"/>
+  <anchor x="721.417" y="1609" name="top"/>
+  <anchor x="1279.167" y="1609" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="458.283" y="-21.046" type="curve" smooth="yes"/>
+      <point x="842.429" y="-29.85"/>
+      <point x="1018" y="354.268"/>
+      <point x="1064.812" y="680.478" type="curve" smooth="yes"/>
+      <point x="1077.699" y="773.266" type="line" smooth="yes"/>
+      <point x="1115.853" y="1070.372"/>
+      <point x="1048.067" y="1468.244"/>
+      <point x="676.27" y="1476.776" type="curve" smooth="yes"/>
+      <point x="366.274" y="1483.89"/>
+      <point x="170.616" y="1249.605"/>
+      <point x="126.138" y="960.5" type="curve"/>
+      <point x="410.281" y="961.77" type="line"/>
+      <point x="433.474" y="1101.831"/>
+      <point x="487.99" y="1239.691"/>
+      <point x="653.928" y="1233.252" type="curve" smooth="yes"/>
+      <point x="857.732" y="1225.343"/>
+      <point x="805.73" y="902.482"/>
+      <point x="790.422" y="775.741" type="curve" smooth="yes"/>
+      <point x="778.308" y="679.772" type="line" smooth="yes"/>
+      <point x="755.986" y="509.707"/>
+      <point x="710.969" y="212.742"/>
+      <point x="480.458" y="222.283" type="curve" smooth="yes"/>
+      <point x="330.212" y="228.502"/>
+      <point x="317.661" y="361.821"/>
+      <point x="320.748" y="485.402" type="curve"/>
+      <point x="33.735" y="485.922" type="line"/>
+      <point x="32.134" y="212.232"/>
+      <point x="161.52" y="-14.244"/>
+    </contour>
+    <contour>
+      <point x="917.38" y="605.083" type="line"/>
+      <point x="960.449" y="849.903" type="line"/>
+      <point x="462.083" y="849.916" type="line"/>
+      <point x="419.014" y="605.095" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2114.glif
@@ -56,16 +56,16 @@
       <point x="1110" y="206"/>
     </contour>
     <contour>
+      <point x="98.691" y="1216.093" type="line"/>
       <point x="1121" y="1216" type="line"/>
       <point x="1154" y="1399" type="line"/>
       <point x="131.043" y="1398.919" type="line"/>
-      <point x="98.691" y="1216.093" type="line"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1492"/>
+  <unicode hex="2114"/>
+  <anchor x="972.993" y="-10" name="bottom"/>
+  <anchor x="1299.188" y="-407" name="bottom_dd"/>
+  <anchor x="776.414" y="1500" name="marktop"/>
+  <anchor x="1259.45" y="1603" name="parent_top"/>
+  <anchor x="1259.45" y="1603" name="top"/>
+  <anchor x="1646.48" y="1603" name="top0315"/>
+  <anchor x="1645.962" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1006" y="-21" type="curve" smooth="yes"/>
+      <point x="1301" y="-32"/>
+      <point x="1386" y="272"/>
+      <point x="1414" y="510" type="curve" smooth="yes"/>
+      <point x="1422" y="582" type="line" smooth="yes"/>
+      <point x="1445" y="799"/>
+      <point x="1436" y="1098"/>
+      <point x="1152" y="1104" type="curve" smooth="yes"/>
+      <point x="901" y="1109"/>
+      <point x="796" y="795"/>
+      <point x="760" y="593" type="curve" smooth="yes"/>
+      <point x="747" y="489" type="line"/>
+      <point x="735" y="306"/>
+      <point x="765" y="-13"/>
+    </contour>
+    <contour>
+      <point x="44" y="0" type="line"/>
+      <point x="321" y="0" type="line"/>
+      <point x="588" y="1536" type="line"/>
+      <point x="310" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="505" y="0" type="line"/>
+      <point x="761" y="0" type="line"/>
+      <point x="822" y="239" type="line"/>
+      <point x="1047" y="1536" type="line"/>
+      <point x="772" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="949" y="214" type="curve" smooth="yes"/>
+      <point x="825" y="221"/>
+      <point x="823" y="350"/>
+      <point x="833" y="447" type="curve" smooth="yes"/>
+      <point x="858" y="636" type="line" smooth="yes"/>
+      <point x="874" y="742"/>
+      <point x="924" y="872"/>
+      <point x="1052" y="868" type="curve" smooth="yes"/>
+      <point x="1193" y="864"/>
+      <point x="1155" y="671"/>
+      <point x="1146" y="578" type="curve" smooth="yes"/>
+      <point x="1139" y="506" type="line" smooth="yes"/>
+      <point x="1126" y="385"/>
+      <point x="1110" y="206"/>
+    </contour>
+    <contour>
+      <point x="1121" y="1216" type="line"/>
+      <point x="1154" y="1399" type="line"/>
+      <point x="131.043" y="1398.919" type="line"/>
+      <point x="98.691" y="1216.093" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="807"/>
+  <advance width="1534"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="179" y="-241" type="curve" smooth="yes"/>
-      <point x="249" y="-241"/>
-      <point x="296" y="-180"/>
-      <point x="296" y="-95" type="curve" smooth="yes"/>
-      <point x="296" y="8"/>
-      <point x="204" y="99"/>
-      <point x="147" y="200" type="curve"/>
-      <point x="194" y="272"/>
-      <point x="254" y="341"/>
-      <point x="316" y="394" type="curve" smooth="yes"/>
-      <point x="384" y="452"/>
-      <point x="455" y="492"/>
-      <point x="514" y="492" type="curve" smooth="yes"/>
-      <point x="616" y="492"/>
-      <point x="624" y="359"/>
-      <point x="624" y="322" type="curve" smooth="yes"/>
-      <point x="624" y="285"/>
-      <point x="611" y="30"/>
-      <point x="447" y="30" type="curve" smooth="yes"/>
-      <point x="396" y="30"/>
-      <point x="347" y="57"/>
-      <point x="347" y="112" type="curve" smooth="yes"/>
-      <point x="347" y="119"/>
-      <point x="348" y="126"/>
-      <point x="350" y="132" type="curve"/>
-      <point x="382" y="136"/>
-      <point x="415" y="151"/>
-      <point x="415" y="194" type="curve" smooth="yes"/>
-      <point x="415" y="225"/>
-      <point x="394" y="244"/>
-      <point x="363" y="244" type="curve" smooth="yes"/>
-      <point x="315" y="244"/>
-      <point x="285" y="206"/>
-      <point x="285" y="140" type="curve" smooth="yes"/>
-      <point x="285" y="51"/>
-      <point x="349" y="-10"/>
-      <point x="455" y="-10" type="curve" smooth="yes"/>
-      <point x="633" y="-10"/>
-      <point x="726" y="159"/>
-      <point x="726" y="306" type="curve" smooth="yes"/>
-      <point x="726" y="437"/>
-      <point x="666" y="549"/>
-      <point x="544" y="549" type="curve" smooth="yes"/>
-      <point x="494" y="549"/>
-      <point x="398" y="512"/>
-      <point x="292" y="419" type="curve" smooth="yes"/>
-      <point x="240" y="373"/>
-      <point x="179" y="310"/>
-      <point x="127" y="238" type="curve"/>
-      <point x="112" y="272"/>
-      <point x="103" y="307"/>
-      <point x="103" y="345" type="curve" smooth="yes"/>
-      <point x="103" y="474"/>
-      <point x="133" y="548"/>
-      <point x="214" y="625" type="curve"/>
-      <point x="198" y="647" type="line"/>
-      <point x="139" y="610"/>
-      <point x="15" y="496"/>
-      <point x="15" y="337" type="curve" smooth="yes"/>
-      <point x="15" y="267"/>
-      <point x="39" y="206"/>
-      <point x="71" y="149" type="curve"/>
-      <point x="36" y="85"/>
-      <point x="10" y="11"/>
-      <point x="10" y="-56" type="curve" smooth="yes"/>
-      <point x="10" y="-163"/>
-      <point x="84" y="-241"/>
+      <point x="401" y="-494" type="curve" smooth="yes"/>
+      <point x="538" y="-494"/>
+      <point x="632" y="-369"/>
+      <point x="632" y="-195" type="curve" smooth="yes"/>
+      <point x="632" y="16"/>
+      <point x="450" y="203"/>
+      <point x="337" y="410" type="curve"/>
+      <point x="432" y="557"/>
+      <point x="552" y="698"/>
+      <point x="673" y="807" type="curve" smooth="yes"/>
+      <point x="806" y="926"/>
+      <point x="948" y="1008"/>
+      <point x="1066" y="1008" type="curve" smooth="yes"/>
+      <point x="1269" y="1008"/>
+      <point x="1284" y="735"/>
+      <point x="1284" y="659" type="curve" smooth="yes"/>
+      <point x="1284" y="584"/>
+      <point x="1259" y="61"/>
+      <point x="933" y="61" type="curve" smooth="yes"/>
+      <point x="831" y="61"/>
+      <point x="733" y="117"/>
+      <point x="733" y="229" type="curve" smooth="yes"/>
+      <point x="733" y="244"/>
+      <point x="735" y="258"/>
+      <point x="739" y="270" type="curve"/>
+      <point x="804" y="279"/>
+      <point x="870" y="309"/>
+      <point x="870" y="397" type="curve" smooth="yes"/>
+      <point x="870" y="461"/>
+      <point x="827" y="500"/>
+      <point x="765" y="500" type="curve" smooth="yes"/>
+      <point x="669" y="500"/>
+      <point x="612" y="422"/>
+      <point x="612" y="287" type="curve" smooth="yes"/>
+      <point x="612" y="104"/>
+      <point x="737" y="-20"/>
+      <point x="948" y="-20" type="curve" smooth="yes"/>
+      <point x="1300" y="-20"/>
+      <point x="1486" y="326"/>
+      <point x="1486" y="627" type="curve" smooth="yes"/>
+      <point x="1486" y="895"/>
+      <point x="1365" y="1124"/>
+      <point x="1126" y="1124" type="curve" smooth="yes"/>
+      <point x="1025" y="1124"/>
+      <point x="837" y="1049"/>
+      <point x="626" y="858" type="curve" smooth="yes"/>
+      <point x="522" y="764"/>
+      <point x="401" y="635"/>
+      <point x="298" y="487" type="curve"/>
+      <point x="268" y="557"/>
+      <point x="249" y="629"/>
+      <point x="249" y="707" type="curve" smooth="yes"/>
+      <point x="249" y="971"/>
+      <point x="309" y="1122"/>
+      <point x="468" y="1280" type="curve"/>
+      <point x="438" y="1325" type="line"/>
+      <point x="321" y="1249"/>
+      <point x="75" y="1016"/>
+      <point x="75" y="690" type="curve" smooth="yes"/>
+      <point x="75" y="547"/>
+      <point x="122" y="422"/>
+      <point x="186" y="305" type="curve"/>
+      <point x="116" y="174"/>
+      <point x="65" y="23"/>
+      <point x="65" y="-115" type="curve" smooth="yes"/>
+      <point x="65" y="-334"/>
+      <point x="210" y="-494"/>
     </contour>
     <contour>
-      <point x="161" y="-199" type="curve" smooth="yes"/>
-      <point x="117" y="-199"/>
-      <point x="50" y="-145"/>
-      <point x="50" y="-51" type="curve" smooth="yes"/>
-      <point x="50" y="-4"/>
-      <point x="66" y="52"/>
-      <point x="94" y="110" type="curve"/>
-      <point x="148" y="24"/>
-      <point x="209" y="-52"/>
-      <point x="209" y="-134" type="curve" smooth="yes"/>
-      <point x="209" y="-176"/>
-      <point x="190" y="-199"/>
+      <point x="366" y="-408" type="curve" smooth="yes"/>
+      <point x="276" y="-408"/>
+      <point x="145" y="-297"/>
+      <point x="145" y="-104" type="curve" smooth="yes"/>
+      <point x="145" y="-8"/>
+      <point x="178" y="106"/>
+      <point x="233" y="225" type="curve"/>
+      <point x="337" y="49"/>
+      <point x="460" y="-106"/>
+      <point x="460" y="-274" type="curve" smooth="yes"/>
+      <point x="460" y="-360"/>
+      <point x="423" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="807"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="179" y="-241" type="curve" smooth="yes"/>
+      <point x="249" y="-241"/>
+      <point x="296" y="-180"/>
+      <point x="296" y="-95" type="curve" smooth="yes"/>
+      <point x="296" y="8"/>
+      <point x="204" y="99"/>
+      <point x="147" y="200" type="curve"/>
+      <point x="194" y="272"/>
+      <point x="254" y="341"/>
+      <point x="316" y="394" type="curve" smooth="yes"/>
+      <point x="384" y="452"/>
+      <point x="455" y="492"/>
+      <point x="514" y="492" type="curve" smooth="yes"/>
+      <point x="616" y="492"/>
+      <point x="624" y="359"/>
+      <point x="624" y="322" type="curve" smooth="yes"/>
+      <point x="624" y="285"/>
+      <point x="611" y="30"/>
+      <point x="447" y="30" type="curve" smooth="yes"/>
+      <point x="396" y="30"/>
+      <point x="347" y="57"/>
+      <point x="347" y="112" type="curve" smooth="yes"/>
+      <point x="347" y="119"/>
+      <point x="348" y="126"/>
+      <point x="350" y="132" type="curve"/>
+      <point x="382" y="136"/>
+      <point x="415" y="151"/>
+      <point x="415" y="194" type="curve" smooth="yes"/>
+      <point x="415" y="225"/>
+      <point x="394" y="244"/>
+      <point x="363" y="244" type="curve" smooth="yes"/>
+      <point x="315" y="244"/>
+      <point x="285" y="206"/>
+      <point x="285" y="140" type="curve" smooth="yes"/>
+      <point x="285" y="51"/>
+      <point x="349" y="-10"/>
+      <point x="455" y="-10" type="curve" smooth="yes"/>
+      <point x="633" y="-10"/>
+      <point x="726" y="159"/>
+      <point x="726" y="306" type="curve" smooth="yes"/>
+      <point x="726" y="437"/>
+      <point x="666" y="549"/>
+      <point x="544" y="549" type="curve" smooth="yes"/>
+      <point x="494" y="549"/>
+      <point x="398" y="512"/>
+      <point x="292" y="419" type="curve" smooth="yes"/>
+      <point x="240" y="373"/>
+      <point x="179" y="310"/>
+      <point x="127" y="238" type="curve"/>
+      <point x="112" y="272"/>
+      <point x="103" y="307"/>
+      <point x="103" y="345" type="curve" smooth="yes"/>
+      <point x="103" y="474"/>
+      <point x="133" y="548"/>
+      <point x="214" y="625" type="curve"/>
+      <point x="198" y="647" type="line"/>
+      <point x="139" y="610"/>
+      <point x="15" y="496"/>
+      <point x="15" y="337" type="curve" smooth="yes"/>
+      <point x="15" y="267"/>
+      <point x="39" y="206"/>
+      <point x="71" y="149" type="curve"/>
+      <point x="36" y="85"/>
+      <point x="10" y="11"/>
+      <point x="10" y="-56" type="curve" smooth="yes"/>
+      <point x="10" y="-163"/>
+      <point x="84" y="-241"/>
+    </contour>
+    <contour>
+      <point x="161" y="-199" type="curve" smooth="yes"/>
+      <point x="117" y="-199"/>
+      <point x="50" y="-145"/>
+      <point x="50" y="-51" type="curve" smooth="yes"/>
+      <point x="50" y="-4"/>
+      <point x="66" y="52"/>
+      <point x="94" y="110" type="curve"/>
+      <point x="148" y="24"/>
+      <point x="209" y="-52"/>
+      <point x="209" y="-134" type="curve" smooth="yes"/>
+      <point x="209" y="-176"/>
+      <point x="190" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1168"/>
+  <unicode hex="2127"/>
+  <anchor x="776.851" y="1446" name="top"/>
+  <outline>
+    <contour>
+      <point x="546" y="-19" type="curve" smooth="yes"/>
+      <point x="884" y="-28"/>
+      <point x="1071" y="299"/>
+      <point x="1113" y="594" type="curve" smooth="yes"/>
+      <point x="1124" y="679" type="line" smooth="yes"/>
+      <point x="1154" y="929"/>
+      <point x="1070" y="1286"/>
+      <point x="784" y="1351" type="curve"/>
+      <point x="769" y="1204" type="line"/>
+      <point x="897" y="1122"/>
+      <point x="818" y="795"/>
+      <point x="804" y="679" type="curve" smooth="yes"/>
+      <point x="793" y="592" type="line" smooth="yes"/>
+      <point x="778" y="476"/>
+      <point x="739" y="216"/>
+      <point x="572" y="226" type="curve" smooth="yes"/>
+      <point x="425" y="234"/>
+      <point x="464" y="503"/>
+      <point x="474" y="591" type="curve" smooth="yes"/>
+      <point x="485" y="679" type="line" smooth="yes"/>
+      <point x="508" y="851"/>
+      <point x="535" y="1108"/>
+      <point x="703" y="1206" type="curve"/>
+      <point x="719" y="1353" type="line"/>
+      <point x="400" y="1306"/>
+      <point x="206" y="974"/>
+      <point x="164" y="679" type="curve" smooth="yes"/>
+      <point x="152" y="594" type="line" smooth="yes"/>
+      <point x="119" y="319"/>
+      <point x="220" y="-11"/>
+    </contour>
+    <contour>
+      <point x="277" y="1209" type="line"/>
+      <point x="701" y="1209" type="line"/>
+      <point x="745" y="1456" type="line"/>
+      <point x="320" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="768" y="1209" type="line"/>
+      <point x="1199" y="1209" type="line"/>
+      <point x="1242" y="1456" type="line"/>
+      <point x="811" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2127.glif
@@ -2,51 +2,51 @@
 <glyph name="uni2127" format="2">
   <advance width="1168"/>
   <unicode hex="2127"/>
-  <anchor x="776.851" y="1446" name="top"/>
+  <anchor x="715" y="1446" name="top"/>
   <outline>
     <contour>
-      <point x="546" y="-19" type="curve" smooth="yes"/>
-      <point x="884" y="-28"/>
-      <point x="1071" y="299"/>
-      <point x="1113" y="594" type="curve" smooth="yes"/>
-      <point x="1124" y="679" type="line" smooth="yes"/>
-      <point x="1154" y="929"/>
-      <point x="1070" y="1286"/>
-      <point x="784" y="1351" type="curve"/>
-      <point x="769" y="1204" type="line"/>
-      <point x="897" y="1122"/>
-      <point x="818" y="795"/>
-      <point x="804" y="679" type="curve" smooth="yes"/>
-      <point x="793" y="592" type="line" smooth="yes"/>
-      <point x="778" y="476"/>
-      <point x="739" y="216"/>
-      <point x="572" y="226" type="curve" smooth="yes"/>
-      <point x="425" y="234"/>
-      <point x="464" y="503"/>
-      <point x="474" y="591" type="curve" smooth="yes"/>
-      <point x="485" y="679" type="line" smooth="yes"/>
-      <point x="508" y="851"/>
-      <point x="535" y="1108"/>
-      <point x="703" y="1206" type="curve"/>
-      <point x="719" y="1353" type="line"/>
-      <point x="400" y="1306"/>
-      <point x="206" y="974"/>
-      <point x="164" y="679" type="curve" smooth="yes"/>
-      <point x="152" y="594" type="line" smooth="yes"/>
-      <point x="119" y="319"/>
-      <point x="220" y="-11"/>
+      <point x="484" y="-19" type="curve" smooth="yes"/>
+      <point x="822" y="-28"/>
+      <point x="1009" y="299"/>
+      <point x="1051" y="594" type="curve" smooth="yes"/>
+      <point x="1062" y="679" type="line" smooth="yes"/>
+      <point x="1092" y="929"/>
+      <point x="1008" y="1286"/>
+      <point x="722" y="1351" type="curve"/>
+      <point x="707" y="1204" type="line"/>
+      <point x="835" y="1122"/>
+      <point x="756" y="795"/>
+      <point x="742" y="679" type="curve" smooth="yes"/>
+      <point x="731" y="592" type="line" smooth="yes"/>
+      <point x="716" y="476"/>
+      <point x="677" y="216"/>
+      <point x="510" y="226" type="curve" smooth="yes"/>
+      <point x="363" y="234"/>
+      <point x="402" y="503"/>
+      <point x="412" y="591" type="curve" smooth="yes"/>
+      <point x="423" y="679" type="line" smooth="yes"/>
+      <point x="446" y="851"/>
+      <point x="473" y="1108"/>
+      <point x="641" y="1206" type="curve"/>
+      <point x="657" y="1353" type="line"/>
+      <point x="338" y="1306"/>
+      <point x="144" y="974"/>
+      <point x="102" y="679" type="curve" smooth="yes"/>
+      <point x="90" y="594" type="line" smooth="yes"/>
+      <point x="57" y="319"/>
+      <point x="158" y="-11"/>
     </contour>
     <contour>
-      <point x="277" y="1209" type="line"/>
-      <point x="701" y="1209" type="line"/>
-      <point x="745" y="1456" type="line"/>
-      <point x="320" y="1456" type="line"/>
+      <point x="215" y="1209" type="line"/>
+      <point x="639" y="1209" type="line"/>
+      <point x="683" y="1456" type="line"/>
+      <point x="258" y="1456" type="line"/>
     </contour>
     <contour>
-      <point x="768" y="1209" type="line"/>
-      <point x="1199" y="1209" type="line"/>
-      <point x="1242" y="1456" type="line"/>
-      <point x="811" y="1456" type="line"/>
+      <point x="706" y="1209" type="line"/>
+      <point x="1137" y="1209" type="line"/>
+      <point x="1180" y="1456" type="line"/>
+      <point x="749" y="1456" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="620"/>
+  <unicode hex="2129"/>
+  <anchor x="225.162" y="-197" name="bottom"/>
+  <anchor x="-98.818" y="-197" name="bottom0315"/>
+  <anchor x="225.162" y="-197" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="132" y="-11" type="line"/>
+      <point x="409" y="-11" type="line"/>
+      <point x="537" y="762" type="line"/>
+      <point x="552" y="928"/>
+      <point x="496" y="1078"/>
+      <point x="309" y="1081" type="curve" smooth="yes"/>
+      <point x="259" y="1082"/>
+      <point x="210" y="1074"/>
+      <point x="164" y="1056" type="curve"/>
+      <point x="139" y="834" type="line"/>
+      <point x="161" y="837"/>
+      <point x="184" y="841"/>
+      <point x="206" y="840" type="curve" smooth="yes"/>
+      <point x="270" y="837"/>
+      <point x="264" y="785"/>
+      <point x="258" y="733" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2139.glif
@@ -2,13 +2,13 @@
 <glyph name="uni2139" format="2">
   <advance width="501"/>
   <unicode hex="2139"/>
-  <anchor x="148.319" y="10" name="bottom"/>
-  <anchor x="308.098" y="-407" name="bottom_dd"/>
-  <anchor x="422.072" y="1600" name="parent_top"/>
-  <anchor x="320.7" y="654" name="rhotichook"/>
-  <anchor x="422.072" y="1600" name="top"/>
-  <anchor x="654.872" y="1600" name="top0315"/>
-  <anchor x="654.872" y="1600" name="top_dd"/>
+  <anchor x="148.319" y="10.0" name="bottom"/>
+  <anchor x="308.098" y="-407.0" name="bottom_dd"/>
+  <anchor x="422.072" y="1600.0" name="parent_top"/>
+  <anchor x="320.7" y="654.0" name="rhotichook"/>
+  <anchor x="422.072" y="1600.0" name="top"/>
+  <anchor x="654.872" y="1600.0" name="top0315"/>
+  <anchor x="654.872" y="1600.0" name="top_dd"/>
   <outline>
     <component base="i"/>
   </outline>
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="501"/>
+  <unicode hex="2139"/>
+  <anchor x="148.319" y="10" name="bottom"/>
+  <anchor x="308.098" y="-407" name="bottom_dd"/>
+  <anchor x="422.072" y="1600" name="parent_top"/>
+  <anchor x="320.7" y="654" name="rhotichook"/>
+  <anchor x="422.072" y="1600" name="top"/>
+  <anchor x="654.872" y="1600" name="top0315"/>
+  <anchor x="654.872" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni213A_.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni213A" format="2">
-  <advance width="1746"/>
+  <advance width="1783"/>
   <unicode hex="213A"/>
-  <anchor x="1594.076" y="646.83" name="bottom"/>
-  <anchor x="1894.209" y="1230.927" name="bottom_dd"/>
-  <anchor x="-40.106" y="643.12" name="parent_top"/>
-  <anchor x="-40.106" y="643.12" name="top"/>
-  <anchor x="-142.517" y="1223.92" name="top0315"/>
-  <anchor x="-142.517" y="1223.92" name="top_dd"/>
+  <anchor x="1502" y="647" name="bottom"/>
+  <anchor x="1802" y="1231" name="bottom_dd"/>
+  <anchor x="-132" y="643" name="parent_top"/>
+  <anchor x="-132" y="643" name="top"/>
+  <anchor x="-235" y="1224" name="top0315"/>
+  <anchor x="-235" y="1224" name="top_dd"/>
   <outline>
     <contour>
-      <point x="819" y="149" type="curve" smooth="yes"/>
-      <point x="1046" y="155" type="line" smooth="yes"/>
-      <point x="1355" y="170"/>
-      <point x="1653" y="326"/>
-      <point x="1599" y="676" type="curve" smooth="yes"/>
-      <point x="1543" y="1043"/>
-      <point x="1200" y="1167"/>
-      <point x="868" y="1158" type="curve" smooth="yes"/>
-      <point x="641" y="1153" type="line" smooth="yes"/>
-      <point x="333" y="1139"/>
-      <point x="33" y="983"/>
-      <point x="87" y="633" type="curve" smooth="yes"/>
-      <point x="143" y="266"/>
-      <point x="487" y="140"/>
+      <point x="615" y="91" type="curve"/>
+      <point x="840" y="91" type="line"/>
+      <point x="1260" y="91"/>
+      <point x="1511" y="305"/>
+      <point x="1563" y="617" type="curve" smooth="yes"/>
+      <point x="1615" y="930"/>
+      <point x="1436" y="1141"/>
+      <point x="1016" y="1141" type="curve"/>
+      <point x="791" y="1141" type="line"/>
+      <point x="371" y="1141"/>
+      <point x="119" y="929"/>
+      <point x="67" y="615" type="curve" smooth="yes"/>
+      <point x="14" y="303"/>
+      <point x="195" y="91"/>
     </contour>
     <contour>
-      <point x="767" y="431" type="line" smooth="yes"/>
-      <point x="598" y="425"/>
-      <point x="360" y="444"/>
-      <point x="332" y="654" type="curve" smooth="yes"/>
-      <point x="307" y="845"/>
-      <point x="551" y="863"/>
-      <point x="687" y="870" type="curve" smooth="yes"/>
-      <point x="919" y="878" type="line" smooth="yes"/>
-      <point x="1086" y="883"/>
-      <point x="1328" y="864"/>
-      <point x="1355" y="655" type="curve" smooth="yes"/>
-      <point x="1380" y="463"/>
-      <point x="1133" y="445"/>
-      <point x="997" y="438" type="curve" smooth="yes"/>
+      <point x="662" y="385" type="line" smooth="yes"/>
+      <point x="385" y="385"/>
+      <point x="288" y="465"/>
+      <point x="313" y="615" type="curve" smooth="yes"/>
+      <point x="338" y="765"/>
+      <point x="463" y="847"/>
+      <point x="740" y="847" type="curve"/>
+      <point x="967" y="847" type="line"/>
+      <point x="1242" y="847"/>
+      <point x="1343" y="767"/>
+      <point x="1318" y="617" type="curve" smooth="yes"/>
+      <point x="1293" y="466"/>
+      <point x="1164" y="385"/>
+      <point x="889" y="385" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="1517" y="659" type="line"/>
-      <point x="1787" y="998" type="line"/>
-      <point x="1596" y="1165" type="line"/>
-      <point x="1326" y="819" type="line"/>
+      <point x="1491" y="620" type="line"/>
+      <point x="1862" y="962" type="line"/>
+      <point x="1723" y="1147" type="line"/>
+      <point x="1349" y="798" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1746"/>
+  <unicode hex="213A"/>
+  <anchor x="1594.076" y="646.83" name="bottom"/>
+  <anchor x="1894.209" y="1230.927" name="bottom_dd"/>
+  <anchor x="-40.106" y="643.12" name="parent_top"/>
+  <anchor x="-40.106" y="643.12" name="top"/>
+  <anchor x="-142.517" y="1223.92" name="top0315"/>
+  <anchor x="-142.517" y="1223.92" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="819" y="149" type="curve" smooth="yes"/>
+      <point x="1046" y="155" type="line" smooth="yes"/>
+      <point x="1355" y="170"/>
+      <point x="1653" y="326"/>
+      <point x="1599" y="676" type="curve" smooth="yes"/>
+      <point x="1543" y="1043"/>
+      <point x="1200" y="1167"/>
+      <point x="868" y="1158" type="curve" smooth="yes"/>
+      <point x="641" y="1153" type="line" smooth="yes"/>
+      <point x="333" y="1139"/>
+      <point x="33" y="983"/>
+      <point x="87" y="633" type="curve" smooth="yes"/>
+      <point x="143" y="266"/>
+      <point x="487" y="140"/>
+    </contour>
+    <contour>
+      <point x="767" y="431" type="line" smooth="yes"/>
+      <point x="598" y="425"/>
+      <point x="360" y="444"/>
+      <point x="332" y="654" type="curve" smooth="yes"/>
+      <point x="307" y="845"/>
+      <point x="551" y="863"/>
+      <point x="687" y="870" type="curve" smooth="yes"/>
+      <point x="919" y="878" type="line" smooth="yes"/>
+      <point x="1086" y="883"/>
+      <point x="1328" y="864"/>
+      <point x="1355" y="655" type="curve" smooth="yes"/>
+      <point x="1380" y="463"/>
+      <point x="1133" y="445"/>
+      <point x="997" y="438" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1517" y="659" type="line"/>
+      <point x="1787" y="998" type="line"/>
+      <point x="1596" y="1165" type="line"/>
+      <point x="1326" y="819" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1163"/>
+  <unicode hex="2141"/>
+  <anchor x="484.926" y="-145" name="bottom"/>
+  <anchor x="-85.434" y="-145" name="bottom0315"/>
+  <anchor x="-84.052" y="-137" name="bottom_dd"/>
+  <anchor x="484.926" y="-145" name="parent_bottom"/>
+  <anchor x="737.088" y="1466" name="top"/>
+  <anchor x="262.722" y="1870" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="518" y="-14" type="curve" smooth="yes"/>
+      <point x="890" y="-22"/>
+      <point x="1063" y="282"/>
+      <point x="1111" y="612" type="curve" smooth="yes"/>
+      <point x="1149" y="859" type="line" smooth="yes"/>
+      <point x="1189" y="1173"/>
+      <point x="1080" y="1478"/>
+      <point x="723" y="1483" type="curve" smooth="yes"/>
+      <point x="550" y="1485"/>
+      <point x="353" y="1432"/>
+      <point x="233" y="1298" type="curve"/>
+      <point x="141" y="697" type="line"/>
+      <point x="628" y="697" type="line"/>
+      <point x="667" y="919" type="line"/>
+      <point x="465" y="919" type="line"/>
+      <point x="517" y="1186" type="line"/>
+      <point x="574" y="1216"/>
+      <point x="625" y="1238"/>
+      <point x="692" y="1238" type="curve" smooth="yes"/>
+      <point x="897" y="1235"/>
+      <point x="879" y="1009"/>
+      <point x="860" y="860" type="curve" smooth="yes"/>
+      <point x="824" y="610" type="line" smooth="yes"/>
+      <point x="801" y="440"/>
+      <point x="744" y="220"/>
+      <point x="533" y="229" type="curve" smooth="yes"/>
+      <point x="389" y="235"/>
+      <point x="376" y="348"/>
+      <point x="376" y="471" type="curve"/>
+      <point x="97" y="471" type="line"/>
+      <point x="100" y="187"/>
+      <point x="213" y="-8"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="951"/>
+  <unicode hex="2142"/>
+  <anchor x="595.318" y="-144" name="bottom"/>
+  <anchor x="-73.982" y="-144" name="bottom0315"/>
+  <anchor x="-73.982" y="-144" name="bottom_dd"/>
+  <anchor x="595.318" y="-144" name="parent_bottom"/>
+  <anchor x="626.571" y="1446" name="top"/>
+  <anchor x="272.792" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="481" y="0" type="line"/>
+      <point x="769" y="0" type="line"/>
+      <point x="1021" y="1456" type="line"/>
+      <point x="733" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="191" y="1212" type="line"/>
+      <point x="781" y="1212" type="line"/>
+      <point x="823" y="1456" type="line"/>
+      <point x="234" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="904"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="434" y="0" type="line"/>
+      <point x="722" y="0" type="line"/>
+      <point x="974" y="1456" type="line"/>
+      <point x="686" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="-65" y="0" type="line"/>
+      <point x="524" y="0" type="line"/>
+      <point x="567" y="244" type="line"/>
+      <point x="-23" y="244" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1079"/>
+  <unicode hex="2144"/>
+  <anchor x="443.958" y="-144" name="bottom"/>
+  <anchor x="-74.022" y="-144" name="bottom0315"/>
+  <anchor x="-74.022" y="-144" name="bottom_dd"/>
+  <anchor x="443.958" y="-144" name="parent_bottom"/>
+  <anchor x="718.242" y="1421" name="top"/>
+  <anchor x="272.752" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="-61" y="0" type="line"/>
+      <point x="263" y="0" type="line"/>
+      <point x="588" y="651" type="line"/>
+      <point x="687" y="0" type="line"/>
+      <point x="989" y="0" type="line"/>
+      <point x="773" y="913" type="line"/>
+      <point x="868" y="1456" type="line"/>
+      <point x="577" y="1456" type="line"/>
+      <point x="488" y="942" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214A_.glif
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1361"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="64" y="300" type="line"/>
+      <point x="352" y="300" type="line"/>
+      <point x="506.751" y="1211.167" type="line"/>
+      <point x="912" y="1209" type="line"/>
+      <point x="1028" y="1202"/>
+      <point x="1038" y="1072"/>
+      <point x="1026" y="980" type="curve" smooth="yes"/>
+      <point x="1010" y="856"/>
+      <point x="938" y="754"/>
+      <point x="806" y="755" type="curve" smooth="yes"/>
+      <point x="671" y="756" type="line"/>
+      <point x="636" y="511" type="line"/>
+      <point x="792" y="511" type="line" smooth="yes"/>
+      <point x="1079" y="510"/>
+      <point x="1290" y="693"/>
+      <point x="1316" y="982" type="curve" smooth="yes"/>
+      <point x="1338" y="1240"/>
+      <point x="1194" y="1455"/>
+      <point x="925" y="1455" type="curve" smooth="yes"/>
+      <point x="261.394" y="1455.965" type="line"/>
+    </contour>
+    <contour>
+      <point x="617" y="0" type="line"/>
+      <point x="1206" y="0" type="line"/>
+      <point x="1249" y="244" type="line"/>
+      <point x="659" y="244" type="line"/>
+    </contour>
+    <contour>
+      <point x="419" y="0" type="line"/>
+      <point x="707" y="0" type="line"/>
+      <point x="988" y="1600" type="line"/>
+      <point x="700" y="1600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214B_.glif
@@ -4,66 +4,66 @@
   <unicode hex="214B"/>
   <outline>
     <contour>
-      <point x="606" y="-19" type="curve" smooth="yes"/>
-      <point x="832" y="-24"/>
-      <point x="968" y="165"/>
-      <point x="984" y="374" type="curve" smooth="yes"/>
-      <point x="997" y="532"/>
-      <point x="921" y="679"/>
-      <point x="851" y="815" type="curve" smooth="yes"/>
-      <point x="510" y="1459" type="line"/>
-      <point x="214" y="1459" type="line"/>
-      <point x="641" y="661" type="line" smooth="yes"/>
-      <point x="688" y="574"/>
-      <point x="759" y="472"/>
-      <point x="746" y="368" type="curve" smooth="yes"/>
-      <point x="738" y="306"/>
-      <point x="704" y="215"/>
-      <point x="628" y="216" type="curve" smooth="yes"/>
-      <point x="568" y="216"/>
-      <point x="553" y="284"/>
-      <point x="557" y="332" type="curve" smooth="yes"/>
-      <point x="563" y="404"/>
-      <point x="601" y="455"/>
-      <point x="658" y="498" type="curve" smooth="yes"/>
-      <point x="919" y="682" type="line" smooth="yes"/>
-      <point x="1055" y="780"/>
-      <point x="1179" y="897"/>
-      <point x="1193" y="1075" type="curve" smooth="yes"/>
-      <point x="1209" y="1298"/>
-      <point x="1075" y="1474"/>
-      <point x="845" y="1479" type="curve" smooth="yes"/>
-      <point x="701" y="1483"/>
-      <point x="584" y="1421"/>
-      <point x="477" y="1332" type="curve" smooth="yes"/>
-      <point x="465" y="1322"/>
-      <point x="452" y="1312"/>
-      <point x="440" y="1302" type="curve" smooth="yes"/>
-      <point x="271" y="1162"/>
-      <point x="197" y="957"/>
-      <point x="178" y="743" type="curve"/>
-      <point x="409" y="744" type="line"/>
-      <point x="433" y="935"/>
-      <point x="566" y="1263"/>
-      <point x="810" y="1246" type="curve" smooth="yes"/>
-      <point x="902" y="1240"/>
-      <point x="915" y="1130"/>
-      <point x="907" y="1058" type="curve" smooth="yes"/>
-      <point x="900" y="995"/>
-      <point x="875" y="919"/>
-      <point x="830" y="873" type="curve"/>
-      <point x="518" y="644" type="line" smooth="yes"/>
-      <point x="409" y="563"/>
-      <point x="330" y="454"/>
-      <point x="321" y="314" type="curve" smooth="yes"/>
-      <point x="311" y="139"/>
-      <point x="425" y="-14"/>
+      <point x="559" y="-19" type="curve" smooth="yes"/>
+      <point x="785" y="-24"/>
+      <point x="921" y="165"/>
+      <point x="937" y="374" type="curve" smooth="yes"/>
+      <point x="950" y="532"/>
+      <point x="874" y="679"/>
+      <point x="804" y="815" type="curve" smooth="yes"/>
+      <point x="463" y="1459" type="line"/>
+      <point x="167" y="1459" type="line"/>
+      <point x="594" y="661" type="line" smooth="yes"/>
+      <point x="641" y="574"/>
+      <point x="712" y="472"/>
+      <point x="699" y="368" type="curve" smooth="yes"/>
+      <point x="691" y="306"/>
+      <point x="657" y="215"/>
+      <point x="581" y="216" type="curve" smooth="yes"/>
+      <point x="521" y="216"/>
+      <point x="506" y="284"/>
+      <point x="510" y="332" type="curve" smooth="yes"/>
+      <point x="516" y="404"/>
+      <point x="554" y="455"/>
+      <point x="611" y="498" type="curve" smooth="yes"/>
+      <point x="872" y="682" type="line" smooth="yes"/>
+      <point x="1008" y="780"/>
+      <point x="1132" y="897"/>
+      <point x="1146" y="1075" type="curve" smooth="yes"/>
+      <point x="1162" y="1298"/>
+      <point x="1028" y="1474"/>
+      <point x="798" y="1479" type="curve" smooth="yes"/>
+      <point x="654" y="1483"/>
+      <point x="537" y="1421"/>
+      <point x="430" y="1332" type="curve" smooth="yes"/>
+      <point x="418" y="1322"/>
+      <point x="405" y="1312"/>
+      <point x="393" y="1302" type="curve" smooth="yes"/>
+      <point x="224" y="1162"/>
+      <point x="150" y="957"/>
+      <point x="131" y="743" type="curve"/>
+      <point x="362" y="744" type="line"/>
+      <point x="386" y="935"/>
+      <point x="519" y="1263"/>
+      <point x="763" y="1246" type="curve" smooth="yes"/>
+      <point x="855" y="1240"/>
+      <point x="868" y="1130"/>
+      <point x="860" y="1058" type="curve" smooth="yes"/>
+      <point x="853" y="995"/>
+      <point x="828" y="919"/>
+      <point x="783" y="873" type="curve"/>
+      <point x="471" y="644" type="line" smooth="yes"/>
+      <point x="362" y="563"/>
+      <point x="283" y="454"/>
+      <point x="274" y="314" type="curve" smooth="yes"/>
+      <point x="264" y="139"/>
+      <point x="378" y="-14"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1150"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="606" y="-19" type="curve" smooth="yes"/>
+      <point x="832" y="-24"/>
+      <point x="968" y="165"/>
+      <point x="984" y="374" type="curve" smooth="yes"/>
+      <point x="997" y="532"/>
+      <point x="921" y="679"/>
+      <point x="851" y="815" type="curve" smooth="yes"/>
+      <point x="510" y="1459" type="line"/>
+      <point x="214" y="1459" type="line"/>
+      <point x="641" y="661" type="line" smooth="yes"/>
+      <point x="688" y="574"/>
+      <point x="759" y="472"/>
+      <point x="746" y="368" type="curve" smooth="yes"/>
+      <point x="738" y="306"/>
+      <point x="704" y="215"/>
+      <point x="628" y="216" type="curve" smooth="yes"/>
+      <point x="568" y="216"/>
+      <point x="553" y="284"/>
+      <point x="557" y="332" type="curve" smooth="yes"/>
+      <point x="563" y="404"/>
+      <point x="601" y="455"/>
+      <point x="658" y="498" type="curve" smooth="yes"/>
+      <point x="919" y="682" type="line" smooth="yes"/>
+      <point x="1055" y="780"/>
+      <point x="1179" y="897"/>
+      <point x="1193" y="1075" type="curve" smooth="yes"/>
+      <point x="1209" y="1298"/>
+      <point x="1075" y="1474"/>
+      <point x="845" y="1479" type="curve" smooth="yes"/>
+      <point x="701" y="1483"/>
+      <point x="584" y="1421"/>
+      <point x="477" y="1332" type="curve" smooth="yes"/>
+      <point x="465" y="1322"/>
+      <point x="452" y="1312"/>
+      <point x="440" y="1302" type="curve" smooth="yes"/>
+      <point x="271" y="1162"/>
+      <point x="197" y="957"/>
+      <point x="178" y="743" type="curve"/>
+      <point x="409" y="744" type="line"/>
+      <point x="433" y="935"/>
+      <point x="566" y="1263"/>
+      <point x="810" y="1246" type="curve" smooth="yes"/>
+      <point x="902" y="1240"/>
+      <point x="915" y="1130"/>
+      <point x="907" y="1058" type="curve" smooth="yes"/>
+      <point x="900" y="995"/>
+      <point x="875" y="919"/>
+      <point x="830" y="873" type="curve"/>
+      <point x="518" y="644" type="line" smooth="yes"/>
+      <point x="409" y="563"/>
+      <point x="330" y="454"/>
+      <point x="321" y="314" type="curve" smooth="yes"/>
+      <point x="311" y="139"/>
+      <point x="425" y="-14"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="619"/>
+  <advance width="1266"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="235" y="-10" type="curve" smooth="yes"/>
-      <point x="317" y="-10"/>
-      <point x="344" y="51"/>
-      <point x="344" y="117" type="curve" smooth="yes"/>
-      <point x="344" y="140"/>
-      <point x="336" y="204"/>
-      <point x="328" y="277" type="curve"/>
-      <point x="404" y="291"/>
-      <point x="470" y="326"/>
-      <point x="512" y="375" type="curve"/>
-      <point x="521" y="361"/>
-      <point x="526" y="345"/>
-      <point x="526" y="327" type="curve" smooth="yes"/>
-      <point x="526" y="281"/>
-      <point x="479" y="238"/>
-      <point x="461" y="224" type="curve"/>
-      <point x="495" y="224" type="line"/>
-      <point x="514" y="238"/>
-      <point x="556" y="281"/>
-      <point x="556" y="326" type="curve" smooth="yes"/>
-      <point x="556" y="354"/>
-      <point x="546" y="378"/>
-      <point x="529" y="397" type="curve"/>
-      <point x="550" y="427"/>
-      <point x="562" y="462"/>
-      <point x="562" y="500" type="curve" smooth="yes"/>
-      <point x="562" y="608"/>
-      <point x="491" y="725"/>
-      <point x="382" y="725" type="curve" smooth="yes"/>
-      <point x="299" y="725"/>
-      <point x="272" y="664"/>
-      <point x="272" y="569" type="curve" smooth="yes"/>
-      <point x="272" y="548"/>
-      <point x="273" y="515"/>
-      <point x="274" y="477" type="curve"/>
-      <point x="262" y="478"/>
-      <point x="251" y="478"/>
-      <point x="241" y="478" type="curve" smooth="yes"/>
-      <point x="230" y="478"/>
-      <point x="211" y="477"/>
-      <point x="190" y="475" type="curve"/>
-      <point x="192" y="613" type="line"/>
-      <point x="207" y="635"/>
-      <point x="221" y="658"/>
-      <point x="221" y="675" type="curve" smooth="yes"/>
-      <point x="221" y="681"/>
-      <point x="220" y="708"/>
-      <point x="193" y="708" type="curve" smooth="yes"/>
-      <point x="158" y="708"/>
-      <point x="170" y="669"/>
-      <point x="154" y="669" type="curve" smooth="yes"/>
-      <point x="134" y="669"/>
-      <point x="123" y="715"/>
-      <point x="75" y="715" type="curve" smooth="yes"/>
-      <point x="52" y="715"/>
-      <point x="11" y="702"/>
-      <point x="11" y="643" type="curve" smooth="yes"/>
-      <point x="11" y="603"/>
-      <point x="38" y="572"/>
-      <point x="82" y="572" type="curve" smooth="yes"/>
-      <point x="89" y="572"/>
-      <point x="96" y="573"/>
-      <point x="101" y="574" type="curve"/>
-      <point x="100" y="592" type="line"/>
-      <point x="96" y="591"/>
-      <point x="88" y="590"/>
-      <point x="82" y="590" type="curve" smooth="yes"/>
-      <point x="64" y="590"/>
-      <point x="58" y="606"/>
-      <point x="58" y="617" type="curve" smooth="yes"/>
-      <point x="58" y="630"/>
-      <point x="67" y="644"/>
-      <point x="86" y="644" type="curve" smooth="yes"/>
-      <point x="108" y="644"/>
-      <point x="155" y="625"/>
-      <point x="172" y="615" type="curve"/>
-      <point x="156" y="471" type="line"/>
-      <point x="94" y="460"/>
-      <point x="24" y="433"/>
-      <point x="24" y="369" type="curve" smooth="yes"/>
-      <point x="24" y="315"/>
-      <point x="77" y="290"/>
-      <point x="137" y="279" type="curve"/>
-      <point x="130" y="208"/>
-      <point x="126" y="144"/>
-      <point x="126" y="117" type="curve" smooth="yes"/>
-      <point x="126" y="51"/>
-      <point x="153" y="-10"/>
+      <point x="596" y="-20" type="curve" smooth="yes"/>
+      <point x="764" y="-20"/>
+      <point x="819" y="104"/>
+      <point x="819" y="240" type="curve" smooth="yes"/>
+      <point x="819" y="287"/>
+      <point x="803" y="418"/>
+      <point x="786" y="567" type="curve"/>
+      <point x="942" y="596"/>
+      <point x="1077" y="668"/>
+      <point x="1163" y="768" type="curve"/>
+      <point x="1181" y="739"/>
+      <point x="1192" y="707"/>
+      <point x="1192" y="670" type="curve" smooth="yes"/>
+      <point x="1192" y="575"/>
+      <point x="1095" y="487"/>
+      <point x="1059" y="459" type="curve"/>
+      <point x="1128" y="459" type="line"/>
+      <point x="1167" y="487"/>
+      <point x="1253" y="575"/>
+      <point x="1253" y="668" type="curve" smooth="yes"/>
+      <point x="1253" y="725"/>
+      <point x="1233" y="774"/>
+      <point x="1198" y="813" type="curve"/>
+      <point x="1241" y="874"/>
+      <point x="1265" y="946"/>
+      <point x="1265" y="1024" type="curve" smooth="yes"/>
+      <point x="1265" y="1245"/>
+      <point x="1120" y="1485"/>
+      <point x="897" y="1485" type="curve" smooth="yes"/>
+      <point x="727" y="1485"/>
+      <point x="671" y="1360"/>
+      <point x="671" y="1165" type="curve" smooth="yes"/>
+      <point x="671" y="1122"/>
+      <point x="674" y="1055"/>
+      <point x="676" y="977" type="curve"/>
+      <point x="651" y="979"/>
+      <point x="628" y="979"/>
+      <point x="608" y="979" type="curve" smooth="yes"/>
+      <point x="585" y="979"/>
+      <point x="547" y="977"/>
+      <point x="504" y="973" type="curve"/>
+      <point x="508" y="1255" type="line"/>
+      <point x="538" y="1300"/>
+      <point x="567" y="1348"/>
+      <point x="567" y="1382" type="curve" smooth="yes"/>
+      <point x="567" y="1395"/>
+      <point x="565" y="1450"/>
+      <point x="510" y="1450" type="curve" smooth="yes"/>
+      <point x="438" y="1450"/>
+      <point x="463" y="1370"/>
+      <point x="430" y="1370" type="curve" smooth="yes"/>
+      <point x="389" y="1370"/>
+      <point x="366" y="1464"/>
+      <point x="268" y="1464" type="curve" smooth="yes"/>
+      <point x="221" y="1464"/>
+      <point x="137" y="1438"/>
+      <point x="137" y="1317" type="curve" smooth="yes"/>
+      <point x="137" y="1235"/>
+      <point x="192" y="1171"/>
+      <point x="282" y="1171" type="curve" smooth="yes"/>
+      <point x="297" y="1171"/>
+      <point x="311" y="1174"/>
+      <point x="321" y="1176" type="curve"/>
+      <point x="319" y="1212" type="line"/>
+      <point x="311" y="1210"/>
+      <point x="295" y="1208"/>
+      <point x="282" y="1208" type="curve" smooth="yes"/>
+      <point x="246" y="1208"/>
+      <point x="233" y="1241"/>
+      <point x="233" y="1264" type="curve" smooth="yes"/>
+      <point x="233" y="1290"/>
+      <point x="252" y="1319"/>
+      <point x="291" y="1319" type="curve" smooth="yes"/>
+      <point x="336" y="1319"/>
+      <point x="432" y="1280"/>
+      <point x="467" y="1260" type="curve"/>
+      <point x="434" y="965" type="line"/>
+      <point x="307" y="942"/>
+      <point x="164" y="887"/>
+      <point x="164" y="756" type="curve" smooth="yes"/>
+      <point x="164" y="645"/>
+      <point x="272" y="594"/>
+      <point x="395" y="571" type="curve"/>
+      <point x="381" y="426"/>
+      <point x="372" y="295"/>
+      <point x="372" y="240" type="curve" smooth="yes"/>
+      <point x="372" y="104"/>
+      <point x="428" y="-20"/>
     </contour>
     <contour>
-      <point x="235" y="20" type="curve" smooth="yes"/>
-      <point x="198" y="20"/>
-      <point x="178" y="58"/>
-      <point x="178" y="115" type="curve" smooth="yes"/>
-      <point x="178" y="146"/>
-      <point x="180" y="206"/>
-      <point x="182" y="273" type="curve"/>
-      <point x="207" y="270"/>
-      <point x="231" y="270"/>
-      <point x="252" y="270" type="curve" smooth="yes"/>
-      <point x="262" y="270"/>
-      <point x="273" y="270"/>
-      <point x="284" y="271" type="curve"/>
-      <point x="287" y="195"/>
-      <point x="291" y="132"/>
-      <point x="291" y="115" type="curve" smooth="yes"/>
-      <point x="291" y="58"/>
-      <point x="271" y="20"/>
+      <point x="596" y="41" type="curve" smooth="yes"/>
+      <point x="520" y="41"/>
+      <point x="479" y="119"/>
+      <point x="479" y="236" type="curve" smooth="yes"/>
+      <point x="479" y="299"/>
+      <point x="483" y="422"/>
+      <point x="487" y="559" type="curve"/>
+      <point x="538" y="553"/>
+      <point x="588" y="553"/>
+      <point x="631" y="553" type="curve" smooth="yes"/>
+      <point x="651" y="553"/>
+      <point x="674" y="553"/>
+      <point x="696" y="555" type="curve"/>
+      <point x="702" y="399"/>
+      <point x="710" y="270"/>
+      <point x="710" y="236" type="curve" smooth="yes"/>
+      <point x="710" y="119"/>
+      <point x="669" y="41"/>
     </contour>
     <contour>
-      <point x="139" y="299" type="line"/>
-      <point x="59" y="318"/>
-      <point x="49" y="358"/>
-      <point x="49" y="372" type="curve" smooth="yes"/>
-      <point x="49" y="384"/>
-      <point x="55" y="434"/>
-      <point x="154" y="453" type="curve"/>
+      <point x="399" y="612" type="line"/>
+      <point x="235" y="651"/>
+      <point x="215" y="733"/>
+      <point x="215" y="762" type="curve" smooth="yes"/>
+      <point x="215" y="786"/>
+      <point x="227" y="889"/>
+      <point x="430" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="251" y="288" type="curve" smooth="yes"/>
-      <point x="224" y="288"/>
-      <point x="203" y="289"/>
-      <point x="183" y="291" type="curve"/>
-      <point x="189" y="458" type="line"/>
-      <point x="204" y="459"/>
-      <point x="221" y="460"/>
-      <point x="240" y="460" type="curve" smooth="yes"/>
-      <point x="252" y="460"/>
-      <point x="263" y="459"/>
-      <point x="275" y="459" type="curve"/>
-      <point x="283" y="289" type="line"/>
-      <point x="272" y="288"/>
-      <point x="262" y="288"/>
+      <point x="628" y="590" type="curve" smooth="yes"/>
+      <point x="573" y="590"/>
+      <point x="530" y="592"/>
+      <point x="489" y="596" type="curve"/>
+      <point x="502" y="938" type="line"/>
+      <point x="532" y="940"/>
+      <point x="567" y="942"/>
+      <point x="606" y="942" type="curve" smooth="yes"/>
+      <point x="631" y="942"/>
+      <point x="653" y="940"/>
+      <point x="678" y="940" type="curve"/>
+      <point x="694" y="592" type="line"/>
+      <point x="671" y="590"/>
+      <point x="651" y="590"/>
     </contour>
     <contour>
-      <point x="326" y="295" type="curve"/>
-      <point x="307" y="457" type="line"/>
-      <point x="367" y="452"/>
-      <point x="427" y="439"/>
-      <point x="469" y="414" type="curve"/>
-      <point x="446" y="351"/>
-      <point x="398" y="311"/>
+      <point x="782" y="604" type="curve"/>
+      <point x="743" y="936" type="line"/>
+      <point x="866" y="926"/>
+      <point x="989" y="899"/>
+      <point x="1075" y="848" type="curve"/>
+      <point x="1028" y="719"/>
+      <point x="930" y="637"/>
     </contour>
     <contour>
-      <point x="474" y="436" type="curve"/>
-      <point x="425" y="460"/>
-      <point x="360" y="471"/>
-      <point x="305" y="475" type="curve"/>
-      <point x="301" y="514"/>
-      <point x="299" y="548"/>
-      <point x="299" y="572" type="curve" smooth="yes"/>
-      <point x="299" y="636"/>
-      <point x="305" y="707"/>
-      <point x="379" y="707" type="curve" smooth="yes"/>
-      <point x="470" y="707"/>
-      <point x="486" y="593"/>
-      <point x="486" y="519" type="curve" smooth="yes"/>
-      <point x="486" y="488"/>
-      <point x="481" y="461"/>
+      <point x="1087" y="893" type="curve"/>
+      <point x="987" y="942"/>
+      <point x="852" y="965"/>
+      <point x="739" y="973" type="curve"/>
+      <point x="731" y="1053"/>
+      <point x="727" y="1122"/>
+      <point x="727" y="1171" type="curve" smooth="yes"/>
+      <point x="727" y="1303"/>
+      <point x="739" y="1448"/>
+      <point x="891" y="1448" type="curve" smooth="yes"/>
+      <point x="1077" y="1448"/>
+      <point x="1110" y="1214"/>
+      <point x="1110" y="1063" type="curve" smooth="yes"/>
+      <point x="1110" y="999"/>
+      <point x="1102" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="619"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="235" y="-10" type="curve" smooth="yes"/>
+      <point x="317" y="-10"/>
+      <point x="344" y="51"/>
+      <point x="344" y="117" type="curve" smooth="yes"/>
+      <point x="344" y="140"/>
+      <point x="336" y="204"/>
+      <point x="328" y="277" type="curve"/>
+      <point x="404" y="291"/>
+      <point x="470" y="326"/>
+      <point x="512" y="375" type="curve"/>
+      <point x="521" y="361"/>
+      <point x="526" y="345"/>
+      <point x="526" y="327" type="curve" smooth="yes"/>
+      <point x="526" y="281"/>
+      <point x="479" y="238"/>
+      <point x="461" y="224" type="curve"/>
+      <point x="495" y="224" type="line"/>
+      <point x="514" y="238"/>
+      <point x="556" y="281"/>
+      <point x="556" y="326" type="curve" smooth="yes"/>
+      <point x="556" y="354"/>
+      <point x="546" y="378"/>
+      <point x="529" y="397" type="curve"/>
+      <point x="550" y="427"/>
+      <point x="562" y="462"/>
+      <point x="562" y="500" type="curve" smooth="yes"/>
+      <point x="562" y="608"/>
+      <point x="491" y="725"/>
+      <point x="382" y="725" type="curve" smooth="yes"/>
+      <point x="299" y="725"/>
+      <point x="272" y="664"/>
+      <point x="272" y="569" type="curve" smooth="yes"/>
+      <point x="272" y="548"/>
+      <point x="273" y="515"/>
+      <point x="274" y="477" type="curve"/>
+      <point x="262" y="478"/>
+      <point x="251" y="478"/>
+      <point x="241" y="478" type="curve" smooth="yes"/>
+      <point x="230" y="478"/>
+      <point x="211" y="477"/>
+      <point x="190" y="475" type="curve"/>
+      <point x="192" y="613" type="line"/>
+      <point x="207" y="635"/>
+      <point x="221" y="658"/>
+      <point x="221" y="675" type="curve" smooth="yes"/>
+      <point x="221" y="681"/>
+      <point x="220" y="708"/>
+      <point x="193" y="708" type="curve" smooth="yes"/>
+      <point x="158" y="708"/>
+      <point x="170" y="669"/>
+      <point x="154" y="669" type="curve" smooth="yes"/>
+      <point x="134" y="669"/>
+      <point x="123" y="715"/>
+      <point x="75" y="715" type="curve" smooth="yes"/>
+      <point x="52" y="715"/>
+      <point x="11" y="702"/>
+      <point x="11" y="643" type="curve" smooth="yes"/>
+      <point x="11" y="603"/>
+      <point x="38" y="572"/>
+      <point x="82" y="572" type="curve" smooth="yes"/>
+      <point x="89" y="572"/>
+      <point x="96" y="573"/>
+      <point x="101" y="574" type="curve"/>
+      <point x="100" y="592" type="line"/>
+      <point x="96" y="591"/>
+      <point x="88" y="590"/>
+      <point x="82" y="590" type="curve" smooth="yes"/>
+      <point x="64" y="590"/>
+      <point x="58" y="606"/>
+      <point x="58" y="617" type="curve" smooth="yes"/>
+      <point x="58" y="630"/>
+      <point x="67" y="644"/>
+      <point x="86" y="644" type="curve" smooth="yes"/>
+      <point x="108" y="644"/>
+      <point x="155" y="625"/>
+      <point x="172" y="615" type="curve"/>
+      <point x="156" y="471" type="line"/>
+      <point x="94" y="460"/>
+      <point x="24" y="433"/>
+      <point x="24" y="369" type="curve" smooth="yes"/>
+      <point x="24" y="315"/>
+      <point x="77" y="290"/>
+      <point x="137" y="279" type="curve"/>
+      <point x="130" y="208"/>
+      <point x="126" y="144"/>
+      <point x="126" y="117" type="curve" smooth="yes"/>
+      <point x="126" y="51"/>
+      <point x="153" y="-10"/>
+    </contour>
+    <contour>
+      <point x="235" y="20" type="curve" smooth="yes"/>
+      <point x="198" y="20"/>
+      <point x="178" y="58"/>
+      <point x="178" y="115" type="curve" smooth="yes"/>
+      <point x="178" y="146"/>
+      <point x="180" y="206"/>
+      <point x="182" y="273" type="curve"/>
+      <point x="207" y="270"/>
+      <point x="231" y="270"/>
+      <point x="252" y="270" type="curve" smooth="yes"/>
+      <point x="262" y="270"/>
+      <point x="273" y="270"/>
+      <point x="284" y="271" type="curve"/>
+      <point x="287" y="195"/>
+      <point x="291" y="132"/>
+      <point x="291" y="115" type="curve" smooth="yes"/>
+      <point x="291" y="58"/>
+      <point x="271" y="20"/>
+    </contour>
+    <contour>
+      <point x="139" y="299" type="line"/>
+      <point x="59" y="318"/>
+      <point x="49" y="358"/>
+      <point x="49" y="372" type="curve" smooth="yes"/>
+      <point x="49" y="384"/>
+      <point x="55" y="434"/>
+      <point x="154" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="251" y="288" type="curve" smooth="yes"/>
+      <point x="224" y="288"/>
+      <point x="203" y="289"/>
+      <point x="183" y="291" type="curve"/>
+      <point x="189" y="458" type="line"/>
+      <point x="204" y="459"/>
+      <point x="221" y="460"/>
+      <point x="240" y="460" type="curve" smooth="yes"/>
+      <point x="252" y="460"/>
+      <point x="263" y="459"/>
+      <point x="275" y="459" type="curve"/>
+      <point x="283" y="289" type="line"/>
+      <point x="272" y="288"/>
+      <point x="262" y="288"/>
+    </contour>
+    <contour>
+      <point x="326" y="295" type="curve"/>
+      <point x="307" y="457" type="line"/>
+      <point x="367" y="452"/>
+      <point x="427" y="439"/>
+      <point x="469" y="414" type="curve"/>
+      <point x="446" y="351"/>
+      <point x="398" y="311"/>
+    </contour>
+    <contour>
+      <point x="474" y="436" type="curve"/>
+      <point x="425" y="460"/>
+      <point x="360" y="471"/>
+      <point x="305" y="475" type="curve"/>
+      <point x="301" y="514"/>
+      <point x="299" y="548"/>
+      <point x="299" y="572" type="curve" smooth="yes"/>
+      <point x="299" y="636"/>
+      <point x="305" y="707"/>
+      <point x="379" y="707" type="curve" smooth="yes"/>
+      <point x="470" y="707"/>
+      <point x="486" y="593"/>
+      <point x="486" y="519" type="curve" smooth="yes"/>
+      <point x="486" y="488"/>
+      <point x="481" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:57:57 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-BoldItalic.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="851"/>
+  <unicode hex="214E"/>
+  <anchor x="242" y="10" name="bottom"/>
+  <anchor x="603" y="-407" name="bottom_dd"/>
+  <anchor x="546" y="1320" name="parent_top"/>
+  <anchor x="546" y="1320" name="top"/>
+  <anchor x="902" y="1320" name="top0315"/>
+  <anchor x="950" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="393" y="0" type="line"/>
+      <point x="669" y="0" type="line"/>
+      <point x="857" y="1082" type="line"/>
+      <point x="581" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="-21" y="0" type="line"/>
+      <point x="468" y="0" type="line"/>
+      <point x="509" y="235" type="line"/>
+      <point x="21" y="235" type="line"/>
+    </contour>
+    <contour>
+      <point x="100" y="476" type="line"/>
+      <point x="550" y="476" type="line"/>
+      <point x="592" y="711" type="line"/>
+      <point x="141" y="711" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:57:57 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-BoldItalic.ufo/lib.plist
+++ b/sources/RobotoCondensed-BoldItalic.ufo/lib.plist
@@ -6898,6 +6898,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-Italic.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Italic.ufo/fontinfo.plist
@@ -375,7 +375,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/contents.plist
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="835"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="-7" y="0" type="line"/>
+      <point x="282" y="0" type="line" smooth="yes"/>
+      <point x="542" y="0"/>
+      <point x="691" y="231"/>
+      <point x="691" y="483" type="curve" smooth="yes"/>
+      <point x="691" y="633"/>
+      <point x="638" y="731"/>
+      <point x="536" y="762" type="curve"/>
+      <point x="536" y="768" type="line"/>
+      <point x="726" y="819"/>
+      <point x="810" y="1001"/>
+      <point x="810" y="1169" type="curve" smooth="yes"/>
+      <point x="810" y="1370"/>
+      <point x="689" y="1462"/>
+      <point x="515" y="1462" type="curve" smooth="yes"/>
+      <point x="302" y="1462" type="line"/>
+    </contour>
+    <contour>
+      <point x="73" y="-201" type="line"/>
+      <point x="155" y="-201" type="line"/>
+      <point x="222" y="111" type="line"/>
+      <point x="140" y="111" type="line"/>
+    </contour>
+    <contour>
+      <point x="257" y="-201" type="line"/>
+      <point x="339" y="-201" type="line"/>
+      <point x="407" y="111" type="line"/>
+      <point x="325" y="111" type="line"/>
+    </contour>
+    <contour>
+      <point x="188" y="145" type="line"/>
+      <point x="304" y="694" type="line"/>
+      <point x="374" y="694" type="line" smooth="yes"/>
+      <point x="474" y="694"/>
+      <point x="521" y="641"/>
+      <point x="521" y="500" type="curve" smooth="yes"/>
+      <point x="521" y="330"/>
+      <point x="452" y="145"/>
+      <point x="282" y="145" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="333" y="834" type="line"/>
+      <point x="435" y="1319" type="line"/>
+      <point x="478" y="1319" type="line" smooth="yes"/>
+      <point x="589" y="1319"/>
+      <point x="634" y="1272"/>
+      <point x="634" y="1149" type="curve" smooth="yes"/>
+      <point x="634" y="991"/>
+      <point x="560" y="834"/>
+      <point x="396" y="834" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="405" y="1358" type="line"/>
+      <point x="487" y="1358" type="line"/>
+      <point x="554" y="1669" type="line"/>
+      <point x="472" y="1669" type="line"/>
+    </contour>
+    <contour>
+      <point x="589" y="1358" type="line"/>
+      <point x="671" y="1358" type="line"/>
+      <point x="738" y="1669" type="line"/>
+      <point x="657" y="1669" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="938"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="246" y="0" type="line"/>
+      <point x="774" y="0" type="line"/>
+      <point x="797" y="139" type="line"/>
+      <point x="410" y="139" type="line"/>
+      <point x="453" y="395" type="line"/>
+      <point x="497" y="403"/>
+      <point x="537" y="418"/>
+      <point x="572" y="440" type="curve"/>
+      <point x="590" y="551" type="line"/>
+      <point x="551" y="528"/>
+      <point x="512" y="512"/>
+      <point x="471" y="502" type="curve"/>
+      <point x="572" y="1106" type="line"/>
+      <point x="600" y="1100"/>
+      <point x="631" y="1087"/>
+      <point x="658" y="1071" type="curve"/>
+      <point x="708" y="1174" type="line"/>
+      <point x="675" y="1194"/>
+      <point x="634" y="1208"/>
+      <point x="590" y="1214" type="curve"/>
+      <point x="632" y="1462" type="line"/>
+      <point x="491" y="1462" type="line"/>
+      <point x="448" y="1208" type="line"/>
+      <point x="299" y="1171"/>
+      <point x="189" y="1030"/>
+      <point x="151" y="801" type="curve" smooth="yes"/>
+      <point x="112" y="569"/>
+      <point x="171" y="428"/>
+      <point x="312" y="397" type="curve"/>
+    </contour>
+    <contour>
+      <point x="332" y="512" type="line"/>
+      <point x="268" y="549"/>
+      <point x="249" y="651"/>
+      <point x="274" y="801" type="curve" smooth="yes"/>
+      <point x="301" y="961"/>
+      <point x="353" y="1059"/>
+      <point x="429" y="1096" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="920"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2108.glif
@@ -37,10 +37,10 @@
       <point x="223.306" y="-12.76"/>
     </contour>
     <contour>
-      <point x="918.612" y="647.082" type="line"/>
-      <point x="946.658" y="804.908" type="line"/>
-      <point x="467.121" y="804.917" type="line"/>
       <point x="439.075" y="647.09" type="line"/>
+      <point x="939" y="647" type="line"/>
+      <point x="967" y="805" type="line"/>
+      <point x="467.121" y="804.917" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1173"/>
+  <unicode hex="2108"/>
+  <anchor x="761.627" y="1634" name="parent_top"/>
+  <anchor x="761.627" y="1634" name="top"/>
+  <anchor x="1331.987" y="1634" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="505.925" y="-20.033" type="curve" smooth="yes"/>
+      <point x="865.869" y="-29.296"/>
+      <point x="1032.83" y="354.977"/>
+      <point x="1078.005" y="655.29" type="curve" smooth="yes"/>
+      <point x="1099.169" y="799.3" type="line" smooth="yes"/>
+      <point x="1136.896" y="1084.191"/>
+      <point x="1071.919" y="1467.51"/>
+      <point x="715.48" y="1476.569" type="curve" smooth="yes"/>
+      <point x="424.059" y="1483.975"/>
+      <point x="262.982" y="1250.704"/>
+      <point x="214.399" y="988.86" type="curve"/>
+      <point x="391.829" y="990.163" type="line"/>
+      <point x="433.489" y="1154.502"/>
+      <point x="507.578" y="1327.162"/>
+      <point x="705.596" y="1319.873" type="curve" smooth="yes"/>
+      <point x="959.48" y="1310.527"/>
+      <point x="943.9" y="979.917"/>
+      <point x="919.734" y="801.942" type="curve" smooth="yes"/>
+      <point x="897.973" y="654.83" type="line" smooth="yes"/>
+      <point x="866.87" y="450.6"/>
+      <point x="778.749" y="127.756"/>
+      <point x="516.358" y="135.825" type="curve" smooth="yes"/>
+      <point x="323.063" y="141.769"/>
+      <point x="298.527" y="301.687"/>
+      <point x="294.714" y="463.607" type="curve"/>
+      <point x="115.74" y="463.826" type="line"/>
+      <point x="118.216" y="209.07"/>
+      <point x="223.306" y="-12.76"/>
+    </contour>
+    <contour>
+      <point x="918.612" y="647.082" type="line"/>
+      <point x="946.658" y="804.908" type="line"/>
+      <point x="467.121" y="804.917" type="line"/>
+      <point x="439.075" y="647.09" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1489"/>
+  <unicode hex="2114"/>
+  <anchor x="912.853" y="-10" name="bottom"/>
+  <anchor x="1295.308" y="-407" name="bottom_dd"/>
+  <anchor x="690.205" y="1540" name="marktop"/>
+  <anchor x="1227.853" y="1611" name="parent_top"/>
+  <anchor x="1227.853" y="1611" name="top"/>
+  <anchor x="1643.983" y="1611" name="top0315"/>
+  <anchor x="1642.082" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="966" y="-20" type="curve" smooth="yes"/>
+      <point x="1252" y="-30"/>
+      <point x="1350" y="254"/>
+      <point x="1381" y="490" type="curve" smooth="yes"/>
+      <point x="1394" y="590" type="line" smooth="yes"/>
+      <point x="1419" y="810"/>
+      <point x="1399" y="1095"/>
+      <point x="1120" y="1103" type="curve" smooth="yes"/>
+      <point x="857" y="1110"/>
+      <point x="754" y="823"/>
+      <point x="718" y="607" type="curve" smooth="yes"/>
+      <point x="700" y="472" type="line"/>
+      <point x="684" y="276"/>
+      <point x="716" y="-12"/>
+    </contour>
+    <contour>
+      <point x="74" y="0" type="line"/>
+      <point x="246" y="0" type="line"/>
+      <point x="513" y="1536" type="line"/>
+      <point x="341" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="533" y="0" type="line"/>
+      <point x="693" y="0" type="line"/>
+      <point x="741" y="199" type="line"/>
+      <point x="973" y="1536" type="line"/>
+      <point x="800" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="931" y="136" type="curve" smooth="yes"/>
+      <point x="801" y="143"/>
+      <point x="737" y="278"/>
+      <point x="742" y="396" type="curve"/>
+      <point x="788" y="682" type="line"/>
+      <point x="820" y="810"/>
+      <point x="921" y="952"/>
+      <point x="1066" y="948" type="curve" smooth="yes"/>
+      <point x="1257" y="943"/>
+      <point x="1237" y="730"/>
+      <point x="1222" y="591" type="curve" smooth="yes"/>
+      <point x="1210" y="489" type="line" smooth="yes"/>
+      <point x="1189" y="326"/>
+      <point x="1132" y="127"/>
+    </contour>
+    <contour>
+      <point x="125" y="1233" type="line"/>
+      <point x="1107" y="1233" type="line"/>
+      <point x="1134" y="1385" type="line"/>
+      <point x="152" y="1385" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="807"/>
+  <advance width="1534"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="179" y="-241" type="curve" smooth="yes"/>
-      <point x="249" y="-241"/>
-      <point x="296" y="-180"/>
-      <point x="296" y="-95" type="curve" smooth="yes"/>
-      <point x="296" y="8"/>
-      <point x="204" y="99"/>
-      <point x="147" y="200" type="curve"/>
-      <point x="194" y="272"/>
-      <point x="254" y="341"/>
-      <point x="316" y="394" type="curve" smooth="yes"/>
-      <point x="384" y="452"/>
-      <point x="455" y="492"/>
-      <point x="514" y="492" type="curve" smooth="yes"/>
-      <point x="616" y="492"/>
-      <point x="624" y="359"/>
-      <point x="624" y="322" type="curve" smooth="yes"/>
-      <point x="624" y="285"/>
-      <point x="611" y="30"/>
-      <point x="447" y="30" type="curve" smooth="yes"/>
-      <point x="396" y="30"/>
-      <point x="347" y="57"/>
-      <point x="347" y="112" type="curve" smooth="yes"/>
-      <point x="347" y="119"/>
-      <point x="348" y="126"/>
-      <point x="350" y="132" type="curve"/>
-      <point x="382" y="136"/>
-      <point x="415" y="151"/>
-      <point x="415" y="194" type="curve" smooth="yes"/>
-      <point x="415" y="225"/>
-      <point x="394" y="244"/>
-      <point x="363" y="244" type="curve" smooth="yes"/>
-      <point x="315" y="244"/>
-      <point x="285" y="206"/>
-      <point x="285" y="140" type="curve" smooth="yes"/>
-      <point x="285" y="51"/>
-      <point x="349" y="-10"/>
-      <point x="455" y="-10" type="curve" smooth="yes"/>
-      <point x="633" y="-10"/>
-      <point x="726" y="159"/>
-      <point x="726" y="306" type="curve" smooth="yes"/>
-      <point x="726" y="437"/>
-      <point x="666" y="549"/>
-      <point x="544" y="549" type="curve" smooth="yes"/>
-      <point x="494" y="549"/>
-      <point x="398" y="512"/>
-      <point x="292" y="419" type="curve" smooth="yes"/>
-      <point x="240" y="373"/>
-      <point x="179" y="310"/>
-      <point x="127" y="238" type="curve"/>
-      <point x="112" y="272"/>
-      <point x="103" y="307"/>
-      <point x="103" y="345" type="curve" smooth="yes"/>
-      <point x="103" y="474"/>
-      <point x="133" y="548"/>
-      <point x="214" y="625" type="curve"/>
-      <point x="198" y="647" type="line"/>
-      <point x="139" y="610"/>
-      <point x="15" y="496"/>
-      <point x="15" y="337" type="curve" smooth="yes"/>
-      <point x="15" y="267"/>
-      <point x="39" y="206"/>
-      <point x="71" y="149" type="curve"/>
-      <point x="36" y="85"/>
-      <point x="10" y="11"/>
-      <point x="10" y="-56" type="curve" smooth="yes"/>
-      <point x="10" y="-163"/>
-      <point x="84" y="-241"/>
+      <point x="401" y="-494" type="curve" smooth="yes"/>
+      <point x="538" y="-494"/>
+      <point x="632" y="-369"/>
+      <point x="632" y="-195" type="curve" smooth="yes"/>
+      <point x="632" y="16"/>
+      <point x="450" y="203"/>
+      <point x="337" y="410" type="curve"/>
+      <point x="432" y="557"/>
+      <point x="552" y="698"/>
+      <point x="673" y="807" type="curve" smooth="yes"/>
+      <point x="806" y="926"/>
+      <point x="948" y="1008"/>
+      <point x="1066" y="1008" type="curve" smooth="yes"/>
+      <point x="1269" y="1008"/>
+      <point x="1284" y="735"/>
+      <point x="1284" y="659" type="curve" smooth="yes"/>
+      <point x="1284" y="584"/>
+      <point x="1259" y="61"/>
+      <point x="933" y="61" type="curve" smooth="yes"/>
+      <point x="831" y="61"/>
+      <point x="733" y="117"/>
+      <point x="733" y="229" type="curve" smooth="yes"/>
+      <point x="733" y="244"/>
+      <point x="735" y="258"/>
+      <point x="739" y="270" type="curve"/>
+      <point x="804" y="279"/>
+      <point x="870" y="309"/>
+      <point x="870" y="397" type="curve" smooth="yes"/>
+      <point x="870" y="461"/>
+      <point x="827" y="500"/>
+      <point x="765" y="500" type="curve" smooth="yes"/>
+      <point x="669" y="500"/>
+      <point x="612" y="422"/>
+      <point x="612" y="287" type="curve" smooth="yes"/>
+      <point x="612" y="104"/>
+      <point x="737" y="-20"/>
+      <point x="948" y="-20" type="curve" smooth="yes"/>
+      <point x="1300" y="-20"/>
+      <point x="1486" y="326"/>
+      <point x="1486" y="627" type="curve" smooth="yes"/>
+      <point x="1486" y="895"/>
+      <point x="1365" y="1124"/>
+      <point x="1126" y="1124" type="curve" smooth="yes"/>
+      <point x="1025" y="1124"/>
+      <point x="837" y="1049"/>
+      <point x="626" y="858" type="curve" smooth="yes"/>
+      <point x="522" y="764"/>
+      <point x="401" y="635"/>
+      <point x="298" y="487" type="curve"/>
+      <point x="268" y="557"/>
+      <point x="249" y="629"/>
+      <point x="249" y="707" type="curve" smooth="yes"/>
+      <point x="249" y="971"/>
+      <point x="309" y="1122"/>
+      <point x="468" y="1280" type="curve"/>
+      <point x="438" y="1325" type="line"/>
+      <point x="321" y="1249"/>
+      <point x="75" y="1016"/>
+      <point x="75" y="690" type="curve" smooth="yes"/>
+      <point x="75" y="547"/>
+      <point x="122" y="422"/>
+      <point x="186" y="305" type="curve"/>
+      <point x="116" y="174"/>
+      <point x="65" y="23"/>
+      <point x="65" y="-115" type="curve" smooth="yes"/>
+      <point x="65" y="-334"/>
+      <point x="210" y="-494"/>
     </contour>
     <contour>
-      <point x="161" y="-199" type="curve" smooth="yes"/>
-      <point x="117" y="-199"/>
-      <point x="50" y="-145"/>
-      <point x="50" y="-51" type="curve" smooth="yes"/>
-      <point x="50" y="-4"/>
-      <point x="66" y="52"/>
-      <point x="94" y="110" type="curve"/>
-      <point x="148" y="24"/>
-      <point x="209" y="-52"/>
-      <point x="209" y="-134" type="curve" smooth="yes"/>
-      <point x="209" y="-176"/>
-      <point x="190" y="-199"/>
+      <point x="366" y="-408" type="curve" smooth="yes"/>
+      <point x="276" y="-408"/>
+      <point x="145" y="-297"/>
+      <point x="145" y="-104" type="curve" smooth="yes"/>
+      <point x="145" y="-8"/>
+      <point x="178" y="106"/>
+      <point x="233" y="225" type="curve"/>
+      <point x="337" y="49"/>
+      <point x="460" y="-106"/>
+      <point x="460" y="-274" type="curve" smooth="yes"/>
+      <point x="460" y="-360"/>
+      <point x="423" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="807"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="179" y="-241" type="curve" smooth="yes"/>
+      <point x="249" y="-241"/>
+      <point x="296" y="-180"/>
+      <point x="296" y="-95" type="curve" smooth="yes"/>
+      <point x="296" y="8"/>
+      <point x="204" y="99"/>
+      <point x="147" y="200" type="curve"/>
+      <point x="194" y="272"/>
+      <point x="254" y="341"/>
+      <point x="316" y="394" type="curve" smooth="yes"/>
+      <point x="384" y="452"/>
+      <point x="455" y="492"/>
+      <point x="514" y="492" type="curve" smooth="yes"/>
+      <point x="616" y="492"/>
+      <point x="624" y="359"/>
+      <point x="624" y="322" type="curve" smooth="yes"/>
+      <point x="624" y="285"/>
+      <point x="611" y="30"/>
+      <point x="447" y="30" type="curve" smooth="yes"/>
+      <point x="396" y="30"/>
+      <point x="347" y="57"/>
+      <point x="347" y="112" type="curve" smooth="yes"/>
+      <point x="347" y="119"/>
+      <point x="348" y="126"/>
+      <point x="350" y="132" type="curve"/>
+      <point x="382" y="136"/>
+      <point x="415" y="151"/>
+      <point x="415" y="194" type="curve" smooth="yes"/>
+      <point x="415" y="225"/>
+      <point x="394" y="244"/>
+      <point x="363" y="244" type="curve" smooth="yes"/>
+      <point x="315" y="244"/>
+      <point x="285" y="206"/>
+      <point x="285" y="140" type="curve" smooth="yes"/>
+      <point x="285" y="51"/>
+      <point x="349" y="-10"/>
+      <point x="455" y="-10" type="curve" smooth="yes"/>
+      <point x="633" y="-10"/>
+      <point x="726" y="159"/>
+      <point x="726" y="306" type="curve" smooth="yes"/>
+      <point x="726" y="437"/>
+      <point x="666" y="549"/>
+      <point x="544" y="549" type="curve" smooth="yes"/>
+      <point x="494" y="549"/>
+      <point x="398" y="512"/>
+      <point x="292" y="419" type="curve" smooth="yes"/>
+      <point x="240" y="373"/>
+      <point x="179" y="310"/>
+      <point x="127" y="238" type="curve"/>
+      <point x="112" y="272"/>
+      <point x="103" y="307"/>
+      <point x="103" y="345" type="curve" smooth="yes"/>
+      <point x="103" y="474"/>
+      <point x="133" y="548"/>
+      <point x="214" y="625" type="curve"/>
+      <point x="198" y="647" type="line"/>
+      <point x="139" y="610"/>
+      <point x="15" y="496"/>
+      <point x="15" y="337" type="curve" smooth="yes"/>
+      <point x="15" y="267"/>
+      <point x="39" y="206"/>
+      <point x="71" y="149" type="curve"/>
+      <point x="36" y="85"/>
+      <point x="10" y="11"/>
+      <point x="10" y="-56" type="curve" smooth="yes"/>
+      <point x="10" y="-163"/>
+      <point x="84" y="-241"/>
+    </contour>
+    <contour>
+      <point x="161" y="-199" type="curve" smooth="yes"/>
+      <point x="117" y="-199"/>
+      <point x="50" y="-145"/>
+      <point x="50" y="-51" type="curve" smooth="yes"/>
+      <point x="50" y="-4"/>
+      <point x="66" y="52"/>
+      <point x="94" y="110" type="curve"/>
+      <point x="148" y="24"/>
+      <point x="209" y="-52"/>
+      <point x="209" y="-134" type="curve" smooth="yes"/>
+      <point x="209" y="-176"/>
+      <point x="190" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2127.glif
@@ -2,51 +2,51 @@
 <glyph name="uni2127" format="2">
   <advance width="1155"/>
   <unicode hex="2127"/>
-  <anchor x="768.701" y="1446" name="top"/>
+  <anchor x="713" y="1446" name="top"/>
   <outline>
     <contour>
-      <point x="538" y="-20" type="curve" smooth="yes"/>
-      <point x="881" y="-30"/>
-      <point x="1050" y="327"/>
-      <point x="1093" y="616" type="curve" smooth="yes"/>
-      <point x="1109" y="730" type="line" smooth="yes"/>
-      <point x="1142" y="971"/>
-      <point x="1099" y="1368"/>
-      <point x="808" y="1433" type="curve"/>
-      <point x="794" y="1292" type="line"/>
-      <point x="1001" y="1231"/>
-      <point x="948" y="886"/>
-      <point x="927" y="731" type="curve" smooth="yes"/>
-      <point x="911" y="614" type="line" smooth="yes"/>
-      <point x="882" y="421"/>
-      <point x="794" y="125"/>
-      <point x="547" y="136" type="curve" smooth="yes"/>
-      <point x="317" y="146"/>
-      <point x="334" y="453"/>
-      <point x="354" y="613" type="curve" smooth="yes"/>
-      <point x="371" y="730" type="line" smooth="yes"/>
-      <point x="401" y="938"/>
-      <point x="466" y="1233"/>
-      <point x="703" y="1295" type="curve"/>
-      <point x="719" y="1436" type="line"/>
-      <point x="395" y="1385"/>
-      <point x="234" y="1019"/>
-      <point x="189" y="730" type="curve" smooth="yes"/>
-      <point x="173" y="616" type="line" smooth="yes"/>
-      <point x="139" y="352"/>
-      <point x="210" y="-11"/>
+      <point x="482" y="-20" type="curve" smooth="yes"/>
+      <point x="825" y="-30"/>
+      <point x="994" y="327"/>
+      <point x="1037" y="616" type="curve" smooth="yes"/>
+      <point x="1053" y="730" type="line" smooth="yes"/>
+      <point x="1086" y="971"/>
+      <point x="1043" y="1368"/>
+      <point x="752" y="1433" type="curve"/>
+      <point x="738" y="1292" type="line"/>
+      <point x="945" y="1231"/>
+      <point x="892" y="886"/>
+      <point x="871" y="731" type="curve" smooth="yes"/>
+      <point x="855" y="614" type="line" smooth="yes"/>
+      <point x="826" y="421"/>
+      <point x="738" y="125"/>
+      <point x="491" y="136" type="curve" smooth="yes"/>
+      <point x="261" y="146"/>
+      <point x="278" y="453"/>
+      <point x="298" y="613" type="curve" smooth="yes"/>
+      <point x="315" y="730" type="line" smooth="yes"/>
+      <point x="345" y="938"/>
+      <point x="410" y="1233"/>
+      <point x="647" y="1295" type="curve"/>
+      <point x="663" y="1436" type="line"/>
+      <point x="339" y="1385"/>
+      <point x="178" y="1019"/>
+      <point x="133" y="730" type="curve" smooth="yes"/>
+      <point x="117" y="616" type="line" smooth="yes"/>
+      <point x="83" y="352"/>
+      <point x="154" y="-11"/>
     </contour>
     <contour>
-      <point x="298" y="1299" type="line"/>
-      <point x="701" y="1299" type="line"/>
-      <point x="729" y="1456" type="line"/>
-      <point x="326" y="1456" type="line"/>
+      <point x="242" y="1299" type="line"/>
+      <point x="645" y="1299" type="line"/>
+      <point x="673" y="1456" type="line"/>
+      <point x="270" y="1456" type="line"/>
     </contour>
     <contour>
-      <point x="792" y="1299" type="line"/>
-      <point x="1202" y="1299" type="line"/>
-      <point x="1230" y="1456" type="line"/>
-      <point x="820" y="1456" type="line"/>
+      <point x="736" y="1299" type="line"/>
+      <point x="1146" y="1299" type="line"/>
+      <point x="1174" y="1456" type="line"/>
+      <point x="764" y="1456" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1155"/>
+  <unicode hex="2127"/>
+  <anchor x="768.701" y="1446" name="top"/>
+  <outline>
+    <contour>
+      <point x="538" y="-20" type="curve" smooth="yes"/>
+      <point x="881" y="-30"/>
+      <point x="1050" y="327"/>
+      <point x="1093" y="616" type="curve" smooth="yes"/>
+      <point x="1109" y="730" type="line" smooth="yes"/>
+      <point x="1142" y="971"/>
+      <point x="1099" y="1368"/>
+      <point x="808" y="1433" type="curve"/>
+      <point x="794" y="1292" type="line"/>
+      <point x="1001" y="1231"/>
+      <point x="948" y="886"/>
+      <point x="927" y="731" type="curve" smooth="yes"/>
+      <point x="911" y="614" type="line" smooth="yes"/>
+      <point x="882" y="421"/>
+      <point x="794" y="125"/>
+      <point x="547" y="136" type="curve" smooth="yes"/>
+      <point x="317" y="146"/>
+      <point x="334" y="453"/>
+      <point x="354" y="613" type="curve" smooth="yes"/>
+      <point x="371" y="730" type="line" smooth="yes"/>
+      <point x="401" y="938"/>
+      <point x="466" y="1233"/>
+      <point x="703" y="1295" type="curve"/>
+      <point x="719" y="1436" type="line"/>
+      <point x="395" y="1385"/>
+      <point x="234" y="1019"/>
+      <point x="189" y="730" type="curve" smooth="yes"/>
+      <point x="173" y="616" type="line" smooth="yes"/>
+      <point x="139" y="352"/>
+      <point x="210" y="-11"/>
+    </contour>
+    <contour>
+      <point x="298" y="1299" type="line"/>
+      <point x="701" y="1299" type="line"/>
+      <point x="729" y="1456" type="line"/>
+      <point x="326" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="792" y="1299" type="line"/>
+      <point x="1202" y="1299" type="line"/>
+      <point x="1230" y="1456" type="line"/>
+      <point x="820" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="596"/>
+  <unicode hex="2129"/>
+  <anchor x="202.899" y="-199" name="bottom"/>
+  <anchor x="-98.771" y="-199" name="bottom0315"/>
+  <anchor x="202.899" y="-199" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="154" y="-12" type="line"/>
+      <point x="327" y="-12" type="line"/>
+      <point x="461" y="793" type="line"/>
+      <point x="472" y="918"/>
+      <point x="447" y="1078"/>
+      <point x="291" y="1081" type="curve" smooth="yes"/>
+      <point x="252" y="1082"/>
+      <point x="213" y="1076"/>
+      <point x="177" y="1063" type="curve"/>
+      <point x="164" y="911" type="line"/>
+      <point x="186" y="916"/>
+      <point x="209" y="921"/>
+      <point x="232" y="921" type="curve" smooth="yes"/>
+      <point x="300" y="921"/>
+      <point x="296" y="847"/>
+      <point x="291" y="796" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2139.glif
@@ -2,13 +2,13 @@
 <glyph name="uni2139" format="2">
   <advance width="456"/>
   <unicode hex="2139"/>
-  <anchor x="126.009" y="10" name="bottom"/>
-  <anchor x="262.508" y="-407" name="bottom_dd"/>
-  <anchor x="401.702" y="1600" name="parent_top"/>
-  <anchor x="264.44" y="654" name="rhotichook"/>
-  <anchor x="401.702" y="1600" name="top"/>
-  <anchor x="609.282" y="1600" name="top0315"/>
-  <anchor x="609.282" y="1600" name="top_dd"/>
+  <anchor x="126.009" y="10.0" name="bottom"/>
+  <anchor x="262.508" y="-407.0" name="bottom_dd"/>
+  <anchor x="401.702" y="1600.0" name="parent_top"/>
+  <anchor x="264.44" y="654.0" name="rhotichook"/>
+  <anchor x="401.702" y="1600.0" name="top"/>
+  <anchor x="609.282" y="1600.0" name="top0315"/>
+  <anchor x="609.282" y="1600.0" name="top_dd"/>
   <outline>
     <component base="i"/>
   </outline>
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="456"/>
+  <unicode hex="2139"/>
+  <anchor x="126.009" y="10" name="bottom"/>
+  <anchor x="262.508" y="-407" name="bottom_dd"/>
+  <anchor x="401.702" y="1600" name="parent_top"/>
+  <anchor x="264.44" y="654" name="rhotichook"/>
+  <anchor x="401.702" y="1600" name="top"/>
+  <anchor x="609.282" y="1600" name="top0315"/>
+  <anchor x="609.282" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1771"/>
+  <unicode hex="213A"/>
+  <anchor x="1604.076" y="656.83" name="bottom"/>
+  <anchor x="1905.051" y="1236.15" name="bottom_dd"/>
+  <anchor x="-30.106" y="653.12" name="parent_top"/>
+  <anchor x="-30.106" y="653.12" name="top"/>
+  <anchor x="-131.675" y="1229.144" name="top0315"/>
+  <anchor x="-131.675" y="1229.144" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="810" y="185" type="curve" smooth="yes"/>
+      <point x="1065" y="190" type="line" smooth="yes"/>
+      <point x="1352" y="203"/>
+      <point x="1663" y="336"/>
+      <point x="1612" y="673" type="curve" smooth="yes"/>
+      <point x="1557" y="1032"/>
+      <point x="1216" y="1131"/>
+      <point x="899" y="1125" type="curve" smooth="yes"/>
+      <point x="645" y="1120" type="line" smooth="yes"/>
+      <point x="354" y="1107"/>
+      <point x="47" y="978"/>
+      <point x="98" y="637" type="curve" smooth="yes"/>
+      <point x="152" y="284"/>
+      <point x="497" y="176"/>
+    </contour>
+    <contour>
+      <point x="777" y="360" type="line" smooth="yes"/>
+      <point x="563" y="353"/>
+      <point x="296" y="402"/>
+      <point x="261" y="655" type="curve" smooth="yes"/>
+      <point x="227" y="895"/>
+      <point x="487" y="937"/>
+      <point x="672" y="945" type="curve" smooth="yes"/>
+      <point x="931" y="951" type="line" smooth="yes"/>
+      <point x="1149" y="958"/>
+      <point x="1414" y="914"/>
+      <point x="1450" y="655" type="curve" smooth="yes"/>
+      <point x="1482" y="419"/>
+      <point x="1214" y="375"/>
+      <point x="1035" y="367" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1530" y="721" type="line"/>
+      <point x="1777" y="1033" type="line"/>
+      <point x="1644" y="1145" type="line"/>
+      <point x="1395" y="827" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni213A_.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni213A" format="2">
-  <advance width="1771"/>
+  <advance width="1791"/>
   <unicode hex="213A"/>
-  <anchor x="1604.076" y="656.83" name="bottom"/>
-  <anchor x="1905.051" y="1236.15" name="bottom_dd"/>
-  <anchor x="-30.106" y="653.12" name="parent_top"/>
-  <anchor x="-30.106" y="653.12" name="top"/>
-  <anchor x="-131.675" y="1229.144" name="top0315"/>
-  <anchor x="-131.675" y="1229.144" name="top_dd"/>
+  <anchor x="1517" y="657" name="bottom"/>
+  <anchor x="1818" y="1236" name="bottom_dd"/>
+  <anchor x="-117" y="653" name="parent_top"/>
+  <anchor x="-117" y="653" name="top"/>
+  <anchor x="-219" y="1229" name="top0315"/>
+  <anchor x="-219" y="1229" name="top_dd"/>
   <outline>
     <contour>
-      <point x="810" y="185" type="curve" smooth="yes"/>
-      <point x="1065" y="190" type="line" smooth="yes"/>
-      <point x="1352" y="203"/>
-      <point x="1663" y="336"/>
-      <point x="1612" y="673" type="curve" smooth="yes"/>
-      <point x="1557" y="1032"/>
-      <point x="1216" y="1131"/>
-      <point x="899" y="1125" type="curve" smooth="yes"/>
-      <point x="645" y="1120" type="line" smooth="yes"/>
-      <point x="354" y="1107"/>
-      <point x="47" y="978"/>
-      <point x="98" y="637" type="curve" smooth="yes"/>
-      <point x="152" y="284"/>
-      <point x="497" y="176"/>
+      <point x="631" y="117" type="curve"/>
+      <point x="883" y="117" type="line"/>
+      <point x="1316" y="117"/>
+      <point x="1538" y="316"/>
+      <point x="1587" y="607" type="curve" smooth="yes"/>
+      <point x="1638" y="909"/>
+      <point x="1440" y="1096"/>
+      <point x="1047" y="1096" type="curve"/>
+      <point x="795" y="1096" type="line"/>
+      <point x="363" y="1096"/>
+      <point x="141" y="908"/>
+      <point x="91" y="606" type="curve" smooth="yes"/>
+      <point x="42" y="314"/>
+      <point x="239" y="117"/>
     </contour>
     <contour>
-      <point x="777" y="360" type="line" smooth="yes"/>
-      <point x="563" y="353"/>
-      <point x="296" y="402"/>
-      <point x="261" y="655" type="curve" smooth="yes"/>
-      <point x="227" y="895"/>
-      <point x="487" y="937"/>
-      <point x="672" y="945" type="curve" smooth="yes"/>
-      <point x="931" y="951" type="line" smooth="yes"/>
-      <point x="1149" y="958"/>
-      <point x="1414" y="914"/>
-      <point x="1450" y="655" type="curve" smooth="yes"/>
-      <point x="1482" y="419"/>
-      <point x="1214" y="375"/>
-      <point x="1035" y="367" type="curve" smooth="yes"/>
+      <point x="660" y="300" type="line" smooth="yes"/>
+      <point x="340" y="300"/>
+      <point x="223" y="418"/>
+      <point x="255" y="606" type="curve" smooth="yes"/>
+      <point x="288" y="805"/>
+      <point x="442" y="914"/>
+      <point x="762" y="914" type="curve"/>
+      <point x="1016" y="914" type="line"/>
+      <point x="1339" y="914"/>
+      <point x="1458" y="808"/>
+      <point x="1424" y="607" type="curve" smooth="yes"/>
+      <point x="1393" y="420"/>
+      <point x="1237" y="300"/>
+      <point x="914" y="300" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="1530" y="721" type="line"/>
-      <point x="1777" y="1033" type="line"/>
-      <point x="1644" y="1145" type="line"/>
-      <point x="1395" y="827" type="line"/>
+      <point x="1535" y="675" type="line"/>
+      <point x="1877" y="991" type="line"/>
+      <point x="1778" y="1116" type="line"/>
+      <point x="1431" y="793" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1174"/>
+  <unicode hex="2141"/>
+  <anchor x="514.886" y="-171" name="bottom"/>
+  <anchor x="-77.784" y="-171" name="bottom0315"/>
+  <anchor x="-72.082" y="-138" name="bottom_dd"/>
+  <anchor x="514.886" y="-171" name="parent_bottom"/>
+  <anchor x="746.214" y="1471" name="top"/>
+  <anchor x="274.692" y="1869" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="524" y="-14" type="curve" smooth="yes"/>
+      <point x="890" y="-23"/>
+      <point x="1044" y="275"/>
+      <point x="1091" y="597" type="curve" smooth="yes"/>
+      <point x="1133" y="870" type="line" smooth="yes"/>
+      <point x="1171" y="1164"/>
+      <point x="1075" y="1477"/>
+      <point x="733" y="1482" type="curve" smooth="yes"/>
+      <point x="558" y="1485"/>
+      <point x="388" y="1422"/>
+      <point x="281" y="1279" type="curve"/>
+      <point x="197" y="737" type="line"/>
+      <point x="633" y="737" type="line"/>
+      <point x="661" y="893" type="line"/>
+      <point x="401" y="893" type="line"/>
+      <point x="462" y="1229" type="line"/>
+      <point x="544" y="1291"/>
+      <point x="620" y="1326"/>
+      <point x="726" y="1324" type="curve" smooth="yes"/>
+      <point x="967" y="1321"/>
+      <point x="978" y="1053"/>
+      <point x="954" y="871" type="curve" smooth="yes"/>
+      <point x="912" y="595" type="line" smooth="yes"/>
+      <point x="880" y="377"/>
+      <point x="796" y="134"/>
+      <point x="534" y="144" type="curve" smooth="yes"/>
+      <point x="364" y="150"/>
+      <point x="319" y="282"/>
+      <point x="320" y="432" type="curve"/>
+      <point x="141" y="433" type="line"/>
+      <point x="136" y="181"/>
+      <point x="257" y="-7"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="945"/>
+  <unicode hex="2142"/>
+  <anchor x="613.289" y="-140" name="bottom"/>
+  <anchor x="-73.471" y="-140" name="bottom0315"/>
+  <anchor x="-74.162" y="-144" name="bottom_dd"/>
+  <anchor x="613.289" y="-140" name="parent_bottom"/>
+  <anchor x="602.141" y="1446" name="top"/>
+  <anchor x="272.612" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="544" y="0" type="line"/>
+      <point x="724" y="0" type="line"/>
+      <point x="976" y="1456" type="line"/>
+      <point x="797" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="215" y="1299" type="line"/>
+      <point x="802" y="1299" type="line"/>
+      <point x="830" y="1456" type="line"/>
+      <point x="243" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="893"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="493" y="0" type="line"/>
+      <point x="672" y="0" type="line"/>
+      <point x="925" y="1456" type="line"/>
+      <point x="745" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="-61" y="0" type="line"/>
+      <point x="526" y="0" type="line"/>
+      <point x="554" y="157" type="line"/>
+      <point x="-33" y="157" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1043"/>
+  <unicode hex="2144"/>
+  <anchor x="424.448" y="-144" name="bottom"/>
+  <anchor x="-74.132" y="-144" name="bottom0315"/>
+  <anchor x="-74.132" y="-144" name="bottom_dd"/>
+  <anchor x="424.448" y="-144" name="parent_bottom"/>
+  <anchor x="704.606" y="1455" name="top"/>
+  <anchor x="272.642" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="-43" y="0" type="line"/>
+      <point x="169" y="0" type="line"/>
+      <point x="585" y="729" type="line"/>
+      <point x="745" y="0" type="line"/>
+      <point x="940" y="0" type="line"/>
+      <point x="699" y="901" type="line"/>
+      <point x="796" y="1456" type="line"/>
+      <point x="616" y="1456" type="line"/>
+      <point x="524" y="923" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni214A_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214A" format="2">
-  <advance width="1116"/>
+  <advance width="1241"/>
   <unicode hex="214A"/>
   <outline>
     <contour>
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1116"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="95" y="300" type="line"/>
+      <point x="270" y="300" type="line"/>
+      <point x="444" y="1301" type="line"/>
+      <point x="783" y="1300" type="line" smooth="yes"/>
+      <point x="942" y="1293"/>
+      <point x="986" y="1150"/>
+      <point x="970" y="1011" type="curve" smooth="yes"/>
+      <point x="950" y="839"/>
+      <point x="842" y="718"/>
+      <point x="664" y="717" type="curve" smooth="yes"/>
+      <point x="605" y="717" type="line"/>
+      <point x="595" y="563" type="line"/>
+      <point x="656" y="563" type="line" smooth="yes"/>
+      <point x="931" y="563"/>
+      <point x="1119" y="738"/>
+      <point x="1145" y="1012" type="curve" smooth="yes"/>
+      <point x="1167" y="1254"/>
+      <point x="1046" y="1450"/>
+      <point x="790" y="1455" type="curve" smooth="yes"/>
+      <point x="297" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="530" y="0" type="line"/>
+      <point x="1077" y="0" type="line"/>
+      <point x="1104" y="154" type="line"/>
+      <point x="557" y="154" type="line"/>
+    </contour>
+    <contour>
+      <point x="408" y="0" type="line"/>
+      <point x="583" y="0" type="line"/>
+      <point x="862" y="1600" type="line"/>
+      <point x="688" y="1600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni214B_.glif
@@ -4,66 +4,66 @@
   <unicode hex="214B"/>
   <outline>
     <contour>
-      <point x="544" y="-18" type="curve" smooth="yes"/>
-      <point x="755" y="-23"/>
-      <point x="873" y="149"/>
-      <point x="887" y="344" type="curve" smooth="yes"/>
-      <point x="900" y="506"/>
-      <point x="806" y="646"/>
-      <point x="734" y="783" type="curve" smooth="yes"/>
-      <point x="391" y="1459" type="line"/>
-      <point x="197" y="1459" type="line"/>
-      <point x="623" y="633" type="line" smooth="yes"/>
-      <point x="671" y="543"/>
-      <point x="730" y="443"/>
-      <point x="718" y="337" type="curve" smooth="yes"/>
-      <point x="709" y="250"/>
-      <point x="660" y="132"/>
-      <point x="556" y="132" type="curve" smooth="yes"/>
-      <point x="474" y="133"/>
-      <point x="439" y="209"/>
-      <point x="445" y="281" type="curve" smooth="yes"/>
-      <point x="454" y="377"/>
-      <point x="507" y="439"/>
-      <point x="580" y="496" type="curve" smooth="yes"/>
-      <point x="778" y="651" type="line" smooth="yes"/>
-      <point x="925" y="761"/>
-      <point x="1077" y="876"/>
-      <point x="1093" y="1075" type="curve" smooth="yes"/>
-      <point x="1111" y="1295"/>
-      <point x="982" y="1474"/>
-      <point x="753" y="1479" type="curve" smooth="yes"/>
-      <point x="624" y="1482"/>
-      <point x="486" y="1421"/>
-      <point x="407" y="1319" type="curve" smooth="yes"/>
-      <point x="396" y="1306"/>
-      <point x="389" y="1290"/>
-      <point x="378" y="1277" type="curve" smooth="yes"/>
-      <point x="257" y="1126"/>
-      <point x="187" y="982"/>
-      <point x="165" y="787" type="curve"/>
-      <point x="317" y="787" type="line"/>
-      <point x="347" y="996"/>
-      <point x="481" y="1338"/>
-      <point x="744" y="1328" type="curve" smooth="yes"/>
-      <point x="885" y="1323"/>
-      <point x="932" y="1200"/>
-      <point x="916" y="1075" type="curve" smooth="yes"/>
-      <point x="903" y="975"/>
-      <point x="835" y="887"/>
-      <point x="760" y="823" type="curve" smooth="yes"/>
-      <point x="482" y="607" type="line" smooth="yes"/>
-      <point x="374" y="524"/>
-      <point x="291" y="424"/>
-      <point x="282" y="282" type="curve" smooth="yes"/>
-      <point x="272" y="121"/>
-      <point x="378" y="-14"/>
+      <point x="516" y="-18" type="curve" smooth="yes"/>
+      <point x="727" y="-23"/>
+      <point x="845" y="149"/>
+      <point x="859" y="344" type="curve" smooth="yes"/>
+      <point x="872" y="506"/>
+      <point x="778" y="646"/>
+      <point x="706" y="783" type="curve" smooth="yes"/>
+      <point x="363" y="1459" type="line"/>
+      <point x="169" y="1459" type="line"/>
+      <point x="595" y="633" type="line" smooth="yes"/>
+      <point x="643" y="543"/>
+      <point x="702" y="443"/>
+      <point x="690" y="337" type="curve" smooth="yes"/>
+      <point x="681" y="250"/>
+      <point x="632" y="132"/>
+      <point x="528" y="132" type="curve" smooth="yes"/>
+      <point x="446" y="133"/>
+      <point x="411" y="209"/>
+      <point x="417" y="281" type="curve" smooth="yes"/>
+      <point x="426" y="377"/>
+      <point x="479" y="439"/>
+      <point x="552" y="496" type="curve" smooth="yes"/>
+      <point x="750" y="651" type="line" smooth="yes"/>
+      <point x="897" y="761"/>
+      <point x="1049" y="876"/>
+      <point x="1065" y="1075" type="curve" smooth="yes"/>
+      <point x="1083" y="1295"/>
+      <point x="954" y="1474"/>
+      <point x="725" y="1479" type="curve" smooth="yes"/>
+      <point x="596" y="1482"/>
+      <point x="458" y="1421"/>
+      <point x="379" y="1319" type="curve" smooth="yes"/>
+      <point x="368" y="1306"/>
+      <point x="361" y="1290"/>
+      <point x="350" y="1277" type="curve" smooth="yes"/>
+      <point x="229" y="1126"/>
+      <point x="159" y="982"/>
+      <point x="137" y="787" type="curve"/>
+      <point x="289" y="787" type="line"/>
+      <point x="319" y="996"/>
+      <point x="453" y="1338"/>
+      <point x="716" y="1328" type="curve" smooth="yes"/>
+      <point x="857" y="1323"/>
+      <point x="904" y="1200"/>
+      <point x="888" y="1075" type="curve" smooth="yes"/>
+      <point x="875" y="975"/>
+      <point x="807" y="887"/>
+      <point x="732" y="823" type="curve" smooth="yes"/>
+      <point x="454" y="607" type="line" smooth="yes"/>
+      <point x="346" y="524"/>
+      <point x="263" y="424"/>
+      <point x="254" y="282" type="curve" smooth="yes"/>
+      <point x="244" y="121"/>
+      <point x="350" y="-14"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1081"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="544" y="-18" type="curve" smooth="yes"/>
+      <point x="755" y="-23"/>
+      <point x="873" y="149"/>
+      <point x="887" y="344" type="curve" smooth="yes"/>
+      <point x="900" y="506"/>
+      <point x="806" y="646"/>
+      <point x="734" y="783" type="curve" smooth="yes"/>
+      <point x="391" y="1459" type="line"/>
+      <point x="197" y="1459" type="line"/>
+      <point x="623" y="633" type="line" smooth="yes"/>
+      <point x="671" y="543"/>
+      <point x="730" y="443"/>
+      <point x="718" y="337" type="curve" smooth="yes"/>
+      <point x="709" y="250"/>
+      <point x="660" y="132"/>
+      <point x="556" y="132" type="curve" smooth="yes"/>
+      <point x="474" y="133"/>
+      <point x="439" y="209"/>
+      <point x="445" y="281" type="curve" smooth="yes"/>
+      <point x="454" y="377"/>
+      <point x="507" y="439"/>
+      <point x="580" y="496" type="curve" smooth="yes"/>
+      <point x="778" y="651" type="line" smooth="yes"/>
+      <point x="925" y="761"/>
+      <point x="1077" y="876"/>
+      <point x="1093" y="1075" type="curve" smooth="yes"/>
+      <point x="1111" y="1295"/>
+      <point x="982" y="1474"/>
+      <point x="753" y="1479" type="curve" smooth="yes"/>
+      <point x="624" y="1482"/>
+      <point x="486" y="1421"/>
+      <point x="407" y="1319" type="curve" smooth="yes"/>
+      <point x="396" y="1306"/>
+      <point x="389" y="1290"/>
+      <point x="378" y="1277" type="curve" smooth="yes"/>
+      <point x="257" y="1126"/>
+      <point x="187" y="982"/>
+      <point x="165" y="787" type="curve"/>
+      <point x="317" y="787" type="line"/>
+      <point x="347" y="996"/>
+      <point x="481" y="1338"/>
+      <point x="744" y="1328" type="curve" smooth="yes"/>
+      <point x="885" y="1323"/>
+      <point x="932" y="1200"/>
+      <point x="916" y="1075" type="curve" smooth="yes"/>
+      <point x="903" y="975"/>
+      <point x="835" y="887"/>
+      <point x="760" y="823" type="curve" smooth="yes"/>
+      <point x="482" y="607" type="line" smooth="yes"/>
+      <point x="374" y="524"/>
+      <point x="291" y="424"/>
+      <point x="282" y="282" type="curve" smooth="yes"/>
+      <point x="272" y="121"/>
+      <point x="378" y="-14"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="619"/>
+  <advance width="1266"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="235" y="-10" type="curve" smooth="yes"/>
-      <point x="317" y="-10"/>
-      <point x="344" y="51"/>
-      <point x="344" y="117" type="curve" smooth="yes"/>
-      <point x="344" y="140"/>
-      <point x="336" y="204"/>
-      <point x="328" y="277" type="curve"/>
-      <point x="404" y="291"/>
-      <point x="470" y="326"/>
-      <point x="512" y="375" type="curve"/>
-      <point x="521" y="361"/>
-      <point x="526" y="345"/>
-      <point x="526" y="327" type="curve" smooth="yes"/>
-      <point x="526" y="281"/>
-      <point x="479" y="238"/>
-      <point x="461" y="224" type="curve"/>
-      <point x="495" y="224" type="line"/>
-      <point x="514" y="238"/>
-      <point x="556" y="281"/>
-      <point x="556" y="326" type="curve" smooth="yes"/>
-      <point x="556" y="354"/>
-      <point x="546" y="378"/>
-      <point x="529" y="397" type="curve"/>
-      <point x="550" y="427"/>
-      <point x="562" y="462"/>
-      <point x="562" y="500" type="curve" smooth="yes"/>
-      <point x="562" y="608"/>
-      <point x="491" y="725"/>
-      <point x="382" y="725" type="curve" smooth="yes"/>
-      <point x="299" y="725"/>
-      <point x="272" y="664"/>
-      <point x="272" y="569" type="curve" smooth="yes"/>
-      <point x="272" y="548"/>
-      <point x="273" y="515"/>
-      <point x="274" y="477" type="curve"/>
-      <point x="262" y="478"/>
-      <point x="251" y="478"/>
-      <point x="241" y="478" type="curve" smooth="yes"/>
-      <point x="230" y="478"/>
-      <point x="211" y="477"/>
-      <point x="190" y="475" type="curve"/>
-      <point x="192" y="613" type="line"/>
-      <point x="207" y="635"/>
-      <point x="221" y="658"/>
-      <point x="221" y="675" type="curve" smooth="yes"/>
-      <point x="221" y="681"/>
-      <point x="220" y="708"/>
-      <point x="193" y="708" type="curve" smooth="yes"/>
-      <point x="158" y="708"/>
-      <point x="170" y="669"/>
-      <point x="154" y="669" type="curve" smooth="yes"/>
-      <point x="134" y="669"/>
-      <point x="123" y="715"/>
-      <point x="75" y="715" type="curve" smooth="yes"/>
-      <point x="52" y="715"/>
-      <point x="11" y="702"/>
-      <point x="11" y="643" type="curve" smooth="yes"/>
-      <point x="11" y="603"/>
-      <point x="38" y="572"/>
-      <point x="82" y="572" type="curve" smooth="yes"/>
-      <point x="89" y="572"/>
-      <point x="96" y="573"/>
-      <point x="101" y="574" type="curve"/>
-      <point x="100" y="592" type="line"/>
-      <point x="96" y="591"/>
-      <point x="88" y="590"/>
-      <point x="82" y="590" type="curve" smooth="yes"/>
-      <point x="64" y="590"/>
-      <point x="58" y="606"/>
-      <point x="58" y="617" type="curve" smooth="yes"/>
-      <point x="58" y="630"/>
-      <point x="67" y="644"/>
-      <point x="86" y="644" type="curve" smooth="yes"/>
-      <point x="108" y="644"/>
-      <point x="155" y="625"/>
-      <point x="172" y="615" type="curve"/>
-      <point x="156" y="471" type="line"/>
-      <point x="94" y="460"/>
-      <point x="24" y="433"/>
-      <point x="24" y="369" type="curve" smooth="yes"/>
-      <point x="24" y="315"/>
-      <point x="77" y="290"/>
-      <point x="137" y="279" type="curve"/>
-      <point x="130" y="208"/>
-      <point x="126" y="144"/>
-      <point x="126" y="117" type="curve" smooth="yes"/>
-      <point x="126" y="51"/>
-      <point x="153" y="-10"/>
+      <point x="596" y="-20" type="curve" smooth="yes"/>
+      <point x="764" y="-20"/>
+      <point x="819" y="104"/>
+      <point x="819" y="240" type="curve" smooth="yes"/>
+      <point x="819" y="287"/>
+      <point x="803" y="418"/>
+      <point x="786" y="567" type="curve"/>
+      <point x="942" y="596"/>
+      <point x="1077" y="668"/>
+      <point x="1163" y="768" type="curve"/>
+      <point x="1181" y="739"/>
+      <point x="1192" y="707"/>
+      <point x="1192" y="670" type="curve" smooth="yes"/>
+      <point x="1192" y="575"/>
+      <point x="1095" y="487"/>
+      <point x="1059" y="459" type="curve"/>
+      <point x="1128" y="459" type="line"/>
+      <point x="1167" y="487"/>
+      <point x="1253" y="575"/>
+      <point x="1253" y="668" type="curve" smooth="yes"/>
+      <point x="1253" y="725"/>
+      <point x="1233" y="774"/>
+      <point x="1198" y="813" type="curve"/>
+      <point x="1241" y="874"/>
+      <point x="1265" y="946"/>
+      <point x="1265" y="1024" type="curve" smooth="yes"/>
+      <point x="1265" y="1245"/>
+      <point x="1120" y="1485"/>
+      <point x="897" y="1485" type="curve" smooth="yes"/>
+      <point x="727" y="1485"/>
+      <point x="671" y="1360"/>
+      <point x="671" y="1165" type="curve" smooth="yes"/>
+      <point x="671" y="1122"/>
+      <point x="674" y="1055"/>
+      <point x="676" y="977" type="curve"/>
+      <point x="651" y="979"/>
+      <point x="628" y="979"/>
+      <point x="608" y="979" type="curve" smooth="yes"/>
+      <point x="585" y="979"/>
+      <point x="547" y="977"/>
+      <point x="504" y="973" type="curve"/>
+      <point x="508" y="1255" type="line"/>
+      <point x="538" y="1300"/>
+      <point x="567" y="1348"/>
+      <point x="567" y="1382" type="curve" smooth="yes"/>
+      <point x="567" y="1395"/>
+      <point x="565" y="1450"/>
+      <point x="510" y="1450" type="curve" smooth="yes"/>
+      <point x="438" y="1450"/>
+      <point x="463" y="1370"/>
+      <point x="430" y="1370" type="curve" smooth="yes"/>
+      <point x="389" y="1370"/>
+      <point x="366" y="1464"/>
+      <point x="268" y="1464" type="curve" smooth="yes"/>
+      <point x="221" y="1464"/>
+      <point x="137" y="1438"/>
+      <point x="137" y="1317" type="curve" smooth="yes"/>
+      <point x="137" y="1235"/>
+      <point x="192" y="1171"/>
+      <point x="282" y="1171" type="curve" smooth="yes"/>
+      <point x="297" y="1171"/>
+      <point x="311" y="1174"/>
+      <point x="321" y="1176" type="curve"/>
+      <point x="319" y="1212" type="line"/>
+      <point x="311" y="1210"/>
+      <point x="295" y="1208"/>
+      <point x="282" y="1208" type="curve" smooth="yes"/>
+      <point x="246" y="1208"/>
+      <point x="233" y="1241"/>
+      <point x="233" y="1264" type="curve" smooth="yes"/>
+      <point x="233" y="1290"/>
+      <point x="252" y="1319"/>
+      <point x="291" y="1319" type="curve" smooth="yes"/>
+      <point x="336" y="1319"/>
+      <point x="432" y="1280"/>
+      <point x="467" y="1260" type="curve"/>
+      <point x="434" y="965" type="line"/>
+      <point x="307" y="942"/>
+      <point x="164" y="887"/>
+      <point x="164" y="756" type="curve" smooth="yes"/>
+      <point x="164" y="645"/>
+      <point x="272" y="594"/>
+      <point x="395" y="571" type="curve"/>
+      <point x="381" y="426"/>
+      <point x="372" y="295"/>
+      <point x="372" y="240" type="curve" smooth="yes"/>
+      <point x="372" y="104"/>
+      <point x="428" y="-20"/>
     </contour>
     <contour>
-      <point x="235" y="20" type="curve" smooth="yes"/>
-      <point x="198" y="20"/>
-      <point x="178" y="58"/>
-      <point x="178" y="115" type="curve" smooth="yes"/>
-      <point x="178" y="146"/>
-      <point x="180" y="206"/>
-      <point x="182" y="273" type="curve"/>
-      <point x="207" y="270"/>
-      <point x="231" y="270"/>
-      <point x="252" y="270" type="curve" smooth="yes"/>
-      <point x="262" y="270"/>
-      <point x="273" y="270"/>
-      <point x="284" y="271" type="curve"/>
-      <point x="287" y="195"/>
-      <point x="291" y="132"/>
-      <point x="291" y="115" type="curve" smooth="yes"/>
-      <point x="291" y="58"/>
-      <point x="271" y="20"/>
+      <point x="596" y="41" type="curve" smooth="yes"/>
+      <point x="520" y="41"/>
+      <point x="479" y="119"/>
+      <point x="479" y="236" type="curve" smooth="yes"/>
+      <point x="479" y="299"/>
+      <point x="483" y="422"/>
+      <point x="487" y="559" type="curve"/>
+      <point x="538" y="553"/>
+      <point x="588" y="553"/>
+      <point x="631" y="553" type="curve" smooth="yes"/>
+      <point x="651" y="553"/>
+      <point x="674" y="553"/>
+      <point x="696" y="555" type="curve"/>
+      <point x="702" y="399"/>
+      <point x="710" y="270"/>
+      <point x="710" y="236" type="curve" smooth="yes"/>
+      <point x="710" y="119"/>
+      <point x="669" y="41"/>
     </contour>
     <contour>
-      <point x="139" y="299" type="line"/>
-      <point x="59" y="318"/>
-      <point x="49" y="358"/>
-      <point x="49" y="372" type="curve" smooth="yes"/>
-      <point x="49" y="384"/>
-      <point x="55" y="434"/>
-      <point x="154" y="453" type="curve"/>
+      <point x="399" y="612" type="line"/>
+      <point x="235" y="651"/>
+      <point x="215" y="733"/>
+      <point x="215" y="762" type="curve" smooth="yes"/>
+      <point x="215" y="786"/>
+      <point x="227" y="889"/>
+      <point x="430" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="251" y="288" type="curve" smooth="yes"/>
-      <point x="224" y="288"/>
-      <point x="203" y="289"/>
-      <point x="183" y="291" type="curve"/>
-      <point x="189" y="458" type="line"/>
-      <point x="204" y="459"/>
-      <point x="221" y="460"/>
-      <point x="240" y="460" type="curve" smooth="yes"/>
-      <point x="252" y="460"/>
-      <point x="263" y="459"/>
-      <point x="275" y="459" type="curve"/>
-      <point x="283" y="289" type="line"/>
-      <point x="272" y="288"/>
-      <point x="262" y="288"/>
+      <point x="628" y="590" type="curve" smooth="yes"/>
+      <point x="573" y="590"/>
+      <point x="530" y="592"/>
+      <point x="489" y="596" type="curve"/>
+      <point x="502" y="938" type="line"/>
+      <point x="532" y="940"/>
+      <point x="567" y="942"/>
+      <point x="606" y="942" type="curve" smooth="yes"/>
+      <point x="631" y="942"/>
+      <point x="653" y="940"/>
+      <point x="678" y="940" type="curve"/>
+      <point x="694" y="592" type="line"/>
+      <point x="671" y="590"/>
+      <point x="651" y="590"/>
     </contour>
     <contour>
-      <point x="326" y="295" type="curve"/>
-      <point x="307" y="457" type="line"/>
-      <point x="367" y="452"/>
-      <point x="427" y="439"/>
-      <point x="469" y="414" type="curve"/>
-      <point x="446" y="351"/>
-      <point x="398" y="311"/>
+      <point x="782" y="604" type="curve"/>
+      <point x="743" y="936" type="line"/>
+      <point x="866" y="926"/>
+      <point x="989" y="899"/>
+      <point x="1075" y="848" type="curve"/>
+      <point x="1028" y="719"/>
+      <point x="930" y="637"/>
     </contour>
     <contour>
-      <point x="474" y="436" type="curve"/>
-      <point x="425" y="460"/>
-      <point x="360" y="471"/>
-      <point x="305" y="475" type="curve"/>
-      <point x="301" y="514"/>
-      <point x="299" y="548"/>
-      <point x="299" y="572" type="curve" smooth="yes"/>
-      <point x="299" y="636"/>
-      <point x="305" y="707"/>
-      <point x="379" y="707" type="curve" smooth="yes"/>
-      <point x="470" y="707"/>
-      <point x="486" y="593"/>
-      <point x="486" y="519" type="curve" smooth="yes"/>
-      <point x="486" y="488"/>
-      <point x="481" y="461"/>
+      <point x="1087" y="893" type="curve"/>
+      <point x="987" y="942"/>
+      <point x="852" y="965"/>
+      <point x="739" y="973" type="curve"/>
+      <point x="731" y="1053"/>
+      <point x="727" y="1122"/>
+      <point x="727" y="1171" type="curve" smooth="yes"/>
+      <point x="727" y="1303"/>
+      <point x="739" y="1448"/>
+      <point x="891" y="1448" type="curve" smooth="yes"/>
+      <point x="1077" y="1448"/>
+      <point x="1110" y="1214"/>
+      <point x="1110" y="1063" type="curve" smooth="yes"/>
+      <point x="1110" y="999"/>
+      <point x="1102" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="619"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="235" y="-10" type="curve" smooth="yes"/>
+      <point x="317" y="-10"/>
+      <point x="344" y="51"/>
+      <point x="344" y="117" type="curve" smooth="yes"/>
+      <point x="344" y="140"/>
+      <point x="336" y="204"/>
+      <point x="328" y="277" type="curve"/>
+      <point x="404" y="291"/>
+      <point x="470" y="326"/>
+      <point x="512" y="375" type="curve"/>
+      <point x="521" y="361"/>
+      <point x="526" y="345"/>
+      <point x="526" y="327" type="curve" smooth="yes"/>
+      <point x="526" y="281"/>
+      <point x="479" y="238"/>
+      <point x="461" y="224" type="curve"/>
+      <point x="495" y="224" type="line"/>
+      <point x="514" y="238"/>
+      <point x="556" y="281"/>
+      <point x="556" y="326" type="curve" smooth="yes"/>
+      <point x="556" y="354"/>
+      <point x="546" y="378"/>
+      <point x="529" y="397" type="curve"/>
+      <point x="550" y="427"/>
+      <point x="562" y="462"/>
+      <point x="562" y="500" type="curve" smooth="yes"/>
+      <point x="562" y="608"/>
+      <point x="491" y="725"/>
+      <point x="382" y="725" type="curve" smooth="yes"/>
+      <point x="299" y="725"/>
+      <point x="272" y="664"/>
+      <point x="272" y="569" type="curve" smooth="yes"/>
+      <point x="272" y="548"/>
+      <point x="273" y="515"/>
+      <point x="274" y="477" type="curve"/>
+      <point x="262" y="478"/>
+      <point x="251" y="478"/>
+      <point x="241" y="478" type="curve" smooth="yes"/>
+      <point x="230" y="478"/>
+      <point x="211" y="477"/>
+      <point x="190" y="475" type="curve"/>
+      <point x="192" y="613" type="line"/>
+      <point x="207" y="635"/>
+      <point x="221" y="658"/>
+      <point x="221" y="675" type="curve" smooth="yes"/>
+      <point x="221" y="681"/>
+      <point x="220" y="708"/>
+      <point x="193" y="708" type="curve" smooth="yes"/>
+      <point x="158" y="708"/>
+      <point x="170" y="669"/>
+      <point x="154" y="669" type="curve" smooth="yes"/>
+      <point x="134" y="669"/>
+      <point x="123" y="715"/>
+      <point x="75" y="715" type="curve" smooth="yes"/>
+      <point x="52" y="715"/>
+      <point x="11" y="702"/>
+      <point x="11" y="643" type="curve" smooth="yes"/>
+      <point x="11" y="603"/>
+      <point x="38" y="572"/>
+      <point x="82" y="572" type="curve" smooth="yes"/>
+      <point x="89" y="572"/>
+      <point x="96" y="573"/>
+      <point x="101" y="574" type="curve"/>
+      <point x="100" y="592" type="line"/>
+      <point x="96" y="591"/>
+      <point x="88" y="590"/>
+      <point x="82" y="590" type="curve" smooth="yes"/>
+      <point x="64" y="590"/>
+      <point x="58" y="606"/>
+      <point x="58" y="617" type="curve" smooth="yes"/>
+      <point x="58" y="630"/>
+      <point x="67" y="644"/>
+      <point x="86" y="644" type="curve" smooth="yes"/>
+      <point x="108" y="644"/>
+      <point x="155" y="625"/>
+      <point x="172" y="615" type="curve"/>
+      <point x="156" y="471" type="line"/>
+      <point x="94" y="460"/>
+      <point x="24" y="433"/>
+      <point x="24" y="369" type="curve" smooth="yes"/>
+      <point x="24" y="315"/>
+      <point x="77" y="290"/>
+      <point x="137" y="279" type="curve"/>
+      <point x="130" y="208"/>
+      <point x="126" y="144"/>
+      <point x="126" y="117" type="curve" smooth="yes"/>
+      <point x="126" y="51"/>
+      <point x="153" y="-10"/>
+    </contour>
+    <contour>
+      <point x="235" y="20" type="curve" smooth="yes"/>
+      <point x="198" y="20"/>
+      <point x="178" y="58"/>
+      <point x="178" y="115" type="curve" smooth="yes"/>
+      <point x="178" y="146"/>
+      <point x="180" y="206"/>
+      <point x="182" y="273" type="curve"/>
+      <point x="207" y="270"/>
+      <point x="231" y="270"/>
+      <point x="252" y="270" type="curve" smooth="yes"/>
+      <point x="262" y="270"/>
+      <point x="273" y="270"/>
+      <point x="284" y="271" type="curve"/>
+      <point x="287" y="195"/>
+      <point x="291" y="132"/>
+      <point x="291" y="115" type="curve" smooth="yes"/>
+      <point x="291" y="58"/>
+      <point x="271" y="20"/>
+    </contour>
+    <contour>
+      <point x="139" y="299" type="line"/>
+      <point x="59" y="318"/>
+      <point x="49" y="358"/>
+      <point x="49" y="372" type="curve" smooth="yes"/>
+      <point x="49" y="384"/>
+      <point x="55" y="434"/>
+      <point x="154" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="251" y="288" type="curve" smooth="yes"/>
+      <point x="224" y="288"/>
+      <point x="203" y="289"/>
+      <point x="183" y="291" type="curve"/>
+      <point x="189" y="458" type="line"/>
+      <point x="204" y="459"/>
+      <point x="221" y="460"/>
+      <point x="240" y="460" type="curve" smooth="yes"/>
+      <point x="252" y="460"/>
+      <point x="263" y="459"/>
+      <point x="275" y="459" type="curve"/>
+      <point x="283" y="289" type="line"/>
+      <point x="272" y="288"/>
+      <point x="262" y="288"/>
+    </contour>
+    <contour>
+      <point x="326" y="295" type="curve"/>
+      <point x="307" y="457" type="line"/>
+      <point x="367" y="452"/>
+      <point x="427" y="439"/>
+      <point x="469" y="414" type="curve"/>
+      <point x="446" y="351"/>
+      <point x="398" y="311"/>
+    </contour>
+    <contour>
+      <point x="474" y="436" type="curve"/>
+      <point x="425" y="460"/>
+      <point x="360" y="471"/>
+      <point x="305" y="475" type="curve"/>
+      <point x="301" y="514"/>
+      <point x="299" y="548"/>
+      <point x="299" y="572" type="curve" smooth="yes"/>
+      <point x="299" y="636"/>
+      <point x="305" y="707"/>
+      <point x="379" y="707" type="curve" smooth="yes"/>
+      <point x="470" y="707"/>
+      <point x="486" y="593"/>
+      <point x="486" y="519" type="curve" smooth="yes"/>
+      <point x="486" y="488"/>
+      <point x="481" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:07 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Italic.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-Italic.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="861"/>
+  <unicode hex="214E"/>
+  <anchor x="316" y="10" name="bottom"/>
+  <anchor x="629" y="-407" name="bottom_dd"/>
+  <anchor x="579" y="1320" name="parent_top"/>
+  <anchor x="579" y="1320" name="top"/>
+  <anchor x="927" y="1320" name="top0315"/>
+  <anchor x="976" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="467" y="0" type="line"/>
+      <point x="640" y="0" type="line"/>
+      <point x="828" y="1082" type="line"/>
+      <point x="655" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="-3" y="0" type="line"/>
+      <point x="505" y="0" type="line"/>
+      <point x="532" y="153" type="line"/>
+      <point x="25" y="153" type="line"/>
+    </contour>
+    <contour>
+      <point x="150" y="513" type="line"/>
+      <point x="594" y="513" type="line"/>
+      <point x="621" y="665" type="line"/>
+      <point x="177" y="665" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:07 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Italic.ufo/lib.plist
+++ b/sources/RobotoCondensed-Italic.ufo/lib.plist
@@ -6898,6 +6898,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-Light.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Light.ufo/fontinfo.plist
@@ -377,7 +377,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/contents.plist
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="931"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="173" y="0" type="line"/>
+      <point x="475" y="0" type="line" smooth="yes"/>
+      <point x="680" y="0"/>
+      <point x="816" y="147"/>
+      <point x="816" y="397" type="curve" smooth="yes"/>
+      <point x="816" y="604"/>
+      <point x="736" y="731"/>
+      <point x="555" y="772" type="curve"/>
+      <point x="555" y="772" type="line"/>
+      <point x="684" y="799"/>
+      <point x="785" y="938"/>
+      <point x="785" y="1126" type="curve" smooth="yes"/>
+      <point x="785" y="1353"/>
+      <point x="654" y="1456"/>
+      <point x="461" y="1456" type="curve" smooth="yes"/>
+      <point x="173" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="335" y="-201" type="line"/>
+      <point x="420" y="-201" type="line"/>
+      <point x="420" y="27" type="line"/>
+      <point x="335" y="27" type="line"/>
+    </contour>
+    <contour>
+      <point x="509" y="-201" type="line"/>
+      <point x="594" y="-201" type="line"/>
+      <point x="594" y="27" type="line"/>
+      <point x="509" y="27" type="line"/>
+    </contour>
+    <contour>
+      <point x="283" y="101" type="line"/>
+      <point x="283" y="713" type="line"/>
+      <point x="455" y="713" type="line" smooth="yes"/>
+      <point x="586" y="713"/>
+      <point x="701" y="648"/>
+      <point x="701" y="399" type="curve" smooth="yes"/>
+      <point x="701" y="186"/>
+      <point x="615" y="101"/>
+      <point x="463" y="101" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="283" y="818" type="line"/>
+      <point x="283" y="1355" type="line"/>
+      <point x="434" y="1355" type="line" smooth="yes"/>
+      <point x="579" y="1355"/>
+      <point x="673" y="1311"/>
+      <point x="673" y="1126" type="curve" smooth="yes"/>
+      <point x="673" y="945"/>
+      <point x="596" y="818"/>
+      <point x="449" y="818" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="335" y="1415" type="line"/>
+      <point x="420" y="1415" type="line"/>
+      <point x="420" y="1663" type="line"/>
+      <point x="335" y="1663" type="line"/>
+    </contour>
+    <contour>
+      <point x="509" y="1415" type="line"/>
+      <point x="594" y="1415" type="line"/>
+      <point x="594" y="1663" type="line"/>
+      <point x="509" y="1663" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2104.glif
@@ -4,50 +4,50 @@
   <unicode hex="2104"/>
   <outline>
     <contour>
-      <point x="362" y="0" type="line"/>
+      <point x="382" y="0" type="line"/>
       <point x="890" y="0" type="line"/>
-      <point x="890" y="139" type="line"/>
-      <point x="503" y="139" type="line"/>
-      <point x="503" y="395" type="line"/>
-      <point x="546" y="403"/>
-      <point x="583" y="418"/>
-      <point x="614" y="440" type="curve"/>
-      <point x="614" y="551" type="line"/>
-      <point x="579" y="528"/>
-      <point x="542" y="512"/>
-      <point x="503" y="502" type="curve"/>
-      <point x="503" y="1106" type="line"/>
-      <point x="532" y="1100"/>
-      <point x="565" y="1087"/>
-      <point x="595" y="1071" type="curve"/>
-      <point x="628" y="1174" type="line"/>
-      <point x="591" y="1194"/>
-      <point x="548" y="1208"/>
-      <point x="503" y="1214" type="curve"/>
-      <point x="503" y="1462" type="line"/>
-      <point x="362" y="1462" type="line"/>
-      <point x="362" y="1208" type="line"/>
-      <point x="219" y="1171"/>
-      <point x="133" y="1030"/>
-      <point x="133" y="801" type="curve" smooth="yes"/>
-      <point x="133" y="569"/>
-      <point x="215" y="428"/>
-      <point x="362" y="397" type="curve"/>
+      <point x="879" y="106" type="line"/>
+      <point x="492" y="106" type="line"/>
+      <point x="492" y="395" type="line"/>
+      <point x="535" y="403"/>
+      <point x="572" y="418"/>
+      <point x="603" y="440" type="curve"/>
+      <point x="603" y="531" type="line"/>
+      <point x="568" y="508"/>
+      <point x="531" y="492"/>
+      <point x="492" y="482" type="curve"/>
+      <point x="492" y="1126" type="line"/>
+      <point x="521" y="1120"/>
+      <point x="554" y="1107"/>
+      <point x="584" y="1091" type="curve"/>
+      <point x="617" y="1174" type="line"/>
+      <point x="580" y="1194"/>
+      <point x="537" y="1208"/>
+      <point x="492" y="1214" type="curve"/>
+      <point x="492" y="1462" type="line"/>
+      <point x="382" y="1462" type="line"/>
+      <point x="382" y="1208" type="line"/>
+      <point x="239" y="1171"/>
+      <point x="164" y="1038"/>
+      <point x="164" y="809" type="curve" smooth="yes"/>
+      <point x="164" y="577"/>
+      <point x="235" y="428"/>
+      <point x="382" y="397" type="curve"/>
     </contour>
     <contour>
-      <point x="362" y="512" type="line"/>
-      <point x="292" y="549"/>
-      <point x="256" y="651"/>
+      <point x="382" y="492" type="line"/>
+      <point x="312" y="529"/>
+      <point x="256" y="621"/>
       <point x="256" y="801" type="curve" smooth="yes"/>
-      <point x="256" y="961"/>
-      <point x="292" y="1059"/>
-      <point x="362" y="1096" type="curve"/>
+      <point x="256" y="991"/>
+      <point x="312" y="1079"/>
+      <point x="382" y="1116" type="curve"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="954"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="362" y="0" type="line"/>
+      <point x="890" y="0" type="line"/>
+      <point x="890" y="139" type="line"/>
+      <point x="503" y="139" type="line"/>
+      <point x="503" y="395" type="line"/>
+      <point x="546" y="403"/>
+      <point x="583" y="418"/>
+      <point x="614" y="440" type="curve"/>
+      <point x="614" y="551" type="line"/>
+      <point x="579" y="528"/>
+      <point x="542" y="512"/>
+      <point x="503" y="502" type="curve"/>
+      <point x="503" y="1106" type="line"/>
+      <point x="532" y="1100"/>
+      <point x="565" y="1087"/>
+      <point x="595" y="1071" type="curve"/>
+      <point x="628" y="1174" type="line"/>
+      <point x="591" y="1194"/>
+      <point x="548" y="1208"/>
+      <point x="503" y="1214" type="curve"/>
+      <point x="503" y="1462" type="line"/>
+      <point x="362" y="1462" type="line"/>
+      <point x="362" y="1208" type="line"/>
+      <point x="219" y="1171"/>
+      <point x="133" y="1030"/>
+      <point x="133" y="801" type="curve" smooth="yes"/>
+      <point x="133" y="569"/>
+      <point x="215" y="428"/>
+      <point x="362" y="397" type="curve"/>
+    </contour>
+    <contour>
+      <point x="362" y="512" type="line"/>
+      <point x="292" y="549"/>
+      <point x="256" y="651"/>
+      <point x="256" y="801" type="curve" smooth="yes"/>
+      <point x="256" y="961"/>
+      <point x="292" y="1059"/>
+      <point x="362" y="1096" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="965"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1181"/>
+  <unicode hex="2108"/>
+  <anchor x="601" y="1634" name="parent_top"/>
+  <anchor x="601" y="1634" name="top"/>
+  <anchor x="1161" y="1634" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="592" y="-20" type="curve" smooth="yes"/>
+      <point x="872" y="-20"/>
+      <point x="1056" y="243"/>
+      <point x="1056" y="637" type="curve" smooth="yes"/>
+      <point x="1056" y="818" type="line" smooth="yes"/>
+      <point x="1056" y="1212"/>
+      <point x="873" y="1476"/>
+      <point x="584" y="1476" type="curve" smooth="yes"/>
+      <point x="320" y="1476"/>
+      <point x="165" y="1299"/>
+      <point x="140" y="1000" type="curve"/>
+      <point x="254" y="1000" type="line"/>
+      <point x="279" y="1234"/>
+      <point x="378" y="1369"/>
+      <point x="584" y="1369" type="curve" smooth="yes"/>
+      <point x="809" y="1369"/>
+      <point x="941" y="1150"/>
+      <point x="941" y="820" type="curve" smooth="yes"/>
+      <point x="941" y="637" type="line" smooth="yes"/>
+      <point x="941" y="319"/>
+      <point x="818" y="87"/>
+      <point x="592" y="87" type="curve" smooth="yes"/>
+      <point x="378" y="87"/>
+      <point x="280" y="210"/>
+      <point x="254" y="454" type="curve"/>
+      <point x="140" y="454" type="line"/>
+      <point x="165" y="160"/>
+      <point x="318" y="-20"/>
+    </contour>
+    <contour>
+      <point x="436" y="678" type="line"/>
+      <point x="955" y="678" type="line"/>
+      <point x="955" y="785" type="line"/>
+      <point x="436" y="785" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2108.glif
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1505"/>
+  <unicode hex="2114"/>
+  <anchor x="1027" y="-10" name="bottom"/>
+  <anchor x="1485" y="-407" name="bottom_dd"/>
+  <anchor x="499" y="1522" name="marktop"/>
+  <anchor x="1042" y="1612" name="parent_top"/>
+  <anchor x="1042" y="1612" name="top"/>
+  <anchor x="1485" y="1612" name="top0315"/>
+  <anchor x="1485" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1049" y="-21" type="curve" smooth="yes"/>
+      <point x="1270" y="-21"/>
+      <point x="1397" y="141"/>
+      <point x="1397" y="490" type="curve" smooth="yes"/>
+      <point x="1397" y="591" type="line"/>
+      <point x="1397" y="953"/>
+      <point x="1270" y="1102"/>
+      <point x="1047" y="1102" type="curve" smooth="yes"/>
+      <point x="837" y="1102"/>
+      <point x="731" y="939"/>
+      <point x="700" y="694" type="curve"/>
+      <point x="700" y="370" type="line"/>
+      <point x="726" y="142"/>
+      <point x="834" y="-21"/>
+    </contour>
+    <contour>
+      <point x="197" y="0" type="line"/>
+      <point x="308" y="0" type="line"/>
+      <point x="308" y="1536" type="line"/>
+      <point x="197" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="657" y="0" type="line"/>
+      <point x="760" y="0" type="line"/>
+      <point x="768" y="210" type="line"/>
+      <point x="768" y="1536" type="line"/>
+      <point x="657" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="1026" y="86" type="curve" smooth="yes"/>
+      <point x="857" y="86"/>
+      <point x="771" y="209"/>
+      <point x="743" y="344" type="curve"/>
+      <point x="743" y="714" type="line"/>
+      <point x="768" y="842"/>
+      <point x="839" y="996"/>
+      <point x="1024" y="996" type="curve" smooth="yes"/>
+      <point x="1210" y="996"/>
+      <point x="1285" y="866"/>
+      <point x="1285" y="591" type="curve" smooth="yes"/>
+      <point x="1285" y="490" type="line"/>
+      <point x="1285" y="213"/>
+      <point x="1206" y="86"/>
+    </contour>
+    <contour>
+      <point x="45" y="1256" type="line"/>
+      <point x="990" y="1256" type="line"/>
+      <point x="990" y="1360" type="line"/>
+      <point x="45" y="1360" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="811"/>
+  <advance width="1610"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="212" y="-241" type="curve" smooth="yes"/>
-      <point x="282" y="-241"/>
-      <point x="329" y="-180"/>
-      <point x="329" y="-95" type="curve" smooth="yes"/>
-      <point x="329" y="8"/>
-      <point x="237" y="99"/>
-      <point x="180" y="200" type="curve"/>
-      <point x="227" y="272"/>
-      <point x="287" y="341"/>
-      <point x="349" y="394" type="curve" smooth="yes"/>
-      <point x="417" y="452"/>
-      <point x="488" y="492"/>
-      <point x="547" y="492" type="curve" smooth="yes"/>
-      <point x="649" y="492"/>
-      <point x="657" y="359"/>
-      <point x="657" y="322" type="curve" smooth="yes"/>
-      <point x="657" y="285"/>
-      <point x="644" y="30"/>
-      <point x="480" y="30" type="curve" smooth="yes"/>
-      <point x="429" y="30"/>
-      <point x="380" y="57"/>
-      <point x="380" y="112" type="curve" smooth="yes"/>
-      <point x="380" y="119"/>
-      <point x="381" y="126"/>
-      <point x="383" y="132" type="curve"/>
-      <point x="415" y="136"/>
-      <point x="448" y="151"/>
-      <point x="448" y="194" type="curve" smooth="yes"/>
-      <point x="448" y="225"/>
-      <point x="427" y="244"/>
-      <point x="396" y="244" type="curve" smooth="yes"/>
-      <point x="348" y="244"/>
-      <point x="318" y="206"/>
-      <point x="318" y="140" type="curve" smooth="yes"/>
-      <point x="318" y="51"/>
-      <point x="382" y="-10"/>
-      <point x="488" y="-10" type="curve" smooth="yes"/>
-      <point x="666" y="-10"/>
-      <point x="759" y="159"/>
-      <point x="759" y="306" type="curve" smooth="yes"/>
-      <point x="759" y="437"/>
-      <point x="699" y="549"/>
-      <point x="577" y="549" type="curve" smooth="yes"/>
-      <point x="527" y="549"/>
-      <point x="431" y="512"/>
-      <point x="325" y="419" type="curve" smooth="yes"/>
-      <point x="273" y="373"/>
-      <point x="212" y="310"/>
-      <point x="160" y="238" type="curve"/>
-      <point x="145" y="272"/>
-      <point x="136" y="307"/>
-      <point x="136" y="345" type="curve" smooth="yes"/>
-      <point x="136" y="474"/>
-      <point x="166" y="548"/>
-      <point x="247" y="625" type="curve"/>
-      <point x="231" y="647" type="line"/>
-      <point x="172" y="610"/>
-      <point x="48" y="496"/>
-      <point x="48" y="337" type="curve" smooth="yes"/>
-      <point x="48" y="267"/>
-      <point x="72" y="206"/>
-      <point x="104" y="149" type="curve"/>
-      <point x="69" y="85"/>
-      <point x="43" y="11"/>
-      <point x="43" y="-56" type="curve" smooth="yes"/>
-      <point x="43" y="-163"/>
-      <point x="117" y="-241"/>
+      <point x="420" y="-494" type="curve" smooth="yes"/>
+      <point x="557" y="-494"/>
+      <point x="651" y="-369"/>
+      <point x="651" y="-195" type="curve" smooth="yes"/>
+      <point x="651" y="16"/>
+      <point x="469" y="203"/>
+      <point x="356" y="410" type="curve"/>
+      <point x="451" y="557"/>
+      <point x="571" y="698"/>
+      <point x="692" y="807" type="curve" smooth="yes"/>
+      <point x="825" y="926"/>
+      <point x="967" y="1008"/>
+      <point x="1085" y="1008" type="curve" smooth="yes"/>
+      <point x="1288" y="1008"/>
+      <point x="1303" y="735"/>
+      <point x="1303" y="659" type="curve" smooth="yes"/>
+      <point x="1303" y="584"/>
+      <point x="1278" y="61"/>
+      <point x="952" y="61" type="curve" smooth="yes"/>
+      <point x="850" y="61"/>
+      <point x="752" y="117"/>
+      <point x="752" y="229" type="curve" smooth="yes"/>
+      <point x="752" y="244"/>
+      <point x="754" y="258"/>
+      <point x="758" y="270" type="curve"/>
+      <point x="823" y="279"/>
+      <point x="889" y="309"/>
+      <point x="889" y="397" type="curve" smooth="yes"/>
+      <point x="889" y="461"/>
+      <point x="846" y="500"/>
+      <point x="784" y="500" type="curve" smooth="yes"/>
+      <point x="688" y="500"/>
+      <point x="631" y="422"/>
+      <point x="631" y="287" type="curve" smooth="yes"/>
+      <point x="631" y="104"/>
+      <point x="756" y="-20"/>
+      <point x="967" y="-20" type="curve" smooth="yes"/>
+      <point x="1319" y="-20"/>
+      <point x="1505" y="326"/>
+      <point x="1505" y="627" type="curve" smooth="yes"/>
+      <point x="1505" y="895"/>
+      <point x="1384" y="1124"/>
+      <point x="1145" y="1124" type="curve" smooth="yes"/>
+      <point x="1044" y="1124"/>
+      <point x="856" y="1049"/>
+      <point x="645" y="858" type="curve" smooth="yes"/>
+      <point x="541" y="764"/>
+      <point x="420" y="635"/>
+      <point x="317" y="487" type="curve"/>
+      <point x="287" y="557"/>
+      <point x="268" y="629"/>
+      <point x="268" y="707" type="curve" smooth="yes"/>
+      <point x="268" y="971"/>
+      <point x="328" y="1122"/>
+      <point x="487" y="1280" type="curve"/>
+      <point x="457" y="1325" type="line"/>
+      <point x="340" y="1249"/>
+      <point x="94" y="1016"/>
+      <point x="94" y="690" type="curve" smooth="yes"/>
+      <point x="94" y="547"/>
+      <point x="141" y="422"/>
+      <point x="205" y="305" type="curve"/>
+      <point x="135" y="174"/>
+      <point x="84" y="23"/>
+      <point x="84" y="-115" type="curve" smooth="yes"/>
+      <point x="84" y="-334"/>
+      <point x="229" y="-494"/>
     </contour>
     <contour>
-      <point x="194" y="-199" type="curve" smooth="yes"/>
-      <point x="150" y="-199"/>
-      <point x="83" y="-145"/>
-      <point x="83" y="-51" type="curve" smooth="yes"/>
-      <point x="83" y="-4"/>
-      <point x="99" y="52"/>
-      <point x="127" y="110" type="curve"/>
-      <point x="181" y="24"/>
-      <point x="242" y="-52"/>
-      <point x="242" y="-134" type="curve" smooth="yes"/>
-      <point x="242" y="-176"/>
-      <point x="223" y="-199"/>
+      <point x="385" y="-408" type="curve" smooth="yes"/>
+      <point x="295" y="-408"/>
+      <point x="164" y="-297"/>
+      <point x="164" y="-104" type="curve" smooth="yes"/>
+      <point x="164" y="-8"/>
+      <point x="197" y="106"/>
+      <point x="252" y="225" type="curve"/>
+      <point x="356" y="49"/>
+      <point x="479" y="-106"/>
+      <point x="479" y="-274" type="curve" smooth="yes"/>
+      <point x="479" y="-360"/>
+      <point x="442" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="811"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="212" y="-241" type="curve" smooth="yes"/>
+      <point x="282" y="-241"/>
+      <point x="329" y="-180"/>
+      <point x="329" y="-95" type="curve" smooth="yes"/>
+      <point x="329" y="8"/>
+      <point x="237" y="99"/>
+      <point x="180" y="200" type="curve"/>
+      <point x="227" y="272"/>
+      <point x="287" y="341"/>
+      <point x="349" y="394" type="curve" smooth="yes"/>
+      <point x="417" y="452"/>
+      <point x="488" y="492"/>
+      <point x="547" y="492" type="curve" smooth="yes"/>
+      <point x="649" y="492"/>
+      <point x="657" y="359"/>
+      <point x="657" y="322" type="curve" smooth="yes"/>
+      <point x="657" y="285"/>
+      <point x="644" y="30"/>
+      <point x="480" y="30" type="curve" smooth="yes"/>
+      <point x="429" y="30"/>
+      <point x="380" y="57"/>
+      <point x="380" y="112" type="curve" smooth="yes"/>
+      <point x="380" y="119"/>
+      <point x="381" y="126"/>
+      <point x="383" y="132" type="curve"/>
+      <point x="415" y="136"/>
+      <point x="448" y="151"/>
+      <point x="448" y="194" type="curve" smooth="yes"/>
+      <point x="448" y="225"/>
+      <point x="427" y="244"/>
+      <point x="396" y="244" type="curve" smooth="yes"/>
+      <point x="348" y="244"/>
+      <point x="318" y="206"/>
+      <point x="318" y="140" type="curve" smooth="yes"/>
+      <point x="318" y="51"/>
+      <point x="382" y="-10"/>
+      <point x="488" y="-10" type="curve" smooth="yes"/>
+      <point x="666" y="-10"/>
+      <point x="759" y="159"/>
+      <point x="759" y="306" type="curve" smooth="yes"/>
+      <point x="759" y="437"/>
+      <point x="699" y="549"/>
+      <point x="577" y="549" type="curve" smooth="yes"/>
+      <point x="527" y="549"/>
+      <point x="431" y="512"/>
+      <point x="325" y="419" type="curve" smooth="yes"/>
+      <point x="273" y="373"/>
+      <point x="212" y="310"/>
+      <point x="160" y="238" type="curve"/>
+      <point x="145" y="272"/>
+      <point x="136" y="307"/>
+      <point x="136" y="345" type="curve" smooth="yes"/>
+      <point x="136" y="474"/>
+      <point x="166" y="548"/>
+      <point x="247" y="625" type="curve"/>
+      <point x="231" y="647" type="line"/>
+      <point x="172" y="610"/>
+      <point x="48" y="496"/>
+      <point x="48" y="337" type="curve" smooth="yes"/>
+      <point x="48" y="267"/>
+      <point x="72" y="206"/>
+      <point x="104" y="149" type="curve"/>
+      <point x="69" y="85"/>
+      <point x="43" y="11"/>
+      <point x="43" y="-56" type="curve" smooth="yes"/>
+      <point x="43" y="-163"/>
+      <point x="117" y="-241"/>
+    </contour>
+    <contour>
+      <point x="194" y="-199" type="curve" smooth="yes"/>
+      <point x="150" y="-199"/>
+      <point x="83" y="-145"/>
+      <point x="83" y="-51" type="curve" smooth="yes"/>
+      <point x="83" y="-4"/>
+      <point x="99" y="52"/>
+      <point x="127" y="110" type="curve"/>
+      <point x="181" y="24"/>
+      <point x="242" y="-52"/>
+      <point x="242" y="-134" type="curve" smooth="yes"/>
+      <point x="242" y="-176"/>
+      <point x="223" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2127.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1170"/>
+  <advance width="1158"/>
   <unicode hex="2127"/>
-  <anchor x="585" y="1446" name="top"/>
+  <anchor x="573" y="1446" name="top"/>
   <outline>
     <contour>
-      <point x="593" y="-20" type="curve" smooth="yes"/>
-      <point x="863" y="-20"/>
-      <point x="1046" y="234"/>
-      <point x="1046" y="612" type="curve"/>
-      <point x="1046" y="727" type="line"/>
-      <point x="1046" y="1109"/>
-      <point x="864" y="1376"/>
-      <point x="656" y="1436" type="curve"/>
-      <point x="656" y="1335" type="line"/>
-      <point x="801" y="1277"/>
-      <point x="930" y="1098"/>
-      <point x="930" y="727" type="curve"/>
-      <point x="930" y="610" type="line"/>
-      <point x="930" y="294"/>
-      <point x="800" y="87"/>
-      <point x="593" y="87" type="curve" smooth="yes"/>
-      <point x="384" y="87"/>
-      <point x="253" y="294"/>
-      <point x="253" y="610" type="curve"/>
-      <point x="253" y="727" type="line"/>
-      <point x="253" y="1096"/>
-      <point x="378" y="1276"/>
-      <point x="522" y="1335" type="curve"/>
-      <point x="522" y="1436" type="line"/>
-      <point x="317" y="1374"/>
-      <point x="137" y="1108"/>
-      <point x="137" y="727" type="curve"/>
-      <point x="137" y="612" type="line"/>
-      <point x="137" y="234"/>
-      <point x="323" y="-20"/>
+      <point x="581" y="-20" type="curve" smooth="yes"/>
+      <point x="851" y="-20"/>
+      <point x="1034" y="234"/>
+      <point x="1034" y="612" type="curve"/>
+      <point x="1034" y="727" type="line"/>
+      <point x="1034" y="1109"/>
+      <point x="852" y="1376"/>
+      <point x="644" y="1436" type="curve"/>
+      <point x="644" y="1335" type="line"/>
+      <point x="789" y="1277"/>
+      <point x="918" y="1098"/>
+      <point x="918" y="727" type="curve"/>
+      <point x="918" y="610" type="line"/>
+      <point x="918" y="294"/>
+      <point x="788" y="87"/>
+      <point x="581" y="87" type="curve" smooth="yes"/>
+      <point x="372" y="87"/>
+      <point x="241" y="294"/>
+      <point x="241" y="610" type="curve"/>
+      <point x="241" y="727" type="line"/>
+      <point x="241" y="1096"/>
+      <point x="366" y="1276"/>
+      <point x="510" y="1335" type="curve"/>
+      <point x="510" y="1436" type="line"/>
+      <point x="305" y="1374"/>
+      <point x="125" y="1108"/>
+      <point x="125" y="727" type="curve"/>
+      <point x="125" y="612" type="line"/>
+      <point x="125" y="234"/>
+      <point x="311" y="-20"/>
     </contour>
     <contour>
-      <point x="133" y="1349" type="line"/>
-      <point x="522" y="1349" type="line"/>
-      <point x="522" y="1456" type="line"/>
-      <point x="133" y="1456" type="line"/>
+      <point x="121" y="1349" type="line"/>
+      <point x="510" y="1349" type="line"/>
+      <point x="510" y="1456" type="line"/>
+      <point x="121" y="1456" type="line"/>
     </contour>
     <contour>
-      <point x="656" y="1349" type="line"/>
-      <point x="1049" y="1349" type="line"/>
-      <point x="1049" y="1456" type="line"/>
-      <point x="656" y="1456" type="line"/>
+      <point x="644" y="1349" type="line"/>
+      <point x="1037" y="1349" type="line"/>
+      <point x="1037" y="1456" type="line"/>
+      <point x="644" y="1456" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1170"/>
+  <unicode hex="2127"/>
+  <anchor x="585" y="1446" name="top"/>
+  <outline>
+    <contour>
+      <point x="593" y="-20" type="curve" smooth="yes"/>
+      <point x="863" y="-20"/>
+      <point x="1046" y="234"/>
+      <point x="1046" y="612" type="curve"/>
+      <point x="1046" y="727" type="line"/>
+      <point x="1046" y="1109"/>
+      <point x="864" y="1376"/>
+      <point x="656" y="1436" type="curve"/>
+      <point x="656" y="1335" type="line"/>
+      <point x="801" y="1277"/>
+      <point x="930" y="1098"/>
+      <point x="930" y="727" type="curve"/>
+      <point x="930" y="610" type="line"/>
+      <point x="930" y="294"/>
+      <point x="800" y="87"/>
+      <point x="593" y="87" type="curve" smooth="yes"/>
+      <point x="384" y="87"/>
+      <point x="253" y="294"/>
+      <point x="253" y="610" type="curve"/>
+      <point x="253" y="727" type="line"/>
+      <point x="253" y="1096"/>
+      <point x="378" y="1276"/>
+      <point x="522" y="1335" type="curve"/>
+      <point x="522" y="1436" type="line"/>
+      <point x="317" y="1374"/>
+      <point x="137" y="1108"/>
+      <point x="137" y="727" type="curve"/>
+      <point x="137" y="612" type="line"/>
+      <point x="137" y="234"/>
+      <point x="323" y="-20"/>
+    </contour>
+    <contour>
+      <point x="133" y="1349" type="line"/>
+      <point x="522" y="1349" type="line"/>
+      <point x="522" y="1456" type="line"/>
+      <point x="133" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="656" y="1349" type="line"/>
+      <point x="1049" y="1349" type="line"/>
+      <point x="1049" y="1456" type="line"/>
+      <point x="656" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2129.glif
@@ -14,8 +14,8 @@
       <point x="304" y="1082"/>
       <point x="189" y="1082" type="curve" smooth="yes"/>
       <point x="146" y="1082"/>
-      <point x="103" y="1076"/>
-      <point x="79" y="1066" type="curve"/>
+      <point x="106" y="1076"/>
+      <point x="82" y="1066" type="curve"/>
       <point x="82" y="964" type="line"/>
       <point x="103" y="969"/>
       <point x="133" y="975"/>
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="564"/>
+  <unicode hex="2129"/>
+  <anchor x="330" y="-197" name="bottom"/>
+  <anchor x="20" y="-197" name="bottom0315"/>
+  <anchor x="330" y="-197" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="277" y="-10" type="line"/>
+      <point x="389" y="-10" type="line"/>
+      <point x="389" y="798" type="line"/>
+      <point x="389" y="1015"/>
+      <point x="304" y="1082"/>
+      <point x="189" y="1082" type="curve" smooth="yes"/>
+      <point x="146" y="1082"/>
+      <point x="103" y="1076"/>
+      <point x="79" y="1066" type="curve"/>
+      <point x="82" y="964" type="line"/>
+      <point x="103" y="969"/>
+      <point x="133" y="975"/>
+      <point x="162" y="975" type="curve" smooth="yes"/>
+      <point x="223" y="975"/>
+      <point x="277" y="948"/>
+      <point x="277" y="799" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="432"/>
+  <unicode hex="2139"/>
+  <anchor x="216" y="10" name="bottom"/>
+  <anchor x="412" y="-407" name="bottom_dd"/>
+  <anchor x="220" y="1600" name="parent_top"/>
+  <anchor x="230" y="654" name="rhotichook"/>
+  <anchor x="220" y="1600" name="top"/>
+  <anchor x="412" y="1600" name="top0315"/>
+  <anchor x="412" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2139.glif
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni213A_.glif
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1838"/>
+  <unicode hex="213A"/>
+  <anchor x="1593" y="657" name="bottom"/>
+  <anchor x="1990" y="1239" name="bottom_dd"/>
+  <anchor x="-17" y="659" name="parent_top"/>
+  <anchor x="-17" y="659" name="top"/>
+  <anchor x="-17" y="1239" name="top0315"/>
+  <anchor x="-17" y="1239" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="698" y="179" type="curve"/>
+      <point x="1012" y="179" type="line"/>
+      <point x="1397" y="179"/>
+      <point x="1604" y="366"/>
+      <point x="1604" y="651" type="curve" smooth="yes"/>
+      <point x="1604" y="943"/>
+      <point x="1397" y="1122"/>
+      <point x="1012" y="1122" type="curve"/>
+      <point x="698" y="1122" type="line"/>
+      <point x="314" y="1122"/>
+      <point x="107" y="942"/>
+      <point x="107" y="650" type="curve" smooth="yes"/>
+      <point x="107" y="364"/>
+      <point x="314" y="179"/>
+    </contour>
+    <contour>
+      <point x="696" y="294" type="line" smooth="yes"/>
+      <point x="378" y="294"/>
+      <point x="217" y="425"/>
+      <point x="217" y="650" type="curve" smooth="yes"/>
+      <point x="217" y="882"/>
+      <point x="378" y="1008"/>
+      <point x="696" y="1008" type="curve"/>
+      <point x="1012" y="1008" type="line"/>
+      <point x="1333" y="1008"/>
+      <point x="1494" y="884"/>
+      <point x="1494" y="651" type="curve" smooth="yes"/>
+      <point x="1494" y="427"/>
+      <point x="1333" y="294"/>
+      <point x="1012" y="294" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1551" y="757" type="line"/>
+      <point x="1838" y="1040" type="line"/>
+      <point x="1759" y="1119" type="line"/>
+      <point x="1469" y="833" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1216"/>
+  <unicode hex="2141"/>
+  <anchor x="621" y="-178" name="bottom"/>
+  <anchor x="20" y="-178" name="bottom0315"/>
+  <anchor x="20" y="-145" name="bottom_dd"/>
+  <anchor x="621" y="-178" name="parent_bottom"/>
+  <anchor x="583" y="1460" name="top"/>
+  <anchor x="20" y="1862" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="600" y="-21" type="curve" smooth="yes"/>
+      <point x="897" y="-21"/>
+      <point x="1069" y="178"/>
+      <point x="1069" y="554" type="curve" smooth="yes"/>
+      <point x="1069" y="889" type="line" smooth="yes"/>
+      <point x="1069" y="1272"/>
+      <point x="873" y="1476"/>
+      <point x="583" y="1476" type="curve" smooth="yes"/>
+      <point x="323" y="1476"/>
+      <point x="200" y="1344"/>
+      <point x="157" y="1286" type="curve"/>
+      <point x="157" y="762" type="line"/>
+      <point x="591" y="762" type="line"/>
+      <point x="591" y="868" type="line"/>
+      <point x="271" y="868" type="line"/>
+      <point x="271" y="1247" type="line"/>
+      <point x="306" y="1283"/>
+      <point x="399" y="1369"/>
+      <point x="583" y="1369" type="curve" smooth="yes"/>
+      <point x="812" y="1369"/>
+      <point x="954" y="1203"/>
+      <point x="954" y="889" type="curve" smooth="yes"/>
+      <point x="954" y="552" type="line" smooth="yes"/>
+      <point x="954" y="249"/>
+      <point x="836" y="86"/>
+      <point x="600" y="86" type="curve" smooth="yes"/>
+      <point x="385" y="86"/>
+      <point x="292" y="208"/>
+      <point x="272" y="409" type="curve"/>
+      <point x="157" y="409" type="line"/>
+      <point x="176" y="136"/>
+      <point x="327" y="-21"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="951"/>
+  <unicode hex="2142"/>
+  <anchor x="720" y="-117" name="bottom"/>
+  <anchor x="20" y="-117" name="bottom0315"/>
+  <anchor x="20" y="-144" name="bottom_dd"/>
+  <anchor x="720" y="-117" name="parent_bottom"/>
+  <anchor x="409" y="1446" name="top"/>
+  <anchor x="20" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="663" y="0" type="line"/>
+      <point x="778" y="0" type="line"/>
+      <point x="778" y="1456" type="line"/>
+      <point x="663" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="64" y="1349" type="line"/>
+      <point x="694" y="1349" type="line"/>
+      <point x="694" y="1456" type="line"/>
+      <point x="64" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="951"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="663" y="0" type="line"/>
+      <point x="778" y="0" type="line"/>
+      <point x="778" y="1456" type="line"/>
+      <point x="663" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="64" y="0" type="line"/>
+      <point x="694" y="0" type="line"/>
+      <point x="694" y="107" type="line"/>
+      <point x="64" y="107" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1071"/>
+  <unicode hex="2144"/>
+  <anchor x="535" y="-145" name="bottom"/>
+  <anchor x="20" y="-145" name="bottom0315"/>
+  <anchor x="20" y="-144" name="bottom_dd"/>
+  <anchor x="535" y="-145" name="parent_bottom"/>
+  <anchor x="536" y="1451" name="top"/>
+  <anchor x="20" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="42" y="0" type="line"/>
+      <point x="174" y="0" type="line"/>
+      <point x="537" y="791" type="line"/>
+      <point x="898" y="0" type="line"/>
+      <point x="1032" y="0" type="line"/>
+      <point x="595" y="908" type="line"/>
+      <point x="595" y="1456" type="line"/>
+      <point x="480" y="1456" type="line"/>
+      <point x="480" y="908" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1104"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="173" y="300" type="line"/>
+      <point x="287" y="300" type="line"/>
+      <point x="287" y="1349" type="line"/>
+      <point x="596" y="1349" type="line"/>
+      <point x="809" y="1349"/>
+      <point x="896" y="1196"/>
+      <point x="896" y="1019" type="curve"/>
+      <point x="896" y="838"/>
+      <point x="809" y="699"/>
+      <point x="596" y="699" type="curve"/>
+      <point x="556" y="699" type="line"/>
+      <point x="556" y="592" type="line"/>
+      <point x="596" y="592" type="line"/>
+      <point x="867" y="592"/>
+      <point x="1011" y="752"/>
+      <point x="1011" y="1021" type="curve"/>
+      <point x="1011" y="1279"/>
+      <point x="866" y="1456"/>
+      <point x="596" y="1456" type="curve"/>
+      <point x="173" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="607" y="0" type="line"/>
+      <point x="1237" y="0" type="line"/>
+      <point x="1237" y="107" type="line"/>
+      <point x="607" y="107" type="line"/>
+    </contour>
+    <contour>
+      <point x="523" y="0" type="line"/>
+      <point x="638" y="0" type="line"/>
+      <point x="638" y="1600" type="line"/>
+      <point x="523" y="1600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni214A_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214A" format="2">
-  <advance width="1104"/>
+  <advance width="1301"/>
   <unicode hex="214A"/>
   <outline>
     <contour>
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1101"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="598" y="-20" type="curve" smooth="yes"/>
+      <point x="771" y="-20"/>
+      <point x="884" y="108"/>
+      <point x="884" y="313" type="curve" smooth="yes"/>
+      <point x="884" y="462"/>
+      <point x="800" y="585"/>
+      <point x="675" y="757" type="curve" smooth="yes"/>
+      <point x="174" y="1457" type="line"/>
+      <point x="41" y="1457" type="line"/>
+      <point x="633" y="631" type="line" smooth="yes"/>
+      <point x="720" y="511"/>
+      <point x="772" y="405"/>
+      <point x="772" y="309" type="curve" smooth="yes"/>
+      <point x="772" y="187"/>
+      <point x="712" y="84"/>
+      <point x="598" y="84" type="curve" smooth="yes"/>
+      <point x="493" y="84"/>
+      <point x="435" y="173"/>
+      <point x="435" y="267" type="curve"/>
+      <point x="435" y="366"/>
+      <point x="485" y="434"/>
+      <point x="556" y="496" type="curve"/>
+      <point x="750" y="671" type="line"/>
+      <point x="887" y="792"/>
+      <point x="991" y="910"/>
+      <point x="991" y="1085" type="curve"/>
+      <point x="991" y="1319"/>
+      <point x="845" y="1477"/>
+      <point x="608" y="1477" type="curve"/>
+      <point x="476" y="1477"/>
+      <point x="349" y="1408"/>
+      <point x="261" y="1296" type="curve" smooth="yes"/>
+      <point x="251" y="1284"/>
+      <point x="251" y="1278"/>
+      <point x="241" y="1266" type="curve" smooth="yes"/>
+      <point x="150" y="1148"/>
+      <point x="103" y="995"/>
+      <point x="103" y="804" type="curve"/>
+      <point x="205" y="804" type="line"/>
+      <point x="205" y="1144"/>
+      <point x="402" y="1373"/>
+      <point x="608" y="1373" type="curve" smooth="yes"/>
+      <point x="793" y="1373"/>
+      <point x="880" y="1238"/>
+      <point x="880" y="1085" type="curve"/>
+      <point x="880" y="1019"/>
+      <point x="862" y="916"/>
+      <point x="722" y="778" type="curve" smooth="yes"/>
+      <point x="495" y="573" type="line" smooth="yes"/>
+      <point x="411" y="499"/>
+      <point x="331" y="398"/>
+      <point x="331" y="267" type="curve"/>
+      <point x="331" y="111"/>
+      <point x="430" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni214B_.glif
@@ -63,7 +63,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="615"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="265" y="-10" type="curve" smooth="yes"/>
+      <point x="347" y="-10"/>
+      <point x="374" y="51"/>
+      <point x="374" y="117" type="curve" smooth="yes"/>
+      <point x="374" y="140"/>
+      <point x="366" y="204"/>
+      <point x="358" y="277" type="curve"/>
+      <point x="434" y="291"/>
+      <point x="500" y="326"/>
+      <point x="542" y="375" type="curve"/>
+      <point x="551" y="361"/>
+      <point x="556" y="345"/>
+      <point x="556" y="327" type="curve" smooth="yes"/>
+      <point x="556" y="281"/>
+      <point x="509" y="238"/>
+      <point x="491" y="224" type="curve"/>
+      <point x="525" y="224" type="line"/>
+      <point x="544" y="238"/>
+      <point x="586" y="281"/>
+      <point x="586" y="326" type="curve" smooth="yes"/>
+      <point x="586" y="354"/>
+      <point x="576" y="378"/>
+      <point x="559" y="397" type="curve"/>
+      <point x="580" y="427"/>
+      <point x="592" y="462"/>
+      <point x="592" y="500" type="curve" smooth="yes"/>
+      <point x="592" y="608"/>
+      <point x="521" y="725"/>
+      <point x="412" y="725" type="curve" smooth="yes"/>
+      <point x="329" y="725"/>
+      <point x="302" y="664"/>
+      <point x="302" y="569" type="curve" smooth="yes"/>
+      <point x="302" y="548"/>
+      <point x="303" y="515"/>
+      <point x="304" y="477" type="curve"/>
+      <point x="292" y="478"/>
+      <point x="281" y="478"/>
+      <point x="271" y="478" type="curve" smooth="yes"/>
+      <point x="260" y="478"/>
+      <point x="241" y="477"/>
+      <point x="220" y="475" type="curve"/>
+      <point x="222" y="613" type="line"/>
+      <point x="237" y="635"/>
+      <point x="251" y="658"/>
+      <point x="251" y="675" type="curve" smooth="yes"/>
+      <point x="251" y="681"/>
+      <point x="250" y="708"/>
+      <point x="223" y="708" type="curve" smooth="yes"/>
+      <point x="188" y="708"/>
+      <point x="200" y="669"/>
+      <point x="184" y="669" type="curve" smooth="yes"/>
+      <point x="164" y="669"/>
+      <point x="153" y="715"/>
+      <point x="105" y="715" type="curve" smooth="yes"/>
+      <point x="82" y="715"/>
+      <point x="41" y="702"/>
+      <point x="41" y="643" type="curve" smooth="yes"/>
+      <point x="41" y="603"/>
+      <point x="68" y="572"/>
+      <point x="112" y="572" type="curve" smooth="yes"/>
+      <point x="119" y="572"/>
+      <point x="126" y="573"/>
+      <point x="131" y="574" type="curve"/>
+      <point x="130" y="592" type="line"/>
+      <point x="126" y="591"/>
+      <point x="118" y="590"/>
+      <point x="112" y="590" type="curve" smooth="yes"/>
+      <point x="94" y="590"/>
+      <point x="88" y="606"/>
+      <point x="88" y="617" type="curve" smooth="yes"/>
+      <point x="88" y="630"/>
+      <point x="97" y="644"/>
+      <point x="116" y="644" type="curve" smooth="yes"/>
+      <point x="138" y="644"/>
+      <point x="185" y="625"/>
+      <point x="202" y="615" type="curve"/>
+      <point x="186" y="471" type="line"/>
+      <point x="124" y="460"/>
+      <point x="54" y="433"/>
+      <point x="54" y="369" type="curve" smooth="yes"/>
+      <point x="54" y="315"/>
+      <point x="107" y="290"/>
+      <point x="167" y="279" type="curve"/>
+      <point x="160" y="208"/>
+      <point x="156" y="144"/>
+      <point x="156" y="117" type="curve" smooth="yes"/>
+      <point x="156" y="51"/>
+      <point x="183" y="-10"/>
+    </contour>
+    <contour>
+      <point x="265" y="20" type="curve" smooth="yes"/>
+      <point x="228" y="20"/>
+      <point x="208" y="58"/>
+      <point x="208" y="115" type="curve" smooth="yes"/>
+      <point x="208" y="146"/>
+      <point x="210" y="206"/>
+      <point x="212" y="273" type="curve"/>
+      <point x="237" y="270"/>
+      <point x="261" y="270"/>
+      <point x="282" y="270" type="curve" smooth="yes"/>
+      <point x="292" y="270"/>
+      <point x="303" y="270"/>
+      <point x="314" y="271" type="curve"/>
+      <point x="317" y="195"/>
+      <point x="321" y="132"/>
+      <point x="321" y="115" type="curve" smooth="yes"/>
+      <point x="321" y="58"/>
+      <point x="301" y="20"/>
+    </contour>
+    <contour>
+      <point x="169" y="299" type="line"/>
+      <point x="89" y="318"/>
+      <point x="79" y="358"/>
+      <point x="79" y="372" type="curve" smooth="yes"/>
+      <point x="79" y="384"/>
+      <point x="85" y="434"/>
+      <point x="184" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="281" y="288" type="curve" smooth="yes"/>
+      <point x="254" y="288"/>
+      <point x="233" y="289"/>
+      <point x="213" y="291" type="curve"/>
+      <point x="219" y="458" type="line"/>
+      <point x="234" y="459"/>
+      <point x="251" y="460"/>
+      <point x="270" y="460" type="curve" smooth="yes"/>
+      <point x="282" y="460"/>
+      <point x="293" y="459"/>
+      <point x="305" y="459" type="curve"/>
+      <point x="313" y="289" type="line"/>
+      <point x="302" y="288"/>
+      <point x="292" y="288"/>
+    </contour>
+    <contour>
+      <point x="356" y="295" type="curve"/>
+      <point x="337" y="457" type="line"/>
+      <point x="397" y="452"/>
+      <point x="457" y="439"/>
+      <point x="499" y="414" type="curve"/>
+      <point x="476" y="351"/>
+      <point x="428" y="311"/>
+    </contour>
+    <contour>
+      <point x="504" y="436" type="curve"/>
+      <point x="455" y="460"/>
+      <point x="390" y="471"/>
+      <point x="335" y="475" type="curve"/>
+      <point x="331" y="514"/>
+      <point x="329" y="548"/>
+      <point x="329" y="572" type="curve" smooth="yes"/>
+      <point x="329" y="636"/>
+      <point x="335" y="707"/>
+      <point x="409" y="707" type="curve" smooth="yes"/>
+      <point x="500" y="707"/>
+      <point x="516" y="593"/>
+      <point x="516" y="519" type="curve" smooth="yes"/>
+      <point x="516" y="488"/>
+      <point x="511" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="615"/>
+  <advance width="1260"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="265" y="-10" type="curve" smooth="yes"/>
-      <point x="347" y="-10"/>
-      <point x="374" y="51"/>
-      <point x="374" y="117" type="curve" smooth="yes"/>
-      <point x="374" y="140"/>
-      <point x="366" y="204"/>
-      <point x="358" y="277" type="curve"/>
-      <point x="434" y="291"/>
-      <point x="500" y="326"/>
-      <point x="542" y="375" type="curve"/>
-      <point x="551" y="361"/>
-      <point x="556" y="345"/>
-      <point x="556" y="327" type="curve" smooth="yes"/>
-      <point x="556" y="281"/>
-      <point x="509" y="238"/>
-      <point x="491" y="224" type="curve"/>
-      <point x="525" y="224" type="line"/>
-      <point x="544" y="238"/>
-      <point x="586" y="281"/>
-      <point x="586" y="326" type="curve" smooth="yes"/>
-      <point x="586" y="354"/>
-      <point x="576" y="378"/>
-      <point x="559" y="397" type="curve"/>
-      <point x="580" y="427"/>
-      <point x="592" y="462"/>
-      <point x="592" y="500" type="curve" smooth="yes"/>
-      <point x="592" y="608"/>
-      <point x="521" y="725"/>
-      <point x="412" y="725" type="curve" smooth="yes"/>
-      <point x="329" y="725"/>
-      <point x="302" y="664"/>
-      <point x="302" y="569" type="curve" smooth="yes"/>
-      <point x="302" y="548"/>
-      <point x="303" y="515"/>
-      <point x="304" y="477" type="curve"/>
-      <point x="292" y="478"/>
-      <point x="281" y="478"/>
-      <point x="271" y="478" type="curve" smooth="yes"/>
-      <point x="260" y="478"/>
-      <point x="241" y="477"/>
-      <point x="220" y="475" type="curve"/>
-      <point x="222" y="613" type="line"/>
-      <point x="237" y="635"/>
-      <point x="251" y="658"/>
-      <point x="251" y="675" type="curve" smooth="yes"/>
-      <point x="251" y="681"/>
-      <point x="250" y="708"/>
-      <point x="223" y="708" type="curve" smooth="yes"/>
-      <point x="188" y="708"/>
-      <point x="200" y="669"/>
-      <point x="184" y="669" type="curve" smooth="yes"/>
-      <point x="164" y="669"/>
-      <point x="153" y="715"/>
-      <point x="105" y="715" type="curve" smooth="yes"/>
-      <point x="82" y="715"/>
-      <point x="41" y="702"/>
-      <point x="41" y="643" type="curve" smooth="yes"/>
-      <point x="41" y="603"/>
-      <point x="68" y="572"/>
-      <point x="112" y="572" type="curve" smooth="yes"/>
-      <point x="119" y="572"/>
-      <point x="126" y="573"/>
-      <point x="131" y="574" type="curve"/>
-      <point x="130" y="592" type="line"/>
-      <point x="126" y="591"/>
-      <point x="118" y="590"/>
-      <point x="112" y="590" type="curve" smooth="yes"/>
-      <point x="94" y="590"/>
-      <point x="88" y="606"/>
-      <point x="88" y="617" type="curve" smooth="yes"/>
-      <point x="88" y="630"/>
-      <point x="97" y="644"/>
-      <point x="116" y="644" type="curve" smooth="yes"/>
-      <point x="138" y="644"/>
-      <point x="185" y="625"/>
-      <point x="202" y="615" type="curve"/>
-      <point x="186" y="471" type="line"/>
-      <point x="124" y="460"/>
-      <point x="54" y="433"/>
-      <point x="54" y="369" type="curve" smooth="yes"/>
-      <point x="54" y="315"/>
-      <point x="107" y="290"/>
-      <point x="167" y="279" type="curve"/>
-      <point x="160" y="208"/>
-      <point x="156" y="144"/>
-      <point x="156" y="117" type="curve" smooth="yes"/>
-      <point x="156" y="51"/>
-      <point x="183" y="-10"/>
+      <point x="543" y="-20" type="curve" smooth="yes"/>
+      <point x="711" y="-20"/>
+      <point x="766" y="104"/>
+      <point x="766" y="240" type="curve" smooth="yes"/>
+      <point x="766" y="287"/>
+      <point x="750" y="418"/>
+      <point x="733" y="567" type="curve"/>
+      <point x="889" y="596"/>
+      <point x="1024" y="668"/>
+      <point x="1110" y="768" type="curve"/>
+      <point x="1128" y="739"/>
+      <point x="1139" y="707"/>
+      <point x="1139" y="670" type="curve" smooth="yes"/>
+      <point x="1139" y="575"/>
+      <point x="1042" y="487"/>
+      <point x="1006" y="459" type="curve"/>
+      <point x="1075" y="459" type="line"/>
+      <point x="1114" y="487"/>
+      <point x="1200" y="575"/>
+      <point x="1200" y="668" type="curve" smooth="yes"/>
+      <point x="1200" y="725"/>
+      <point x="1180" y="774"/>
+      <point x="1145" y="813" type="curve"/>
+      <point x="1188" y="874"/>
+      <point x="1212" y="946"/>
+      <point x="1212" y="1024" type="curve" smooth="yes"/>
+      <point x="1212" y="1245"/>
+      <point x="1067" y="1485"/>
+      <point x="844" y="1485" type="curve" smooth="yes"/>
+      <point x="674" y="1485"/>
+      <point x="618" y="1360"/>
+      <point x="618" y="1165" type="curve" smooth="yes"/>
+      <point x="618" y="1122"/>
+      <point x="621" y="1055"/>
+      <point x="623" y="977" type="curve"/>
+      <point x="598" y="979"/>
+      <point x="575" y="979"/>
+      <point x="555" y="979" type="curve" smooth="yes"/>
+      <point x="532" y="979"/>
+      <point x="494" y="977"/>
+      <point x="451" y="973" type="curve"/>
+      <point x="455" y="1255" type="line"/>
+      <point x="485" y="1300"/>
+      <point x="514" y="1348"/>
+      <point x="514" y="1382" type="curve" smooth="yes"/>
+      <point x="514" y="1395"/>
+      <point x="512" y="1450"/>
+      <point x="457" y="1450" type="curve" smooth="yes"/>
+      <point x="385" y="1450"/>
+      <point x="410" y="1370"/>
+      <point x="377" y="1370" type="curve" smooth="yes"/>
+      <point x="336" y="1370"/>
+      <point x="313" y="1464"/>
+      <point x="215" y="1464" type="curve" smooth="yes"/>
+      <point x="168" y="1464"/>
+      <point x="84" y="1438"/>
+      <point x="84" y="1317" type="curve" smooth="yes"/>
+      <point x="84" y="1235"/>
+      <point x="139" y="1171"/>
+      <point x="229" y="1171" type="curve" smooth="yes"/>
+      <point x="244" y="1171"/>
+      <point x="258" y="1174"/>
+      <point x="268" y="1176" type="curve"/>
+      <point x="266" y="1212" type="line"/>
+      <point x="258" y="1210"/>
+      <point x="242" y="1208"/>
+      <point x="229" y="1208" type="curve" smooth="yes"/>
+      <point x="193" y="1208"/>
+      <point x="180" y="1241"/>
+      <point x="180" y="1264" type="curve" smooth="yes"/>
+      <point x="180" y="1290"/>
+      <point x="199" y="1319"/>
+      <point x="238" y="1319" type="curve" smooth="yes"/>
+      <point x="283" y="1319"/>
+      <point x="379" y="1280"/>
+      <point x="414" y="1260" type="curve"/>
+      <point x="381" y="965" type="line"/>
+      <point x="254" y="942"/>
+      <point x="111" y="887"/>
+      <point x="111" y="756" type="curve" smooth="yes"/>
+      <point x="111" y="645"/>
+      <point x="219" y="594"/>
+      <point x="342" y="571" type="curve"/>
+      <point x="328" y="426"/>
+      <point x="319" y="295"/>
+      <point x="319" y="240" type="curve" smooth="yes"/>
+      <point x="319" y="104"/>
+      <point x="375" y="-20"/>
     </contour>
     <contour>
-      <point x="265" y="20" type="curve" smooth="yes"/>
-      <point x="228" y="20"/>
-      <point x="208" y="58"/>
-      <point x="208" y="115" type="curve" smooth="yes"/>
-      <point x="208" y="146"/>
-      <point x="210" y="206"/>
-      <point x="212" y="273" type="curve"/>
-      <point x="237" y="270"/>
-      <point x="261" y="270"/>
-      <point x="282" y="270" type="curve" smooth="yes"/>
-      <point x="292" y="270"/>
-      <point x="303" y="270"/>
-      <point x="314" y="271" type="curve"/>
-      <point x="317" y="195"/>
-      <point x="321" y="132"/>
-      <point x="321" y="115" type="curve" smooth="yes"/>
-      <point x="321" y="58"/>
-      <point x="301" y="20"/>
+      <point x="543" y="41" type="curve" smooth="yes"/>
+      <point x="467" y="41"/>
+      <point x="426" y="119"/>
+      <point x="426" y="236" type="curve" smooth="yes"/>
+      <point x="426" y="299"/>
+      <point x="430" y="422"/>
+      <point x="434" y="559" type="curve"/>
+      <point x="485" y="553"/>
+      <point x="535" y="553"/>
+      <point x="578" y="553" type="curve" smooth="yes"/>
+      <point x="598" y="553"/>
+      <point x="621" y="553"/>
+      <point x="643" y="555" type="curve"/>
+      <point x="649" y="399"/>
+      <point x="657" y="270"/>
+      <point x="657" y="236" type="curve" smooth="yes"/>
+      <point x="657" y="119"/>
+      <point x="616" y="41"/>
     </contour>
     <contour>
-      <point x="169" y="299" type="line"/>
-      <point x="89" y="318"/>
-      <point x="79" y="358"/>
-      <point x="79" y="372" type="curve" smooth="yes"/>
-      <point x="79" y="384"/>
-      <point x="85" y="434"/>
-      <point x="184" y="453" type="curve"/>
+      <point x="346" y="612" type="line"/>
+      <point x="182" y="651"/>
+      <point x="162" y="733"/>
+      <point x="162" y="762" type="curve" smooth="yes"/>
+      <point x="162" y="786"/>
+      <point x="174" y="889"/>
+      <point x="377" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="281" y="288" type="curve" smooth="yes"/>
-      <point x="254" y="288"/>
-      <point x="233" y="289"/>
-      <point x="213" y="291" type="curve"/>
-      <point x="219" y="458" type="line"/>
-      <point x="234" y="459"/>
-      <point x="251" y="460"/>
-      <point x="270" y="460" type="curve" smooth="yes"/>
-      <point x="282" y="460"/>
-      <point x="293" y="459"/>
-      <point x="305" y="459" type="curve"/>
-      <point x="313" y="289" type="line"/>
-      <point x="302" y="288"/>
-      <point x="292" y="288"/>
+      <point x="575" y="590" type="curve" smooth="yes"/>
+      <point x="520" y="590"/>
+      <point x="477" y="592"/>
+      <point x="436" y="596" type="curve"/>
+      <point x="449" y="938" type="line"/>
+      <point x="479" y="940"/>
+      <point x="514" y="942"/>
+      <point x="553" y="942" type="curve" smooth="yes"/>
+      <point x="578" y="942"/>
+      <point x="600" y="940"/>
+      <point x="625" y="940" type="curve"/>
+      <point x="641" y="592" type="line"/>
+      <point x="618" y="590"/>
+      <point x="598" y="590"/>
     </contour>
     <contour>
-      <point x="356" y="295" type="curve"/>
-      <point x="337" y="457" type="line"/>
-      <point x="397" y="452"/>
-      <point x="457" y="439"/>
-      <point x="499" y="414" type="curve"/>
-      <point x="476" y="351"/>
-      <point x="428" y="311"/>
+      <point x="729" y="604" type="curve"/>
+      <point x="690" y="936" type="line"/>
+      <point x="813" y="926"/>
+      <point x="936" y="899"/>
+      <point x="1022" y="848" type="curve"/>
+      <point x="975" y="719"/>
+      <point x="877" y="637"/>
     </contour>
     <contour>
-      <point x="504" y="436" type="curve"/>
-      <point x="455" y="460"/>
-      <point x="390" y="471"/>
-      <point x="335" y="475" type="curve"/>
-      <point x="331" y="514"/>
-      <point x="329" y="548"/>
-      <point x="329" y="572" type="curve" smooth="yes"/>
-      <point x="329" y="636"/>
-      <point x="335" y="707"/>
-      <point x="409" y="707" type="curve" smooth="yes"/>
-      <point x="500" y="707"/>
-      <point x="516" y="593"/>
-      <point x="516" y="519" type="curve" smooth="yes"/>
-      <point x="516" y="488"/>
-      <point x="511" y="461"/>
+      <point x="1034" y="893" type="curve"/>
+      <point x="934" y="942"/>
+      <point x="799" y="965"/>
+      <point x="686" y="973" type="curve"/>
+      <point x="678" y="1053"/>
+      <point x="674" y="1122"/>
+      <point x="674" y="1171" type="curve" smooth="yes"/>
+      <point x="674" y="1303"/>
+      <point x="686" y="1448"/>
+      <point x="838" y="1448" type="curve" smooth="yes"/>
+      <point x="1024" y="1448"/>
+      <point x="1057" y="1214"/>
+      <point x="1057" y="1063" type="curve" smooth="yes"/>
+      <point x="1057" y="999"/>
+      <point x="1049" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:16 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Light.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-Light.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="904"/>
+  <unicode hex="214E"/>
+  <anchor x="1346" y="-824" name="bottom"/>
+  <anchor x="923" y="-407" name="bottom_dd"/>
+  <anchor x="1290" y="-2134" name="parent_top"/>
+  <anchor x="1290" y="-2134" name="top"/>
+  <anchor x="923" y="-2134" name="top0315"/>
+  <anchor x="923" y="-2414" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="620" y="0" type="line"/>
+      <point x="731" y="0" type="line"/>
+      <point x="731" y="1082" type="line"/>
+      <point x="620" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="75" y="0" type="line"/>
+      <point x="653" y="0" type="line"/>
+      <point x="653" y="105" type="line"/>
+      <point x="75" y="105" type="line"/>
+    </contour>
+    <contour>
+      <point x="145" y="529" type="line"/>
+      <point x="653" y="529" type="line"/>
+      <point x="653" y="633" type="line"/>
+      <point x="145" y="633" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:16 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Light.ufo/lib.plist
+++ b/sources/RobotoCondensed-Light.ufo/lib.plist
@@ -6898,6 +6898,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-LightItalic.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-LightItalic.ufo/fontinfo.plist
@@ -379,7 +379,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/contents.plist
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="868"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="28" y="0" type="line"/>
+      <point x="317" y="0" type="line" smooth="yes"/>
+      <point x="577" y="0"/>
+      <point x="726" y="223"/>
+      <point x="726" y="475" type="curve" smooth="yes"/>
+      <point x="726" y="625"/>
+      <point x="652" y="717"/>
+      <point x="550" y="748" type="curve"/>
+      <point x="550" y="754" type="line"/>
+      <point x="740" y="805"/>
+      <point x="853" y="1001"/>
+      <point x="845" y="1169" type="curve" smooth="yes"/>
+      <point x="835" y="1380"/>
+      <point x="724" y="1462"/>
+      <point x="550" y="1462" type="curve" smooth="yes"/>
+      <point x="317" y="1462" type="line"/>
+    </contour>
+    <contour>
+      <point x="108" y="-201" type="line"/>
+      <point x="180" y="-201" type="line"/>
+      <point x="238" y="74" type="line"/>
+      <point x="166" y="74" type="line"/>
+    </contour>
+    <contour>
+      <point x="292" y="-201" type="line"/>
+      <point x="364" y="-201" type="line"/>
+      <point x="418" y="60" type="line"/>
+      <point x="346" y="60" type="line"/>
+    </contour>
+    <contour>
+      <point x="146" y="102" type="line"/>
+      <point x="270" y="714" type="line"/>
+      <point x="410" y="714" type="line" smooth="yes"/>
+      <point x="538" y="714"/>
+      <point x="612" y="596"/>
+      <point x="612" y="457" type="curve" smooth="yes"/>
+      <point x="612" y="287"/>
+      <point x="550" y="102"/>
+      <point x="310" y="102" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="296" y="814" type="line"/>
+      <point x="408" y="1360" type="line"/>
+      <point x="513" y="1360" type="line" smooth="yes"/>
+      <point x="665" y="1360"/>
+      <point x="731" y="1302"/>
+      <point x="731" y="1149" type="curve" smooth="yes"/>
+      <point x="731" y="991"/>
+      <point x="593" y="814"/>
+      <point x="429" y="814" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="451" y="1409" type="line"/>
+      <point x="523" y="1409" type="line"/>
+      <point x="579" y="1669" type="line"/>
+      <point x="507" y="1669" type="line"/>
+    </contour>
+    <contour>
+      <point x="624" y="1358" type="line"/>
+      <point x="696" y="1358" type="line"/>
+      <point x="763" y="1669" type="line"/>
+      <point x="692" y="1669" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2104.glif
@@ -1,53 +1,53 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2104" format="2">
-  <advance width="943"/>
+  <advance width="913"/>
   <unicode hex="2104"/>
   <outline>
     <contour>
-      <point x="281" y="0" type="line"/>
-      <point x="779" y="0" type="line"/>
-      <point x="798" y="100" type="line"/>
-      <point x="411" y="100" type="line"/>
-      <point x="458" y="395" type="line"/>
-      <point x="502" y="403"/>
-      <point x="542" y="418"/>
-      <point x="577" y="440" type="curve"/>
-      <point x="594" y="546" type="line"/>
-      <point x="555" y="523"/>
-      <point x="516" y="506"/>
-      <point x="475" y="496" type="curve"/>
-      <point x="584" y="1118" type="line"/>
-      <point x="612" y="1112"/>
-      <point x="643" y="1099"/>
-      <point x="670" y="1083" type="curve"/>
-      <point x="713" y="1174" type="line"/>
-      <point x="680" y="1194"/>
-      <point x="639" y="1208"/>
-      <point x="595" y="1214" type="curve"/>
-      <point x="637" y="1462" type="line"/>
-      <point x="526" y="1462" type="line"/>
-      <point x="483" y="1208" type="line"/>
-      <point x="334" y="1171"/>
-      <point x="224" y="1030"/>
-      <point x="186" y="801" type="curve" smooth="yes"/>
-      <point x="147" y="569"/>
-      <point x="206" y="428"/>
-      <point x="347" y="397" type="curve"/>
+      <point x="241" y="0" type="line"/>
+      <point x="749" y="0" type="line"/>
+      <point x="756" y="106" type="line"/>
+      <point x="369" y="106" type="line"/>
+      <point x="417" y="395" type="line"/>
+      <point x="461" y="403"/>
+      <point x="501" y="418"/>
+      <point x="536" y="440" type="curve"/>
+      <point x="551" y="531" type="line"/>
+      <point x="512" y="508"/>
+      <point x="472" y="492"/>
+      <point x="432" y="482" type="curve"/>
+      <point x="539" y="1126" type="line"/>
+      <point x="567" y="1120"/>
+      <point x="598" y="1107"/>
+      <point x="626" y="1091" type="curve"/>
+      <point x="672" y="1174" type="line"/>
+      <point x="639" y="1194"/>
+      <point x="598" y="1208"/>
+      <point x="554" y="1214" type="curve"/>
+      <point x="596" y="1462" type="line"/>
+      <point x="486" y="1462" type="line"/>
+      <point x="443" y="1208" type="line"/>
+      <point x="294" y="1171"/>
+      <point x="197" y="1038"/>
+      <point x="158" y="809" type="curve" smooth="yes"/>
+      <point x="120" y="577"/>
+      <point x="166" y="428"/>
+      <point x="307" y="397" type="curve"/>
     </contour>
     <contour>
-      <point x="366" y="506" type="line"/>
-      <point x="302" y="543"/>
-      <point x="276" y="650"/>
-      <point x="301" y="800" type="curve" smooth="yes"/>
-      <point x="328" y="960"/>
-      <point x="395" y="1071"/>
-      <point x="471" y="1108" type="curve"/>
+      <point x="323" y="492" type="line"/>
+      <point x="260" y="529"/>
+      <point x="219" y="621"/>
+      <point x="249" y="801" type="curve" smooth="yes"/>
+      <point x="281" y="991"/>
+      <point x="352" y="1079"/>
+      <point x="428" y="1116" type="curve"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="943"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="281" y="0" type="line"/>
+      <point x="779" y="0" type="line"/>
+      <point x="798" y="100" type="line"/>
+      <point x="411" y="100" type="line"/>
+      <point x="458" y="395" type="line"/>
+      <point x="502" y="403"/>
+      <point x="542" y="418"/>
+      <point x="577" y="440" type="curve"/>
+      <point x="594" y="546" type="line"/>
+      <point x="555" y="523"/>
+      <point x="516" y="506"/>
+      <point x="475" y="496" type="curve"/>
+      <point x="584" y="1118" type="line"/>
+      <point x="612" y="1112"/>
+      <point x="643" y="1099"/>
+      <point x="670" y="1083" type="curve"/>
+      <point x="713" y="1174" type="line"/>
+      <point x="680" y="1194"/>
+      <point x="639" y="1208"/>
+      <point x="595" y="1214" type="curve"/>
+      <point x="637" y="1462" type="line"/>
+      <point x="526" y="1462" type="line"/>
+      <point x="483" y="1208" type="line"/>
+      <point x="334" y="1171"/>
+      <point x="224" y="1030"/>
+      <point x="186" y="801" type="curve" smooth="yes"/>
+      <point x="147" y="569"/>
+      <point x="206" y="428"/>
+      <point x="347" y="397" type="curve"/>
+    </contour>
+    <contour>
+      <point x="366" y="506" type="line"/>
+      <point x="302" y="543"/>
+      <point x="276" y="650"/>
+      <point x="301" y="800" type="curve" smooth="yes"/>
+      <point x="328" y="960"/>
+      <point x="395" y="1071"/>
+      <point x="471" y="1108" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="936"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1146"/>
+  <unicode hex="2108"/>
+  <anchor x="761.627" y="1634" name="parent_top"/>
+  <anchor x="761.627" y="1634" name="top"/>
+  <anchor x="1304.827" y="1634" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="479.529" y="-20.323" type="curve" smooth="yes"/>
+      <point x="828.425" y="-28.833"/>
+      <point x="988.672" y="347.544"/>
+      <point x="1033.783" y="637.238" type="curve" smooth="yes"/>
+      <point x="1061.568" y="818.284" type="line" smooth="yes"/>
+      <point x="1097.53" y="1084.108"/>
+      <point x="1045.587" y="1466.868"/>
+      <point x="705.842" y="1476.298" type="curve" smooth="yes"/>
+      <point x="417.669" y="1484.297"/>
+      <point x="261.062" y="1257.303"/>
+      <point x="206.387" y="1000.44" type="curve"/>
+      <point x="317.547" y="1001.15" type="line"/>
+      <point x="370.273" y="1194.426"/>
+      <point x="472.453" y="1378.498"/>
+      <point x="699.457" y="1370.267" type="curve" smooth="yes"/>
+      <point x="970.827" y="1360.428"/>
+      <point x="974.795" y="1018.018"/>
+      <point x="947.721" y="821.077" type="curve" smooth="yes"/>
+      <point x="919.412" y="636.823" type="line" smooth="yes"/>
+      <point x="884.002" y="410.594"/>
+      <point x="769.682" y="77.956"/>
+      <point x="487.019" y="86.371" type="curve" smooth="yes"/>
+      <point x="271.472" y="92.788"/>
+      <point x="221.257" y="266.678"/>
+      <point x="223.589" y="454.405" type="curve"/>
+      <point x="110.805" y="454.467" type="line"/>
+      <point x="103.476" y="207.297"/>
+      <point x="205.667" y="-13.644"/>
+    </contour>
+    <contour>
+      <point x="941.261" y="678.079" type="line"/>
+      <point x="960.444" y="784.915" type="line"/>
+      <point x="454.138" y="784.92" type="line"/>
+      <point x="434.954" y="678.084" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2108.glif
@@ -37,10 +37,10 @@
       <point x="205.667" y="-13.644"/>
     </contour>
     <contour>
-      <point x="941.261" y="678.079" type="line"/>
-      <point x="960.444" y="784.915" type="line"/>
-      <point x="454.138" y="784.92" type="line"/>
       <point x="434.954" y="678.084" type="line"/>
+      <point x="971" y="678" type="line"/>
+      <point x="990" y="785" type="line"/>
+      <point x="454.138" y="784.92" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1446"/>
+  <unicode hex="2114"/>
+  <anchor x="876.063" y="-10" name="bottom"/>
+  <anchor x="1251.728" y="-407" name="bottom_dd"/>
+  <anchor x="644.415" y="1522" name="marktop"/>
+  <anchor x="1170.865" y="1612" name="parent_top"/>
+  <anchor x="1170.865" y="1612" name="top"/>
+  <anchor x="1600.575" y="1612" name="top0315"/>
+  <anchor x="1598.502" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="911" y="-21" type="curve" smooth="yes"/>
+      <point x="1197" y="-31"/>
+      <point x="1292" y="257"/>
+      <point x="1324" y="491" type="curve" smooth="yes"/>
+      <point x="1337" y="591" type="line" smooth="yes"/>
+      <point x="1362" y="806"/>
+      <point x="1349" y="1096"/>
+      <point x="1072" y="1103" type="curve" smooth="yes"/>
+      <point x="845" y="1109"/>
+      <point x="715" y="894"/>
+      <point x="676" y="694" type="curve" smooth="yes"/>
+      <point x="627" y="370" type="line"/>
+      <point x="616" y="182"/>
+      <point x="704" y="-14"/>
+    </contour>
+    <contour>
+      <point x="87" y="0" type="line"/>
+      <point x="197" y="0" type="line"/>
+      <point x="464" y="1536" type="line"/>
+      <point x="354" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="517" y="0" type="line"/>
+      <point x="620" y="0" type="line"/>
+      <point x="663" y="204" type="line"/>
+      <point x="895" y="1536" type="line"/>
+      <point x="784" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="895" y="86" type="curve" smooth="yes"/>
+      <point x="759" y="91"/>
+      <point x="662" y="206"/>
+      <point x="666" y="343" type="curve"/>
+      <point x="726" y="715" type="line"/>
+      <point x="763" y="862"/>
+      <point x="883" y="1002"/>
+      <point x="1043" y="998" type="curve" smooth="yes"/>
+      <point x="1259" y="994"/>
+      <point x="1244" y="749"/>
+      <point x="1226" y="592" type="curve" smooth="yes"/>
+      <point x="1214" y="490" type="line" smooth="yes"/>
+      <point x="1190" y="305"/>
+      <point x="1123" y="77"/>
+    </contour>
+    <contour>
+      <point x="1058" y="1256" type="line"/>
+      <point x="1076" y="1360" type="line"/>
+      <point x="175.107" y="1359.925" type="line"/>
+      <point x="156.464" y="1256.08" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2114.glif
@@ -56,16 +56,16 @@
       <point x="1123" y="77"/>
     </contour>
     <contour>
+      <point x="156.464" y="1256.08" type="line"/>
       <point x="1058" y="1256" type="line"/>
       <point x="1076" y="1360" type="line"/>
       <point x="175.107" y="1359.925" type="line"/>
-      <point x="156.464" y="1256.08" type="line"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="807"/>
+  <advance width="1534"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="179" y="-241" type="curve" smooth="yes"/>
-      <point x="249" y="-241"/>
-      <point x="296" y="-180"/>
-      <point x="296" y="-95" type="curve" smooth="yes"/>
-      <point x="296" y="8"/>
-      <point x="204" y="99"/>
-      <point x="147" y="200" type="curve"/>
-      <point x="194" y="272"/>
-      <point x="254" y="341"/>
-      <point x="316" y="394" type="curve" smooth="yes"/>
-      <point x="384" y="452"/>
-      <point x="455" y="492"/>
-      <point x="514" y="492" type="curve" smooth="yes"/>
-      <point x="616" y="492"/>
-      <point x="624" y="359"/>
-      <point x="624" y="322" type="curve" smooth="yes"/>
-      <point x="624" y="285"/>
-      <point x="611" y="30"/>
-      <point x="447" y="30" type="curve" smooth="yes"/>
-      <point x="396" y="30"/>
-      <point x="347" y="57"/>
-      <point x="347" y="112" type="curve" smooth="yes"/>
-      <point x="347" y="119"/>
-      <point x="348" y="126"/>
-      <point x="350" y="132" type="curve"/>
-      <point x="382" y="136"/>
-      <point x="415" y="151"/>
-      <point x="415" y="194" type="curve" smooth="yes"/>
-      <point x="415" y="225"/>
-      <point x="394" y="244"/>
-      <point x="363" y="244" type="curve" smooth="yes"/>
-      <point x="315" y="244"/>
-      <point x="285" y="206"/>
-      <point x="285" y="140" type="curve" smooth="yes"/>
-      <point x="285" y="51"/>
-      <point x="349" y="-10"/>
-      <point x="455" y="-10" type="curve" smooth="yes"/>
-      <point x="633" y="-10"/>
-      <point x="726" y="159"/>
-      <point x="726" y="306" type="curve" smooth="yes"/>
-      <point x="726" y="437"/>
-      <point x="666" y="549"/>
-      <point x="544" y="549" type="curve" smooth="yes"/>
-      <point x="494" y="549"/>
-      <point x="398" y="512"/>
-      <point x="292" y="419" type="curve" smooth="yes"/>
-      <point x="240" y="373"/>
-      <point x="179" y="310"/>
-      <point x="127" y="238" type="curve"/>
-      <point x="112" y="272"/>
-      <point x="103" y="307"/>
-      <point x="103" y="345" type="curve" smooth="yes"/>
-      <point x="103" y="474"/>
-      <point x="133" y="548"/>
-      <point x="214" y="625" type="curve"/>
-      <point x="198" y="647" type="line"/>
-      <point x="139" y="610"/>
-      <point x="15" y="496"/>
-      <point x="15" y="337" type="curve" smooth="yes"/>
-      <point x="15" y="267"/>
-      <point x="39" y="206"/>
-      <point x="71" y="149" type="curve"/>
-      <point x="36" y="85"/>
-      <point x="10" y="11"/>
-      <point x="10" y="-56" type="curve" smooth="yes"/>
-      <point x="10" y="-163"/>
-      <point x="84" y="-241"/>
+      <point x="401" y="-494" type="curve" smooth="yes"/>
+      <point x="538" y="-494"/>
+      <point x="632" y="-369"/>
+      <point x="632" y="-195" type="curve" smooth="yes"/>
+      <point x="632" y="16"/>
+      <point x="450" y="203"/>
+      <point x="337" y="410" type="curve"/>
+      <point x="432" y="557"/>
+      <point x="552" y="698"/>
+      <point x="673" y="807" type="curve" smooth="yes"/>
+      <point x="806" y="926"/>
+      <point x="948" y="1008"/>
+      <point x="1066" y="1008" type="curve" smooth="yes"/>
+      <point x="1269" y="1008"/>
+      <point x="1284" y="735"/>
+      <point x="1284" y="659" type="curve" smooth="yes"/>
+      <point x="1284" y="584"/>
+      <point x="1259" y="61"/>
+      <point x="933" y="61" type="curve" smooth="yes"/>
+      <point x="831" y="61"/>
+      <point x="733" y="117"/>
+      <point x="733" y="229" type="curve" smooth="yes"/>
+      <point x="733" y="244"/>
+      <point x="735" y="258"/>
+      <point x="739" y="270" type="curve"/>
+      <point x="804" y="279"/>
+      <point x="870" y="309"/>
+      <point x="870" y="397" type="curve" smooth="yes"/>
+      <point x="870" y="461"/>
+      <point x="827" y="500"/>
+      <point x="765" y="500" type="curve" smooth="yes"/>
+      <point x="669" y="500"/>
+      <point x="612" y="422"/>
+      <point x="612" y="287" type="curve" smooth="yes"/>
+      <point x="612" y="104"/>
+      <point x="737" y="-20"/>
+      <point x="948" y="-20" type="curve" smooth="yes"/>
+      <point x="1300" y="-20"/>
+      <point x="1486" y="326"/>
+      <point x="1486" y="627" type="curve" smooth="yes"/>
+      <point x="1486" y="895"/>
+      <point x="1365" y="1124"/>
+      <point x="1126" y="1124" type="curve" smooth="yes"/>
+      <point x="1025" y="1124"/>
+      <point x="837" y="1049"/>
+      <point x="626" y="858" type="curve" smooth="yes"/>
+      <point x="522" y="764"/>
+      <point x="401" y="635"/>
+      <point x="298" y="487" type="curve"/>
+      <point x="268" y="557"/>
+      <point x="249" y="629"/>
+      <point x="249" y="707" type="curve" smooth="yes"/>
+      <point x="249" y="971"/>
+      <point x="309" y="1122"/>
+      <point x="468" y="1280" type="curve"/>
+      <point x="438" y="1325" type="line"/>
+      <point x="321" y="1249"/>
+      <point x="75" y="1016"/>
+      <point x="75" y="690" type="curve" smooth="yes"/>
+      <point x="75" y="547"/>
+      <point x="122" y="422"/>
+      <point x="186" y="305" type="curve"/>
+      <point x="116" y="174"/>
+      <point x="65" y="23"/>
+      <point x="65" y="-115" type="curve" smooth="yes"/>
+      <point x="65" y="-334"/>
+      <point x="210" y="-494"/>
     </contour>
     <contour>
-      <point x="161" y="-199" type="curve" smooth="yes"/>
-      <point x="117" y="-199"/>
-      <point x="50" y="-145"/>
-      <point x="50" y="-51" type="curve" smooth="yes"/>
-      <point x="50" y="-4"/>
-      <point x="66" y="52"/>
-      <point x="94" y="110" type="curve"/>
-      <point x="148" y="24"/>
-      <point x="209" y="-52"/>
-      <point x="209" y="-134" type="curve" smooth="yes"/>
-      <point x="209" y="-176"/>
-      <point x="190" y="-199"/>
+      <point x="366" y="-408" type="curve" smooth="yes"/>
+      <point x="276" y="-408"/>
+      <point x="145" y="-297"/>
+      <point x="145" y="-104" type="curve" smooth="yes"/>
+      <point x="145" y="-8"/>
+      <point x="178" y="106"/>
+      <point x="233" y="225" type="curve"/>
+      <point x="337" y="49"/>
+      <point x="460" y="-106"/>
+      <point x="460" y="-274" type="curve" smooth="yes"/>
+      <point x="460" y="-360"/>
+      <point x="423" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="807"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="179" y="-241" type="curve" smooth="yes"/>
+      <point x="249" y="-241"/>
+      <point x="296" y="-180"/>
+      <point x="296" y="-95" type="curve" smooth="yes"/>
+      <point x="296" y="8"/>
+      <point x="204" y="99"/>
+      <point x="147" y="200" type="curve"/>
+      <point x="194" y="272"/>
+      <point x="254" y="341"/>
+      <point x="316" y="394" type="curve" smooth="yes"/>
+      <point x="384" y="452"/>
+      <point x="455" y="492"/>
+      <point x="514" y="492" type="curve" smooth="yes"/>
+      <point x="616" y="492"/>
+      <point x="624" y="359"/>
+      <point x="624" y="322" type="curve" smooth="yes"/>
+      <point x="624" y="285"/>
+      <point x="611" y="30"/>
+      <point x="447" y="30" type="curve" smooth="yes"/>
+      <point x="396" y="30"/>
+      <point x="347" y="57"/>
+      <point x="347" y="112" type="curve" smooth="yes"/>
+      <point x="347" y="119"/>
+      <point x="348" y="126"/>
+      <point x="350" y="132" type="curve"/>
+      <point x="382" y="136"/>
+      <point x="415" y="151"/>
+      <point x="415" y="194" type="curve" smooth="yes"/>
+      <point x="415" y="225"/>
+      <point x="394" y="244"/>
+      <point x="363" y="244" type="curve" smooth="yes"/>
+      <point x="315" y="244"/>
+      <point x="285" y="206"/>
+      <point x="285" y="140" type="curve" smooth="yes"/>
+      <point x="285" y="51"/>
+      <point x="349" y="-10"/>
+      <point x="455" y="-10" type="curve" smooth="yes"/>
+      <point x="633" y="-10"/>
+      <point x="726" y="159"/>
+      <point x="726" y="306" type="curve" smooth="yes"/>
+      <point x="726" y="437"/>
+      <point x="666" y="549"/>
+      <point x="544" y="549" type="curve" smooth="yes"/>
+      <point x="494" y="549"/>
+      <point x="398" y="512"/>
+      <point x="292" y="419" type="curve" smooth="yes"/>
+      <point x="240" y="373"/>
+      <point x="179" y="310"/>
+      <point x="127" y="238" type="curve"/>
+      <point x="112" y="272"/>
+      <point x="103" y="307"/>
+      <point x="103" y="345" type="curve" smooth="yes"/>
+      <point x="103" y="474"/>
+      <point x="133" y="548"/>
+      <point x="214" y="625" type="curve"/>
+      <point x="198" y="647" type="line"/>
+      <point x="139" y="610"/>
+      <point x="15" y="496"/>
+      <point x="15" y="337" type="curve" smooth="yes"/>
+      <point x="15" y="267"/>
+      <point x="39" y="206"/>
+      <point x="71" y="149" type="curve"/>
+      <point x="36" y="85"/>
+      <point x="10" y="11"/>
+      <point x="10" y="-56" type="curve" smooth="yes"/>
+      <point x="10" y="-163"/>
+      <point x="84" y="-241"/>
+    </contour>
+    <contour>
+      <point x="161" y="-199" type="curve" smooth="yes"/>
+      <point x="117" y="-199"/>
+      <point x="50" y="-145"/>
+      <point x="50" y="-51" type="curve" smooth="yes"/>
+      <point x="50" y="-4"/>
+      <point x="66" y="52"/>
+      <point x="94" y="110" type="curve"/>
+      <point x="148" y="24"/>
+      <point x="209" y="-52"/>
+      <point x="209" y="-134" type="curve" smooth="yes"/>
+      <point x="209" y="-176"/>
+      <point x="190" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1135"/>
+  <unicode hex="2127"/>
+  <anchor x="755.491" y="1446" name="top"/>
+  <outline>
+    <contour>
+      <point x="522" y="-20" type="curve" smooth="yes"/>
+      <point x="858" y="-30"/>
+      <point x="1019" y="332"/>
+      <point x="1061" y="612" type="curve" smooth="yes"/>
+      <point x="1078" y="727" type="line" smooth="yes"/>
+      <point x="1110" y="966"/>
+      <point x="1083" y="1332"/>
+      <point x="818" y="1435" type="curve"/>
+      <point x="805" y="1334" type="line"/>
+      <point x="1013" y="1236"/>
+      <point x="987" y="913"/>
+      <point x="962" y="728" type="curve" smooth="yes"/>
+      <point x="945" y="610" type="line" smooth="yes"/>
+      <point x="913" y="394"/>
+      <point x="799" y="76"/>
+      <point x="529" y="86" type="curve" smooth="yes"/>
+      <point x="274" y="96"/>
+      <point x="268" y="422"/>
+      <point x="292" y="608" type="curve" smooth="yes"/>
+      <point x="309" y="727" type="line" smooth="yes"/>
+      <point x="344" y="967"/>
+      <point x="434" y="1237"/>
+      <point x="678" y="1336" type="curve"/>
+      <point x="690" y="1437" type="line"/>
+      <point x="385" y="1350"/>
+      <point x="238" y="1016"/>
+      <point x="194" y="727" type="curve" smooth="yes"/>
+      <point x="177" y="612" type="line" smooth="yes"/>
+      <point x="144" y="359"/>
+      <point x="199" y="-11"/>
+    </contour>
+    <contour>
+      <point x="298" y="1349" type="line"/>
+      <point x="679" y="1349" type="line"/>
+      <point x="698" y="1456" type="line"/>
+      <point x="318" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="806" y="1349" type="line"/>
+      <point x="1190" y="1349" type="line"/>
+      <point x="1209" y="1456" type="line"/>
+      <point x="825" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2127.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1135"/>
+  <advance width="1134"/>
   <unicode hex="2127"/>
-  <anchor x="755.491" y="1446" name="top"/>
+  <anchor x="711" y="1446" name="top"/>
   <outline>
     <contour>
-      <point x="522" y="-20" type="curve" smooth="yes"/>
-      <point x="858" y="-30"/>
-      <point x="1019" y="332"/>
-      <point x="1061" y="612" type="curve" smooth="yes"/>
-      <point x="1078" y="727" type="line" smooth="yes"/>
-      <point x="1110" y="966"/>
-      <point x="1083" y="1332"/>
-      <point x="818" y="1435" type="curve"/>
-      <point x="805" y="1334" type="line"/>
-      <point x="1013" y="1236"/>
-      <point x="987" y="913"/>
-      <point x="962" y="728" type="curve" smooth="yes"/>
-      <point x="945" y="610" type="line" smooth="yes"/>
-      <point x="913" y="394"/>
-      <point x="799" y="76"/>
-      <point x="529" y="86" type="curve" smooth="yes"/>
-      <point x="274" y="96"/>
-      <point x="268" y="422"/>
-      <point x="292" y="608" type="curve" smooth="yes"/>
-      <point x="309" y="727" type="line" smooth="yes"/>
-      <point x="344" y="967"/>
-      <point x="434" y="1237"/>
-      <point x="678" y="1336" type="curve"/>
-      <point x="690" y="1437" type="line"/>
-      <point x="385" y="1350"/>
-      <point x="238" y="1016"/>
-      <point x="194" y="727" type="curve" smooth="yes"/>
-      <point x="177" y="612" type="line" smooth="yes"/>
-      <point x="144" y="359"/>
-      <point x="199" y="-11"/>
+      <point x="478" y="-20" type="curve" smooth="yes"/>
+      <point x="814" y="-30"/>
+      <point x="975" y="332"/>
+      <point x="1017" y="612" type="curve" smooth="yes"/>
+      <point x="1034" y="727" type="line" smooth="yes"/>
+      <point x="1066" y="966"/>
+      <point x="1039" y="1332"/>
+      <point x="774" y="1435" type="curve"/>
+      <point x="761" y="1334" type="line"/>
+      <point x="969" y="1236"/>
+      <point x="943" y="913"/>
+      <point x="918" y="728" type="curve" smooth="yes"/>
+      <point x="901" y="610" type="line" smooth="yes"/>
+      <point x="869" y="394"/>
+      <point x="755" y="76"/>
+      <point x="485" y="86" type="curve" smooth="yes"/>
+      <point x="230" y="96"/>
+      <point x="224" y="422"/>
+      <point x="248" y="608" type="curve" smooth="yes"/>
+      <point x="265" y="727" type="line" smooth="yes"/>
+      <point x="300" y="967"/>
+      <point x="390" y="1237"/>
+      <point x="634" y="1336" type="curve"/>
+      <point x="646" y="1437" type="line"/>
+      <point x="341" y="1350"/>
+      <point x="194" y="1016"/>
+      <point x="150" y="727" type="curve" smooth="yes"/>
+      <point x="133" y="612" type="line" smooth="yes"/>
+      <point x="100" y="359"/>
+      <point x="155" y="-11"/>
     </contour>
     <contour>
-      <point x="298" y="1349" type="line"/>
-      <point x="679" y="1349" type="line"/>
-      <point x="698" y="1456" type="line"/>
-      <point x="318" y="1456" type="line"/>
+      <point x="254" y="1349" type="line"/>
+      <point x="635" y="1349" type="line"/>
+      <point x="654" y="1456" type="line"/>
+      <point x="274" y="1456" type="line"/>
     </contour>
     <contour>
-      <point x="806" y="1349" type="line"/>
-      <point x="1190" y="1349" type="line"/>
-      <point x="1209" y="1456" type="line"/>
-      <point x="825" y="1456" type="line"/>
+      <point x="762" y="1349" type="line"/>
+      <point x="1146" y="1349" type="line"/>
+      <point x="1165" y="1456" type="line"/>
+      <point x="781" y="1456" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="547"/>
+  <unicode hex="2129"/>
+  <anchor x="202.429" y="-196" name="bottom"/>
+  <anchor x="-98.271" y="-196" name="bottom0315"/>
+  <anchor x="202.429" y="-196" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="181" y="-9" type="line"/>
+      <point x="292" y="-9" type="line"/>
+      <point x="427" y="799" type="line"/>
+      <point x="438" y="920"/>
+      <point x="426" y="1078"/>
+      <point x="273" y="1081" type="curve" smooth="yes"/>
+      <point x="238" y="1082"/>
+      <point x="204" y="1078"/>
+      <point x="172" y="1067" type="curve"/>
+      <point x="164" y="965" type="line"/>
+      <point x="190" y="969"/>
+      <point x="216" y="974"/>
+      <point x="242" y="973" type="curve" smooth="yes"/>
+      <point x="332" y="971"/>
+      <point x="323" y="867"/>
+      <point x="317" y="802" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2139.glif
@@ -2,13 +2,13 @@
 <glyph name="uni2139" format="2">
   <advance width="419"/>
   <unicode hex="2139"/>
-  <anchor x="107.579" y="10" name="bottom"/>
-  <anchor x="225.648" y="-407" name="bottom_dd"/>
-  <anchor x="386.182" y="1600" name="parent_top"/>
-  <anchor x="232.43" y="654" name="rhotichook"/>
-  <anchor x="386.182" y="1600" name="top"/>
-  <anchor x="572.422" y="1600" name="top0315"/>
-  <anchor x="572.422" y="1600" name="top_dd"/>
+  <anchor x="107.579" y="10.0" name="bottom"/>
+  <anchor x="225.648" y="-407.0" name="bottom_dd"/>
+  <anchor x="386.182" y="1600.0" name="parent_top"/>
+  <anchor x="232.43" y="654.0" name="rhotichook"/>
+  <anchor x="386.182" y="1600.0" name="top"/>
+  <anchor x="572.422" y="1600.0" name="top0315"/>
+  <anchor x="572.422" y="1600.0" name="top_dd"/>
   <outline>
     <component base="i"/>
   </outline>
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="419"/>
+  <unicode hex="2139"/>
+  <anchor x="107.579" y="10" name="bottom"/>
+  <anchor x="225.648" y="-407" name="bottom_dd"/>
+  <anchor x="386.182" y="1600" name="parent_top"/>
+  <anchor x="232.43" y="654" name="rhotichook"/>
+  <anchor x="386.182" y="1600" name="top"/>
+  <anchor x="572.422" y="1600" name="top0315"/>
+  <anchor x="572.422" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni213A_.glif
@@ -1,51 +1,51 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni213A" format="2">
-  <advance width="1790"/>
+  <advance width="1840"/>
   <unicode hex="213A"/>
-  <anchor x="1611.076" y="666.83" name="bottom"/>
-  <anchor x="1915.925" y="1224.179" name="bottom_dd"/>
-  <anchor x="-23.106" y="663.12" name="parent_top"/>
-  <anchor x="-23.106" y="663.12" name="top"/>
-  <anchor x="-120.801" y="1217.173" name="top0315"/>
-  <anchor x="-120.801" y="1217.173" name="top_dd"/>
+  <anchor x="1535" y="667" name="bottom"/>
+  <anchor x="1840" y="1224" name="bottom_dd"/>
+  <anchor x="-99" y="663" name="parent_top"/>
+  <anchor x="-99" y="663" name="top"/>
+  <anchor x="-197" y="1217" name="top0315"/>
+  <anchor x="-197" y="1217" name="top_dd"/>
   <outline>
     <contour>
-      <point x="784" y="204" type="curve" smooth="yes"/>
-      <point x="1102" y="210" type="line" smooth="yes"/>
-      <point x="1378" y="222"/>
-      <point x="1670" y="350"/>
-      <point x="1621" y="673" type="curve" smooth="yes"/>
-      <point x="1570" y="1013"/>
-      <point x="1246" y="1119"/>
-      <point x="942" y="1112" type="curve" smooth="yes"/>
-      <point x="624" y="1107" type="line" smooth="yes"/>
-      <point x="346" y="1095"/>
-      <point x="57" y="968"/>
-      <point x="106" y="644" type="curve" smooth="yes"/>
-      <point x="157" y="306"/>
-      <point x="483" y="197"/>
+      <point x="622" y="179" type="curve"/>
+      <point x="936" y="179" type="line"/>
+      <point x="1351" y="179"/>
+      <point x="1559" y="366"/>
+      <point x="1607" y="651" type="curve" smooth="yes"/>
+      <point x="1656" y="943"/>
+      <point x="1459" y="1122"/>
+      <point x="1094" y="1122" type="curve"/>
+      <point x="780" y="1122" type="line"/>
+      <point x="376" y="1122"/>
+      <point x="159" y="942"/>
+      <point x="110" y="650" type="curve" smooth="yes"/>
+      <point x="62" y="364"/>
+      <point x="258" y="179"/>
     </contour>
     <contour>
-      <point x="762" y="316" type="line" smooth="yes"/>
-      <point x="524" y="310"/>
-      <point x="254" y="383"/>
-      <point x="215" y="655" type="curve" smooth="yes"/>
-      <point x="177" y="916"/>
-      <point x="429" y="986"/>
-      <point x="641" y="995" type="curve" smooth="yes"/>
-      <point x="962" y="1002" type="line" smooth="yes"/>
-      <point x="1204" y="1008"/>
-      <point x="1473" y="938"/>
-      <point x="1512" y="662" type="curve" smooth="yes"/>
-      <point x="1549" y="404"/>
-      <point x="1291" y="333"/>
-      <point x="1083" y="323" type="curve" smooth="yes"/>
+      <point x="639" y="294" type="line" smooth="yes"/>
+      <point x="321" y="294"/>
+      <point x="182" y="425"/>
+      <point x="220" y="650" type="curve" smooth="yes"/>
+      <point x="259" y="882"/>
+      <point x="441" y="1008"/>
+      <point x="759" y="1008" type="curve"/>
+      <point x="1075" y="1008" type="line"/>
+      <point x="1396" y="1008"/>
+      <point x="1536" y="884"/>
+      <point x="1497" y="651" type="curve" smooth="yes"/>
+      <point x="1460" y="427"/>
+      <point x="1276" y="294"/>
+      <point x="955" y="294" type="curve" smooth="yes"/>
     </contour>
     <contour>
-      <point x="1546" y="761" type="line"/>
-      <point x="1795" y="1038" type="line"/>
-      <point x="1707" y="1110" type="line"/>
-      <point x="1456" y="830" type="line"/>
+      <point x="1572" y="757" type="line"/>
+      <point x="1906" y="1040" type="line"/>
+      <point x="1840" y="1119" type="line"/>
+      <point x="1502" y="833" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1790"/>
+  <unicode hex="213A"/>
+  <anchor x="1611.076" y="666.83" name="bottom"/>
+  <anchor x="1915.925" y="1224.179" name="bottom_dd"/>
+  <anchor x="-23.106" y="663.12" name="parent_top"/>
+  <anchor x="-23.106" y="663.12" name="top"/>
+  <anchor x="-120.801" y="1217.173" name="top0315"/>
+  <anchor x="-120.801" y="1217.173" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="784" y="204" type="curve" smooth="yes"/>
+      <point x="1102" y="210" type="line" smooth="yes"/>
+      <point x="1378" y="222"/>
+      <point x="1670" y="350"/>
+      <point x="1621" y="673" type="curve" smooth="yes"/>
+      <point x="1570" y="1013"/>
+      <point x="1246" y="1119"/>
+      <point x="942" y="1112" type="curve" smooth="yes"/>
+      <point x="624" y="1107" type="line" smooth="yes"/>
+      <point x="346" y="1095"/>
+      <point x="57" y="968"/>
+      <point x="106" y="644" type="curve" smooth="yes"/>
+      <point x="157" y="306"/>
+      <point x="483" y="197"/>
+    </contour>
+    <contour>
+      <point x="762" y="316" type="line" smooth="yes"/>
+      <point x="524" y="310"/>
+      <point x="254" y="383"/>
+      <point x="215" y="655" type="curve" smooth="yes"/>
+      <point x="177" y="916"/>
+      <point x="429" y="986"/>
+      <point x="641" y="995" type="curve" smooth="yes"/>
+      <point x="962" y="1002" type="line" smooth="yes"/>
+      <point x="1204" y="1008"/>
+      <point x="1473" y="938"/>
+      <point x="1512" y="662" type="curve" smooth="yes"/>
+      <point x="1549" y="404"/>
+      <point x="1291" y="333"/>
+      <point x="1083" y="323" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1546" y="761" type="line"/>
+      <point x="1795" y="1038" type="line"/>
+      <point x="1707" y="1110" type="line"/>
+      <point x="1456" y="830" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1179"/>
+  <unicode hex="2141"/>
+  <anchor x="504.366" y="-172" name="bottom"/>
+  <anchor x="-78.604" y="-172" name="bottom0315"/>
+  <anchor x="-72.902" y="-139" name="bottom_dd"/>
+  <anchor x="504.366" y="-172" name="parent_bottom"/>
+  <anchor x="750.523" y="1466" name="top"/>
+  <anchor x="273.872" y="1868" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="523" y="-15" type="curve" smooth="yes"/>
+      <point x="863" y="-23"/>
+      <point x="1024" y="260"/>
+      <point x="1069" y="560" type="curve" smooth="yes"/>
+      <point x="1122" y="895" type="line" smooth="yes"/>
+      <point x="1158" y="1173"/>
+      <point x="1068" y="1477"/>
+      <point x="742" y="1482" type="curve" smooth="yes"/>
+      <point x="576" y="1485"/>
+      <point x="404" y="1423"/>
+      <point x="298" y="1291" type="curve"/>
+      <point x="216" y="768" type="line"/>
+      <point x="638" y="768" type="line"/>
+      <point x="657" y="874" type="line"/>
+      <point x="347" y="874" type="line"/>
+      <point x="414" y="1253" type="line"/>
+      <point x="506" y="1332"/>
+      <point x="614" y="1376"/>
+      <point x="737" y="1374" type="curve" smooth="yes"/>
+      <point x="998" y="1370"/>
+      <point x="1035" y="1104"/>
+      <point x="1007" y="896" type="curve" smooth="yes"/>
+      <point x="954" y="558" type="line" smooth="yes"/>
+      <point x="918" y="323"/>
+      <point x="802" y="83"/>
+      <point x="530" y="92" type="curve" smooth="yes"/>
+      <point x="333" y="98"/>
+      <point x="265" y="235"/>
+      <point x="269" y="415" type="curve"/>
+      <point x="155" y="416" type="line"/>
+      <point x="147" y="171"/>
+      <point x="266" y="-9"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="922"/>
+  <unicode hex="2142"/>
+  <anchor x="608.813" y="-117" name="bottom"/>
+  <anchor x="-70.187" y="-117" name="bottom0315"/>
+  <anchor x="-74.852" y="-144" name="bottom_dd"/>
+  <anchor x="608.813" y="-117" name="parent_bottom"/>
+  <anchor x="577.201" y="1446" name="top"/>
+  <anchor x="271.922" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="571" y="0" type="line"/>
+      <point x="686" y="0" type="line"/>
+      <point x="939" y="1456" type="line"/>
+      <point x="824" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="224" y="1349" type="line"/>
+      <point x="838" y="1349" type="line"/>
+      <point x="857" y="1456" type="line"/>
+      <point x="243" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="869"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="518" y="0" type="line"/>
+      <point x="633" y="0" type="line"/>
+      <point x="886" y="1456" type="line"/>
+      <point x="771" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="-62" y="0" type="line"/>
+      <point x="552" y="0" type="line"/>
+      <point x="571" y="107" type="line"/>
+      <point x="-43" y="107" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1039"/>
+  <unicode hex="2144"/>
+  <anchor x="425.125" y="-145" name="bottom"/>
+  <anchor x="-74.425" y="-145" name="bottom0315"/>
+  <anchor x="-74.252" y="-144" name="bottom_dd"/>
+  <anchor x="425.125" y="-145" name="parent_bottom"/>
+  <anchor x="701.855" y="1451" name="top"/>
+  <anchor x="272.522" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="-34" y="0" type="line"/>
+      <point x="103" y="0" type="line"/>
+      <point x="592" y="788" type="line"/>
+      <point x="803" y="0" type="line"/>
+      <point x="930" y="0" type="line"/>
+      <point x="665" y="901" type="line"/>
+      <point x="762" y="1456" type="line"/>
+      <point x="647" y="1456" type="line"/>
+      <point x="553" y="915" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214A_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214A" format="2">
-  <advance width="1071"/>
+  <advance width="1172"/>
   <unicode hex="214A"/>
   <outline>
     <contour>
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1071"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="112" y="300" type="line"/>
+      <point x="226" y="300" type="line"/>
+      <point x="410.054" y="1349.04" type="line"/>
+      <point x="715.176" y="1347.788" type="line" smooth="yes"/>
+      <point x="897.889" y="1340.56"/>
+      <point x="958.477" y="1192.095"/>
+      <point x="939.962" y="1027.31" type="curve" smooth="yes"/>
+      <point x="917.961" y="831.497"/>
+      <point x="790.316" y="698.449"/>
+      <point x="589.108" y="697.463" type="curve" smooth="yes"/>
+      <point x="549" y="698" type="line"/>
+      <point x="534" y="591" type="line"/>
+      <point x="584.702" y="590.7" type="line" smooth="yes"/>
+      <point x="854.262" y="590.413"/>
+      <point x="1029.08" y="762.648"/>
+      <point x="1054.143" y="1028.364" type="curve" smooth="yes"/>
+      <point x="1076.051" y="1260.618"/>
+      <point x="965.729" y="1447.543"/>
+      <point x="718.682" y="1454.846" type="curve" smooth="yes"/>
+      <point x="315.138" y="1455.986" type="line"/>
+    </contour>
+    <contour>
+      <point x="484" y="0" type="line"/>
+      <point x="1008" y="0" type="line"/>
+      <point x="1027" y="107" type="line"/>
+      <point x="503" y="107" type="line"/>
+    </contour>
+    <contour>
+      <point x="402" y="0" type="line"/>
+      <point x="517" y="0" type="line"/>
+      <point x="796" y="1600" type="line"/>
+      <point x="681" y="1600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1067"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="540" y="-19" type="curve" smooth="yes"/>
+      <point x="734" y="-23"/>
+      <point x="840" y="147"/>
+      <point x="855" y="323" type="curve" smooth="yes"/>
+      <point x="869" y="482"/>
+      <point x="790" y="624"/>
+      <point x="716" y="759" type="curve" smooth="yes"/>
+      <point x="339" y="1459" type="line"/>
+      <point x="216" y="1459" type="line"/>
+      <point x="660" y="633" type="line" smooth="yes"/>
+      <point x="711" y="537"/>
+      <point x="758" y="429"/>
+      <point x="746" y="317" type="curve" smooth="yes"/>
+      <point x="734" y="211"/>
+      <point x="672" y="83"/>
+      <point x="548" y="84" type="curve" smooth="yes"/>
+      <point x="452" y="86"/>
+      <point x="409" y="173"/>
+      <point x="417" y="260" type="curve" smooth="yes"/>
+      <point x="426" y="362"/>
+      <point x="492" y="436"/>
+      <point x="568" y="497" type="curve" smooth="yes"/>
+      <point x="785" y="673" type="line" smooth="yes"/>
+      <point x="922" y="783"/>
+      <point x="1061" y="908"/>
+      <point x="1077" y="1095" type="curve" smooth="yes"/>
+      <point x="1095" y="1306"/>
+      <point x="974" y="1474"/>
+      <point x="755" y="1479" type="curve" smooth="yes"/>
+      <point x="615" y="1482"/>
+      <point x="482" y="1405"/>
+      <point x="394" y="1299" type="curve" smooth="yes"/>
+      <point x="386" y="1290"/>
+      <point x="379" y="1279"/>
+      <point x="371" y="1269" type="curve" smooth="yes"/>
+      <point x="258" y="1131"/>
+      <point x="197" y="983"/>
+      <point x="175" y="806" type="curve"/>
+      <point x="273" y="806" type="line"/>
+      <point x="309" y="1041"/>
+      <point x="461" y="1385"/>
+      <point x="749" y="1375" type="curve" smooth="yes"/>
+      <point x="907" y="1370"/>
+      <point x="983" y="1244"/>
+      <point x="964" y="1095" type="curve" smooth="yes"/>
+      <point x="949" y="969"/>
+      <point x="854" y="861"/>
+      <point x="763" y="781" type="curve" smooth="yes"/>
+      <point x="508" y="575" type="line" smooth="yes"/>
+      <point x="409" y="495"/>
+      <point x="320" y="394"/>
+      <point x="311" y="261" type="curve" smooth="yes"/>
+      <point x="300" y="115"/>
+      <point x="386" y="-15"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214B_.glif
@@ -4,66 +4,66 @@
   <unicode hex="214B"/>
   <outline>
     <contour>
-      <point x="540" y="-19" type="curve" smooth="yes"/>
-      <point x="734" y="-23"/>
-      <point x="840" y="147"/>
-      <point x="855" y="323" type="curve" smooth="yes"/>
-      <point x="869" y="482"/>
-      <point x="790" y="624"/>
-      <point x="716" y="759" type="curve" smooth="yes"/>
-      <point x="339" y="1459" type="line"/>
-      <point x="216" y="1459" type="line"/>
-      <point x="660" y="633" type="line" smooth="yes"/>
-      <point x="711" y="537"/>
-      <point x="758" y="429"/>
-      <point x="746" y="317" type="curve" smooth="yes"/>
-      <point x="734" y="211"/>
-      <point x="672" y="83"/>
-      <point x="548" y="84" type="curve" smooth="yes"/>
-      <point x="452" y="86"/>
-      <point x="409" y="173"/>
-      <point x="417" y="260" type="curve" smooth="yes"/>
-      <point x="426" y="362"/>
-      <point x="492" y="436"/>
-      <point x="568" y="497" type="curve" smooth="yes"/>
-      <point x="785" y="673" type="line" smooth="yes"/>
-      <point x="922" y="783"/>
-      <point x="1061" y="908"/>
-      <point x="1077" y="1095" type="curve" smooth="yes"/>
-      <point x="1095" y="1306"/>
-      <point x="974" y="1474"/>
-      <point x="755" y="1479" type="curve" smooth="yes"/>
-      <point x="615" y="1482"/>
-      <point x="482" y="1405"/>
-      <point x="394" y="1299" type="curve" smooth="yes"/>
-      <point x="386" y="1290"/>
-      <point x="379" y="1279"/>
-      <point x="371" y="1269" type="curve" smooth="yes"/>
-      <point x="258" y="1131"/>
-      <point x="197" y="983"/>
-      <point x="175" y="806" type="curve"/>
-      <point x="273" y="806" type="line"/>
-      <point x="309" y="1041"/>
-      <point x="461" y="1385"/>
-      <point x="749" y="1375" type="curve" smooth="yes"/>
-      <point x="907" y="1370"/>
-      <point x="983" y="1244"/>
-      <point x="964" y="1095" type="curve" smooth="yes"/>
-      <point x="949" y="969"/>
-      <point x="854" y="861"/>
-      <point x="763" y="781" type="curve" smooth="yes"/>
-      <point x="508" y="575" type="line" smooth="yes"/>
-      <point x="409" y="495"/>
-      <point x="320" y="394"/>
-      <point x="311" y="261" type="curve" smooth="yes"/>
-      <point x="300" y="115"/>
-      <point x="386" y="-15"/>
+      <point x="520" y="-19" type="curve" smooth="yes"/>
+      <point x="714" y="-23"/>
+      <point x="820" y="147"/>
+      <point x="835" y="323" type="curve" smooth="yes"/>
+      <point x="849" y="482"/>
+      <point x="770" y="624"/>
+      <point x="696" y="759" type="curve" smooth="yes"/>
+      <point x="319" y="1459" type="line"/>
+      <point x="196" y="1459" type="line"/>
+      <point x="640" y="633" type="line" smooth="yes"/>
+      <point x="691" y="537"/>
+      <point x="738" y="429"/>
+      <point x="726" y="317" type="curve" smooth="yes"/>
+      <point x="714" y="211"/>
+      <point x="652" y="83"/>
+      <point x="528" y="84" type="curve" smooth="yes"/>
+      <point x="432" y="86"/>
+      <point x="389" y="173"/>
+      <point x="397" y="260" type="curve" smooth="yes"/>
+      <point x="406" y="362"/>
+      <point x="472" y="436"/>
+      <point x="548" y="497" type="curve" smooth="yes"/>
+      <point x="765" y="673" type="line" smooth="yes"/>
+      <point x="902" y="783"/>
+      <point x="1041" y="908"/>
+      <point x="1057" y="1095" type="curve" smooth="yes"/>
+      <point x="1075" y="1306"/>
+      <point x="954" y="1474"/>
+      <point x="735" y="1479" type="curve" smooth="yes"/>
+      <point x="595" y="1482"/>
+      <point x="462" y="1405"/>
+      <point x="374" y="1299" type="curve" smooth="yes"/>
+      <point x="366" y="1290"/>
+      <point x="359" y="1279"/>
+      <point x="351" y="1269" type="curve" smooth="yes"/>
+      <point x="238" y="1131"/>
+      <point x="177" y="983"/>
+      <point x="155" y="806" type="curve"/>
+      <point x="253" y="806" type="line"/>
+      <point x="289" y="1041"/>
+      <point x="441" y="1385"/>
+      <point x="729" y="1375" type="curve" smooth="yes"/>
+      <point x="887" y="1370"/>
+      <point x="963" y="1244"/>
+      <point x="944" y="1095" type="curve" smooth="yes"/>
+      <point x="929" y="969"/>
+      <point x="834" y="861"/>
+      <point x="743" y="781" type="curve" smooth="yes"/>
+      <point x="488" y="575" type="line" smooth="yes"/>
+      <point x="389" y="495"/>
+      <point x="300" y="394"/>
+      <point x="291" y="261" type="curve" smooth="yes"/>
+      <point x="280" y="115"/>
+      <point x="366" y="-15"/>
     </contour>
   </outline>
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="619"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="235" y="-10" type="curve" smooth="yes"/>
+      <point x="317" y="-10"/>
+      <point x="344" y="51"/>
+      <point x="344" y="117" type="curve" smooth="yes"/>
+      <point x="344" y="140"/>
+      <point x="336" y="204"/>
+      <point x="328" y="277" type="curve"/>
+      <point x="404" y="291"/>
+      <point x="470" y="326"/>
+      <point x="512" y="375" type="curve"/>
+      <point x="521" y="361"/>
+      <point x="526" y="345"/>
+      <point x="526" y="327" type="curve" smooth="yes"/>
+      <point x="526" y="281"/>
+      <point x="479" y="238"/>
+      <point x="461" y="224" type="curve"/>
+      <point x="495" y="224" type="line"/>
+      <point x="514" y="238"/>
+      <point x="556" y="281"/>
+      <point x="556" y="326" type="curve" smooth="yes"/>
+      <point x="556" y="354"/>
+      <point x="546" y="378"/>
+      <point x="529" y="397" type="curve"/>
+      <point x="550" y="427"/>
+      <point x="562" y="462"/>
+      <point x="562" y="500" type="curve" smooth="yes"/>
+      <point x="562" y="608"/>
+      <point x="491" y="725"/>
+      <point x="382" y="725" type="curve" smooth="yes"/>
+      <point x="299" y="725"/>
+      <point x="272" y="664"/>
+      <point x="272" y="569" type="curve" smooth="yes"/>
+      <point x="272" y="548"/>
+      <point x="273" y="515"/>
+      <point x="274" y="477" type="curve"/>
+      <point x="262" y="478"/>
+      <point x="251" y="478"/>
+      <point x="241" y="478" type="curve" smooth="yes"/>
+      <point x="230" y="478"/>
+      <point x="211" y="477"/>
+      <point x="190" y="475" type="curve"/>
+      <point x="192" y="613" type="line"/>
+      <point x="207" y="635"/>
+      <point x="221" y="658"/>
+      <point x="221" y="675" type="curve" smooth="yes"/>
+      <point x="221" y="681"/>
+      <point x="220" y="708"/>
+      <point x="193" y="708" type="curve" smooth="yes"/>
+      <point x="158" y="708"/>
+      <point x="170" y="669"/>
+      <point x="154" y="669" type="curve" smooth="yes"/>
+      <point x="134" y="669"/>
+      <point x="123" y="715"/>
+      <point x="75" y="715" type="curve" smooth="yes"/>
+      <point x="52" y="715"/>
+      <point x="11" y="702"/>
+      <point x="11" y="643" type="curve" smooth="yes"/>
+      <point x="11" y="603"/>
+      <point x="38" y="572"/>
+      <point x="82" y="572" type="curve" smooth="yes"/>
+      <point x="89" y="572"/>
+      <point x="96" y="573"/>
+      <point x="101" y="574" type="curve"/>
+      <point x="100" y="592" type="line"/>
+      <point x="96" y="591"/>
+      <point x="88" y="590"/>
+      <point x="82" y="590" type="curve" smooth="yes"/>
+      <point x="64" y="590"/>
+      <point x="58" y="606"/>
+      <point x="58" y="617" type="curve" smooth="yes"/>
+      <point x="58" y="630"/>
+      <point x="67" y="644"/>
+      <point x="86" y="644" type="curve" smooth="yes"/>
+      <point x="108" y="644"/>
+      <point x="155" y="625"/>
+      <point x="172" y="615" type="curve"/>
+      <point x="156" y="471" type="line"/>
+      <point x="94" y="460"/>
+      <point x="24" y="433"/>
+      <point x="24" y="369" type="curve" smooth="yes"/>
+      <point x="24" y="315"/>
+      <point x="77" y="290"/>
+      <point x="137" y="279" type="curve"/>
+      <point x="130" y="208"/>
+      <point x="126" y="144"/>
+      <point x="126" y="117" type="curve" smooth="yes"/>
+      <point x="126" y="51"/>
+      <point x="153" y="-10"/>
+    </contour>
+    <contour>
+      <point x="235" y="20" type="curve" smooth="yes"/>
+      <point x="198" y="20"/>
+      <point x="178" y="58"/>
+      <point x="178" y="115" type="curve" smooth="yes"/>
+      <point x="178" y="146"/>
+      <point x="180" y="206"/>
+      <point x="182" y="273" type="curve"/>
+      <point x="207" y="270"/>
+      <point x="231" y="270"/>
+      <point x="252" y="270" type="curve" smooth="yes"/>
+      <point x="262" y="270"/>
+      <point x="273" y="270"/>
+      <point x="284" y="271" type="curve"/>
+      <point x="287" y="195"/>
+      <point x="291" y="132"/>
+      <point x="291" y="115" type="curve" smooth="yes"/>
+      <point x="291" y="58"/>
+      <point x="271" y="20"/>
+    </contour>
+    <contour>
+      <point x="139" y="299" type="line"/>
+      <point x="59" y="318"/>
+      <point x="49" y="358"/>
+      <point x="49" y="372" type="curve" smooth="yes"/>
+      <point x="49" y="384"/>
+      <point x="55" y="434"/>
+      <point x="154" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="251" y="288" type="curve" smooth="yes"/>
+      <point x="224" y="288"/>
+      <point x="203" y="289"/>
+      <point x="183" y="291" type="curve"/>
+      <point x="189" y="458" type="line"/>
+      <point x="204" y="459"/>
+      <point x="221" y="460"/>
+      <point x="240" y="460" type="curve" smooth="yes"/>
+      <point x="252" y="460"/>
+      <point x="263" y="459"/>
+      <point x="275" y="459" type="curve"/>
+      <point x="283" y="289" type="line"/>
+      <point x="272" y="288"/>
+      <point x="262" y="288"/>
+    </contour>
+    <contour>
+      <point x="326" y="295" type="curve"/>
+      <point x="307" y="457" type="line"/>
+      <point x="367" y="452"/>
+      <point x="427" y="439"/>
+      <point x="469" y="414" type="curve"/>
+      <point x="446" y="351"/>
+      <point x="398" y="311"/>
+    </contour>
+    <contour>
+      <point x="474" y="436" type="curve"/>
+      <point x="425" y="460"/>
+      <point x="360" y="471"/>
+      <point x="305" y="475" type="curve"/>
+      <point x="301" y="514"/>
+      <point x="299" y="548"/>
+      <point x="299" y="572" type="curve" smooth="yes"/>
+      <point x="299" y="636"/>
+      <point x="305" y="707"/>
+      <point x="379" y="707" type="curve" smooth="yes"/>
+      <point x="470" y="707"/>
+      <point x="486" y="593"/>
+      <point x="486" y="519" type="curve" smooth="yes"/>
+      <point x="486" y="488"/>
+      <point x="481" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="619"/>
+  <advance width="1266"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="235" y="-10" type="curve" smooth="yes"/>
-      <point x="317" y="-10"/>
-      <point x="344" y="51"/>
-      <point x="344" y="117" type="curve" smooth="yes"/>
-      <point x="344" y="140"/>
-      <point x="336" y="204"/>
-      <point x="328" y="277" type="curve"/>
-      <point x="404" y="291"/>
-      <point x="470" y="326"/>
-      <point x="512" y="375" type="curve"/>
-      <point x="521" y="361"/>
-      <point x="526" y="345"/>
-      <point x="526" y="327" type="curve" smooth="yes"/>
-      <point x="526" y="281"/>
-      <point x="479" y="238"/>
-      <point x="461" y="224" type="curve"/>
-      <point x="495" y="224" type="line"/>
-      <point x="514" y="238"/>
-      <point x="556" y="281"/>
-      <point x="556" y="326" type="curve" smooth="yes"/>
-      <point x="556" y="354"/>
-      <point x="546" y="378"/>
-      <point x="529" y="397" type="curve"/>
-      <point x="550" y="427"/>
-      <point x="562" y="462"/>
-      <point x="562" y="500" type="curve" smooth="yes"/>
-      <point x="562" y="608"/>
-      <point x="491" y="725"/>
-      <point x="382" y="725" type="curve" smooth="yes"/>
-      <point x="299" y="725"/>
-      <point x="272" y="664"/>
-      <point x="272" y="569" type="curve" smooth="yes"/>
-      <point x="272" y="548"/>
-      <point x="273" y="515"/>
-      <point x="274" y="477" type="curve"/>
-      <point x="262" y="478"/>
-      <point x="251" y="478"/>
-      <point x="241" y="478" type="curve" smooth="yes"/>
-      <point x="230" y="478"/>
-      <point x="211" y="477"/>
-      <point x="190" y="475" type="curve"/>
-      <point x="192" y="613" type="line"/>
-      <point x="207" y="635"/>
-      <point x="221" y="658"/>
-      <point x="221" y="675" type="curve" smooth="yes"/>
-      <point x="221" y="681"/>
-      <point x="220" y="708"/>
-      <point x="193" y="708" type="curve" smooth="yes"/>
-      <point x="158" y="708"/>
-      <point x="170" y="669"/>
-      <point x="154" y="669" type="curve" smooth="yes"/>
-      <point x="134" y="669"/>
-      <point x="123" y="715"/>
-      <point x="75" y="715" type="curve" smooth="yes"/>
-      <point x="52" y="715"/>
-      <point x="11" y="702"/>
-      <point x="11" y="643" type="curve" smooth="yes"/>
-      <point x="11" y="603"/>
-      <point x="38" y="572"/>
-      <point x="82" y="572" type="curve" smooth="yes"/>
-      <point x="89" y="572"/>
-      <point x="96" y="573"/>
-      <point x="101" y="574" type="curve"/>
-      <point x="100" y="592" type="line"/>
-      <point x="96" y="591"/>
-      <point x="88" y="590"/>
-      <point x="82" y="590" type="curve" smooth="yes"/>
-      <point x="64" y="590"/>
-      <point x="58" y="606"/>
-      <point x="58" y="617" type="curve" smooth="yes"/>
-      <point x="58" y="630"/>
-      <point x="67" y="644"/>
-      <point x="86" y="644" type="curve" smooth="yes"/>
-      <point x="108" y="644"/>
-      <point x="155" y="625"/>
-      <point x="172" y="615" type="curve"/>
-      <point x="156" y="471" type="line"/>
-      <point x="94" y="460"/>
-      <point x="24" y="433"/>
-      <point x="24" y="369" type="curve" smooth="yes"/>
-      <point x="24" y="315"/>
-      <point x="77" y="290"/>
-      <point x="137" y="279" type="curve"/>
-      <point x="130" y="208"/>
-      <point x="126" y="144"/>
-      <point x="126" y="117" type="curve" smooth="yes"/>
-      <point x="126" y="51"/>
-      <point x="153" y="-10"/>
+      <point x="596" y="-20" type="curve" smooth="yes"/>
+      <point x="764" y="-20"/>
+      <point x="819" y="104"/>
+      <point x="819" y="240" type="curve" smooth="yes"/>
+      <point x="819" y="287"/>
+      <point x="803" y="418"/>
+      <point x="786" y="567" type="curve"/>
+      <point x="942" y="596"/>
+      <point x="1077" y="668"/>
+      <point x="1163" y="768" type="curve"/>
+      <point x="1181" y="739"/>
+      <point x="1192" y="707"/>
+      <point x="1192" y="670" type="curve" smooth="yes"/>
+      <point x="1192" y="575"/>
+      <point x="1095" y="487"/>
+      <point x="1059" y="459" type="curve"/>
+      <point x="1128" y="459" type="line"/>
+      <point x="1167" y="487"/>
+      <point x="1253" y="575"/>
+      <point x="1253" y="668" type="curve" smooth="yes"/>
+      <point x="1253" y="725"/>
+      <point x="1233" y="774"/>
+      <point x="1198" y="813" type="curve"/>
+      <point x="1241" y="874"/>
+      <point x="1265" y="946"/>
+      <point x="1265" y="1024" type="curve" smooth="yes"/>
+      <point x="1265" y="1245"/>
+      <point x="1120" y="1485"/>
+      <point x="897" y="1485" type="curve" smooth="yes"/>
+      <point x="727" y="1485"/>
+      <point x="671" y="1360"/>
+      <point x="671" y="1165" type="curve" smooth="yes"/>
+      <point x="671" y="1122"/>
+      <point x="674" y="1055"/>
+      <point x="676" y="977" type="curve"/>
+      <point x="651" y="979"/>
+      <point x="628" y="979"/>
+      <point x="608" y="979" type="curve" smooth="yes"/>
+      <point x="585" y="979"/>
+      <point x="547" y="977"/>
+      <point x="504" y="973" type="curve"/>
+      <point x="508" y="1255" type="line"/>
+      <point x="538" y="1300"/>
+      <point x="567" y="1348"/>
+      <point x="567" y="1382" type="curve" smooth="yes"/>
+      <point x="567" y="1395"/>
+      <point x="565" y="1450"/>
+      <point x="510" y="1450" type="curve" smooth="yes"/>
+      <point x="438" y="1450"/>
+      <point x="463" y="1370"/>
+      <point x="430" y="1370" type="curve" smooth="yes"/>
+      <point x="389" y="1370"/>
+      <point x="366" y="1464"/>
+      <point x="268" y="1464" type="curve" smooth="yes"/>
+      <point x="221" y="1464"/>
+      <point x="137" y="1438"/>
+      <point x="137" y="1317" type="curve" smooth="yes"/>
+      <point x="137" y="1235"/>
+      <point x="192" y="1171"/>
+      <point x="282" y="1171" type="curve" smooth="yes"/>
+      <point x="297" y="1171"/>
+      <point x="311" y="1174"/>
+      <point x="321" y="1176" type="curve"/>
+      <point x="319" y="1212" type="line"/>
+      <point x="311" y="1210"/>
+      <point x="295" y="1208"/>
+      <point x="282" y="1208" type="curve" smooth="yes"/>
+      <point x="246" y="1208"/>
+      <point x="233" y="1241"/>
+      <point x="233" y="1264" type="curve" smooth="yes"/>
+      <point x="233" y="1290"/>
+      <point x="252" y="1319"/>
+      <point x="291" y="1319" type="curve" smooth="yes"/>
+      <point x="336" y="1319"/>
+      <point x="432" y="1280"/>
+      <point x="467" y="1260" type="curve"/>
+      <point x="434" y="965" type="line"/>
+      <point x="307" y="942"/>
+      <point x="164" y="887"/>
+      <point x="164" y="756" type="curve" smooth="yes"/>
+      <point x="164" y="645"/>
+      <point x="272" y="594"/>
+      <point x="395" y="571" type="curve"/>
+      <point x="381" y="426"/>
+      <point x="372" y="295"/>
+      <point x="372" y="240" type="curve" smooth="yes"/>
+      <point x="372" y="104"/>
+      <point x="428" y="-20"/>
     </contour>
     <contour>
-      <point x="235" y="20" type="curve" smooth="yes"/>
-      <point x="198" y="20"/>
-      <point x="178" y="58"/>
-      <point x="178" y="115" type="curve" smooth="yes"/>
-      <point x="178" y="146"/>
-      <point x="180" y="206"/>
-      <point x="182" y="273" type="curve"/>
-      <point x="207" y="270"/>
-      <point x="231" y="270"/>
-      <point x="252" y="270" type="curve" smooth="yes"/>
-      <point x="262" y="270"/>
-      <point x="273" y="270"/>
-      <point x="284" y="271" type="curve"/>
-      <point x="287" y="195"/>
-      <point x="291" y="132"/>
-      <point x="291" y="115" type="curve" smooth="yes"/>
-      <point x="291" y="58"/>
-      <point x="271" y="20"/>
+      <point x="596" y="41" type="curve" smooth="yes"/>
+      <point x="520" y="41"/>
+      <point x="479" y="119"/>
+      <point x="479" y="236" type="curve" smooth="yes"/>
+      <point x="479" y="299"/>
+      <point x="483" y="422"/>
+      <point x="487" y="559" type="curve"/>
+      <point x="538" y="553"/>
+      <point x="588" y="553"/>
+      <point x="631" y="553" type="curve" smooth="yes"/>
+      <point x="651" y="553"/>
+      <point x="674" y="553"/>
+      <point x="696" y="555" type="curve"/>
+      <point x="702" y="399"/>
+      <point x="710" y="270"/>
+      <point x="710" y="236" type="curve" smooth="yes"/>
+      <point x="710" y="119"/>
+      <point x="669" y="41"/>
     </contour>
     <contour>
-      <point x="139" y="299" type="line"/>
-      <point x="59" y="318"/>
-      <point x="49" y="358"/>
-      <point x="49" y="372" type="curve" smooth="yes"/>
-      <point x="49" y="384"/>
-      <point x="55" y="434"/>
-      <point x="154" y="453" type="curve"/>
+      <point x="399" y="612" type="line"/>
+      <point x="235" y="651"/>
+      <point x="215" y="733"/>
+      <point x="215" y="762" type="curve" smooth="yes"/>
+      <point x="215" y="786"/>
+      <point x="227" y="889"/>
+      <point x="430" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="251" y="288" type="curve" smooth="yes"/>
-      <point x="224" y="288"/>
-      <point x="203" y="289"/>
-      <point x="183" y="291" type="curve"/>
-      <point x="189" y="458" type="line"/>
-      <point x="204" y="459"/>
-      <point x="221" y="460"/>
-      <point x="240" y="460" type="curve" smooth="yes"/>
-      <point x="252" y="460"/>
-      <point x="263" y="459"/>
-      <point x="275" y="459" type="curve"/>
-      <point x="283" y="289" type="line"/>
-      <point x="272" y="288"/>
-      <point x="262" y="288"/>
+      <point x="628" y="590" type="curve" smooth="yes"/>
+      <point x="573" y="590"/>
+      <point x="530" y="592"/>
+      <point x="489" y="596" type="curve"/>
+      <point x="502" y="938" type="line"/>
+      <point x="532" y="940"/>
+      <point x="567" y="942"/>
+      <point x="606" y="942" type="curve" smooth="yes"/>
+      <point x="631" y="942"/>
+      <point x="653" y="940"/>
+      <point x="678" y="940" type="curve"/>
+      <point x="694" y="592" type="line"/>
+      <point x="671" y="590"/>
+      <point x="651" y="590"/>
     </contour>
     <contour>
-      <point x="326" y="295" type="curve"/>
-      <point x="307" y="457" type="line"/>
-      <point x="367" y="452"/>
-      <point x="427" y="439"/>
-      <point x="469" y="414" type="curve"/>
-      <point x="446" y="351"/>
-      <point x="398" y="311"/>
+      <point x="782" y="604" type="curve"/>
+      <point x="743" y="936" type="line"/>
+      <point x="866" y="926"/>
+      <point x="989" y="899"/>
+      <point x="1075" y="848" type="curve"/>
+      <point x="1028" y="719"/>
+      <point x="930" y="637"/>
     </contour>
     <contour>
-      <point x="474" y="436" type="curve"/>
-      <point x="425" y="460"/>
-      <point x="360" y="471"/>
-      <point x="305" y="475" type="curve"/>
-      <point x="301" y="514"/>
-      <point x="299" y="548"/>
-      <point x="299" y="572" type="curve" smooth="yes"/>
-      <point x="299" y="636"/>
-      <point x="305" y="707"/>
-      <point x="379" y="707" type="curve" smooth="yes"/>
-      <point x="470" y="707"/>
-      <point x="486" y="593"/>
-      <point x="486" y="519" type="curve" smooth="yes"/>
-      <point x="486" y="488"/>
-      <point x="481" y="461"/>
+      <point x="1087" y="893" type="curve"/>
+      <point x="987" y="942"/>
+      <point x="852" y="965"/>
+      <point x="739" y="973" type="curve"/>
+      <point x="731" y="1053"/>
+      <point x="727" y="1122"/>
+      <point x="727" y="1171" type="curve" smooth="yes"/>
+      <point x="727" y="1303"/>
+      <point x="739" y="1448"/>
+      <point x="891" y="1448" type="curve" smooth="yes"/>
+      <point x="1077" y="1448"/>
+      <point x="1110" y="1214"/>
+      <point x="1110" y="1063" type="curve" smooth="yes"/>
+      <point x="1110" y="999"/>
+      <point x="1102" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="877"/>
+  <unicode hex="214E"/>
+  <anchor x="312" y="10" name="bottom"/>
+  <anchor x="651" y="-407" name="bottom_dd"/>
+  <anchor x="593" y="1320" name="parent_top"/>
+  <anchor x="593" y="1320" name="top"/>
+  <anchor x="949" y="1320" name="top0315"/>
+  <anchor x="997" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="530" y="0" type="line"/>
+      <point x="641" y="0" type="line"/>
+      <point x="830" y="1082" type="line"/>
+      <point x="719" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="2" y="0" type="line"/>
+      <point x="565" y="0" type="line"/>
+      <point x="584" y="105" type="line"/>
+      <point x="21" y="105" type="line"/>
+    </contour>
+    <contour>
+      <point x="161" y="529" type="line"/>
+      <point x="657" y="529" type="line"/>
+      <point x="676" y="633" type="line"/>
+      <point x="180" y="633" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:27 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-LightItalic.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:27 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-LightItalic.ufo/lib.plist
+++ b/sources/RobotoCondensed-LightItalic.ufo/lib.plist
@@ -6898,6 +6898,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-Regular.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Regular.ufo/fontinfo.plist
@@ -373,7 +373,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
     <key>year</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/contents.plist
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="937"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="157" y="0" type="line"/>
+      <point x="475" y="0" type="line" smooth="yes"/>
+      <point x="708" y="0"/>
+      <point x="819" y="166"/>
+      <point x="819" y="420" type="curve" smooth="yes"/>
+      <point x="819" y="616"/>
+      <point x="747" y="727"/>
+      <point x="587" y="766" type="curve"/>
+      <point x="587" y="774" type="line"/>
+      <point x="721" y="805"/>
+      <point x="792" y="922"/>
+      <point x="792" y="1110" type="curve" smooth="yes"/>
+      <point x="792" y="1339"/>
+      <point x="657" y="1455"/>
+      <point x="426" y="1455" type="curve" smooth="yes"/>
+      <point x="157" y="1455" type="line"/>
+    </contour>
+    <contour>
+      <point x="284" y="-201" type="line"/>
+      <point x="385" y="-201" type="line"/>
+      <point x="385" y="109" type="line"/>
+      <point x="284" y="109" type="line"/>
+    </contour>
+    <contour>
+      <point x="497" y="-201" type="line"/>
+      <point x="598" y="-201" type="line"/>
+      <point x="598" y="109" type="line"/>
+      <point x="497" y="109" type="line"/>
+    </contour>
+    <contour>
+      <point x="331" y="150" type="line"/>
+      <point x="331" y="690" type="line"/>
+      <point x="428" y="690" type="line" smooth="yes"/>
+      <point x="559" y="690"/>
+      <point x="641" y="616"/>
+      <point x="641" y="418" type="curve" smooth="yes"/>
+      <point x="641" y="242"/>
+      <point x="579" y="150"/>
+      <point x="456" y="150" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="331" y="836" type="line"/>
+      <point x="331" y="1308" type="line"/>
+      <point x="424" y="1308" type="line" smooth="yes"/>
+      <point x="542" y="1308"/>
+      <point x="614" y="1261"/>
+      <point x="614" y="1102" type="curve" smooth="yes"/>
+      <point x="614" y="944"/>
+      <point x="555" y="836"/>
+      <point x="415" y="836" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="284" y="1353" type="line"/>
+      <point x="385" y="1353" type="line"/>
+      <point x="385" y="1662" type="line"/>
+      <point x="284" y="1662" type="line"/>
+    </contour>
+    <contour>
+      <point x="497" y="1353" type="line"/>
+      <point x="598" y="1353" type="line"/>
+      <point x="598" y="1662" type="line"/>
+      <point x="497" y="1662" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="945"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="355" y="0" type="line"/>
+      <point x="883" y="0" type="line"/>
+      <point x="883" y="139" type="line"/>
+      <point x="496" y="139" type="line"/>
+      <point x="496" y="395" type="line"/>
+      <point x="539" y="403"/>
+      <point x="576" y="418"/>
+      <point x="607" y="440" type="curve"/>
+      <point x="607" y="551" type="line"/>
+      <point x="572" y="528"/>
+      <point x="535" y="512"/>
+      <point x="496" y="502" type="curve"/>
+      <point x="496" y="1106" type="line"/>
+      <point x="525" y="1100"/>
+      <point x="558" y="1087"/>
+      <point x="588" y="1071" type="curve"/>
+      <point x="621" y="1174" type="line"/>
+      <point x="584" y="1194"/>
+      <point x="541" y="1208"/>
+      <point x="496" y="1214" type="curve"/>
+      <point x="496" y="1462" type="line"/>
+      <point x="355" y="1462" type="line"/>
+      <point x="355" y="1208" type="line"/>
+      <point x="212" y="1171"/>
+      <point x="126" y="1030"/>
+      <point x="126" y="801" type="curve" smooth="yes"/>
+      <point x="126" y="569"/>
+      <point x="208" y="428"/>
+      <point x="355" y="397" type="curve"/>
+    </contour>
+    <contour>
+      <point x="355" y="512" type="line"/>
+      <point x="285" y="549"/>
+      <point x="249" y="651"/>
+      <point x="249" y="801" type="curve" smooth="yes"/>
+      <point x="249" y="961"/>
+      <point x="285" y="1059"/>
+      <point x="355" y="1096" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="949"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2108.glif
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1209"/>
+  <unicode hex="2108"/>
+  <anchor x="601" y="1634" name="parent_top"/>
+  <anchor x="601" y="1634" name="top"/>
+  <anchor x="1189" y="1634" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="615" y="-20" type="curve" smooth="yes"/>
+      <point x="907" y="-20"/>
+      <point x="1099" y="247"/>
+      <point x="1099" y="655" type="curve" smooth="yes"/>
+      <point x="1099" y="799" type="line" smooth="yes"/>
+      <point x="1099" y="1208"/>
+      <point x="907" y="1476"/>
+      <point x="598" y="1476" type="curve" smooth="yes"/>
+      <point x="315" y="1476"/>
+      <point x="171" y="1276"/>
+      <point x="146" y="989" type="curve"/>
+      <point x="330" y="989" type="line"/>
+      <point x="354" y="1192"/>
+      <point x="418" y="1318"/>
+      <point x="598" y="1318" type="curve" smooth="yes"/>
+      <point x="811" y="1318"/>
+      <point x="915" y="1111"/>
+      <point x="915" y="801" type="curve" smooth="yes"/>
+      <point x="915" y="655" type="line" smooth="yes"/>
+      <point x="915" y="369"/>
+      <point x="829" y="137"/>
+      <point x="615" y="137" type="curve" smooth="yes"/>
+      <point x="413" y="137"/>
+      <point x="357" y="257"/>
+      <point x="330" y="463" type="curve"/>
+      <point x="146" y="463" type="line"/>
+      <point x="172" y="187"/>
+      <point x="312" y="-20"/>
+    </contour>
+    <contour>
+      <point x="445" y="647" type="line"/>
+      <point x="938" y="647" type="line"/>
+      <point x="938" y="805" type="line"/>
+      <point x="445" y="805" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1519"/>
+  <unicode hex="2114"/>
+  <anchor x="1034" y="-10" name="bottom"/>
+  <anchor x="1499" y="-407" name="bottom_dd"/>
+  <anchor x="543" y="1540" name="marktop"/>
+  <anchor x="1070" y="1611" name="parent_top"/>
+  <anchor x="1070" y="1611" name="top"/>
+  <anchor x="1499" y="1611" name="top0315"/>
+  <anchor x="1499" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1070" y="-20" type="curve" smooth="yes"/>
+      <point x="1297" y="-20"/>
+      <point x="1426" y="147"/>
+      <point x="1426" y="489" type="curve" smooth="yes"/>
+      <point x="1426" y="590" type="line"/>
+      <point x="1426" y="946"/>
+      <point x="1299" y="1102"/>
+      <point x="1069" y="1102" type="curve" smooth="yes"/>
+      <point x="845" y="1102"/>
+      <point x="749" y="914"/>
+      <point x="726" y="607" type="curve"/>
+      <point x="726" y="472" type="line"/>
+      <point x="750" y="168"/>
+      <point x="846" y="-20"/>
+    </contour>
+    <contour>
+      <point x="183" y="0" type="line"/>
+      <point x="359" y="0" type="line"/>
+      <point x="359" y="1536" type="line"/>
+      <point x="183" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="642" y="0" type="line"/>
+      <point x="804" y="0" type="line"/>
+      <point x="819" y="210" type="line"/>
+      <point x="819" y="1536" type="line"/>
+      <point x="642" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="1024" y="137" type="curve" smooth="yes"/>
+      <point x="877" y="137"/>
+      <point x="809" y="267"/>
+      <point x="783" y="397" type="curve"/>
+      <point x="783" y="681" type="line"/>
+      <point x="808" y="818"/>
+      <point x="880" y="946"/>
+      <point x="1023" y="946" type="curve" smooth="yes"/>
+      <point x="1194" y="946"/>
+      <point x="1249" y="830"/>
+      <point x="1249" y="590" type="curve" smooth="yes"/>
+      <point x="1249" y="489" type="line"/>
+      <point x="1249" y="248"/>
+      <point x="1186" y="137"/>
+    </contour>
+    <contour>
+      <point x="16" y="1233" type="line"/>
+      <point x="1019" y="1233" type="line"/>
+      <point x="1019" y="1385" type="line"/>
+      <point x="16" y="1385" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="808"/>
+  <advance width="1610"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="210" y="-241" type="curve" smooth="yes"/>
-      <point x="280" y="-241"/>
-      <point x="327" y="-180"/>
-      <point x="327" y="-95" type="curve" smooth="yes"/>
-      <point x="327" y="8"/>
-      <point x="235" y="99"/>
-      <point x="178" y="200" type="curve"/>
-      <point x="225" y="272"/>
-      <point x="285" y="341"/>
-      <point x="347" y="394" type="curve" smooth="yes"/>
-      <point x="415" y="452"/>
-      <point x="486" y="492"/>
-      <point x="545" y="492" type="curve" smooth="yes"/>
-      <point x="647" y="492"/>
-      <point x="655" y="359"/>
-      <point x="655" y="322" type="curve" smooth="yes"/>
-      <point x="655" y="285"/>
-      <point x="642" y="30"/>
-      <point x="478" y="30" type="curve" smooth="yes"/>
-      <point x="427" y="30"/>
-      <point x="378" y="57"/>
-      <point x="378" y="112" type="curve" smooth="yes"/>
-      <point x="378" y="119"/>
-      <point x="379" y="126"/>
-      <point x="381" y="132" type="curve"/>
-      <point x="413" y="136"/>
-      <point x="446" y="151"/>
-      <point x="446" y="194" type="curve" smooth="yes"/>
-      <point x="446" y="225"/>
-      <point x="425" y="244"/>
-      <point x="394" y="244" type="curve" smooth="yes"/>
-      <point x="346" y="244"/>
-      <point x="316" y="206"/>
-      <point x="316" y="140" type="curve" smooth="yes"/>
-      <point x="316" y="51"/>
-      <point x="380" y="-10"/>
-      <point x="486" y="-10" type="curve" smooth="yes"/>
-      <point x="664" y="-10"/>
-      <point x="757" y="159"/>
-      <point x="757" y="306" type="curve" smooth="yes"/>
-      <point x="757" y="437"/>
-      <point x="697" y="549"/>
-      <point x="575" y="549" type="curve" smooth="yes"/>
-      <point x="525" y="549"/>
-      <point x="429" y="512"/>
-      <point x="323" y="419" type="curve" smooth="yes"/>
-      <point x="271" y="373"/>
-      <point x="210" y="310"/>
-      <point x="158" y="238" type="curve"/>
-      <point x="143" y="272"/>
-      <point x="134" y="307"/>
-      <point x="134" y="345" type="curve" smooth="yes"/>
-      <point x="134" y="474"/>
-      <point x="164" y="548"/>
-      <point x="245" y="625" type="curve"/>
-      <point x="229" y="647" type="line"/>
-      <point x="170" y="610"/>
-      <point x="46" y="496"/>
-      <point x="46" y="337" type="curve" smooth="yes"/>
-      <point x="46" y="267"/>
-      <point x="70" y="206"/>
-      <point x="102" y="149" type="curve"/>
-      <point x="67" y="85"/>
-      <point x="41" y="11"/>
-      <point x="41" y="-56" type="curve" smooth="yes"/>
-      <point x="41" y="-163"/>
-      <point x="115" y="-241"/>
+      <point x="420" y="-494" type="curve" smooth="yes"/>
+      <point x="557" y="-494"/>
+      <point x="651" y="-369"/>
+      <point x="651" y="-195" type="curve" smooth="yes"/>
+      <point x="651" y="16"/>
+      <point x="469" y="203"/>
+      <point x="356" y="410" type="curve"/>
+      <point x="451" y="557"/>
+      <point x="571" y="698"/>
+      <point x="692" y="807" type="curve" smooth="yes"/>
+      <point x="825" y="926"/>
+      <point x="967" y="1008"/>
+      <point x="1085" y="1008" type="curve" smooth="yes"/>
+      <point x="1288" y="1008"/>
+      <point x="1303" y="735"/>
+      <point x="1303" y="659" type="curve" smooth="yes"/>
+      <point x="1303" y="584"/>
+      <point x="1278" y="61"/>
+      <point x="952" y="61" type="curve" smooth="yes"/>
+      <point x="850" y="61"/>
+      <point x="752" y="117"/>
+      <point x="752" y="229" type="curve" smooth="yes"/>
+      <point x="752" y="244"/>
+      <point x="754" y="258"/>
+      <point x="758" y="270" type="curve"/>
+      <point x="823" y="279"/>
+      <point x="889" y="309"/>
+      <point x="889" y="397" type="curve" smooth="yes"/>
+      <point x="889" y="461"/>
+      <point x="846" y="500"/>
+      <point x="784" y="500" type="curve" smooth="yes"/>
+      <point x="688" y="500"/>
+      <point x="631" y="422"/>
+      <point x="631" y="287" type="curve" smooth="yes"/>
+      <point x="631" y="104"/>
+      <point x="756" y="-20"/>
+      <point x="967" y="-20" type="curve" smooth="yes"/>
+      <point x="1319" y="-20"/>
+      <point x="1505" y="326"/>
+      <point x="1505" y="627" type="curve" smooth="yes"/>
+      <point x="1505" y="895"/>
+      <point x="1384" y="1124"/>
+      <point x="1145" y="1124" type="curve" smooth="yes"/>
+      <point x="1044" y="1124"/>
+      <point x="856" y="1049"/>
+      <point x="645" y="858" type="curve" smooth="yes"/>
+      <point x="541" y="764"/>
+      <point x="420" y="635"/>
+      <point x="317" y="487" type="curve"/>
+      <point x="287" y="557"/>
+      <point x="268" y="629"/>
+      <point x="268" y="707" type="curve" smooth="yes"/>
+      <point x="268" y="971"/>
+      <point x="328" y="1122"/>
+      <point x="487" y="1280" type="curve"/>
+      <point x="457" y="1325" type="line"/>
+      <point x="340" y="1249"/>
+      <point x="94" y="1016"/>
+      <point x="94" y="690" type="curve" smooth="yes"/>
+      <point x="94" y="547"/>
+      <point x="141" y="422"/>
+      <point x="205" y="305" type="curve"/>
+      <point x="135" y="174"/>
+      <point x="84" y="23"/>
+      <point x="84" y="-115" type="curve" smooth="yes"/>
+      <point x="84" y="-334"/>
+      <point x="229" y="-494"/>
     </contour>
     <contour>
-      <point x="192" y="-199" type="curve" smooth="yes"/>
-      <point x="148" y="-199"/>
-      <point x="81" y="-145"/>
-      <point x="81" y="-51" type="curve" smooth="yes"/>
-      <point x="81" y="-4"/>
-      <point x="97" y="52"/>
-      <point x="125" y="110" type="curve"/>
-      <point x="179" y="24"/>
-      <point x="240" y="-52"/>
-      <point x="240" y="-134" type="curve" smooth="yes"/>
-      <point x="240" y="-176"/>
-      <point x="221" y="-199"/>
+      <point x="385" y="-408" type="curve" smooth="yes"/>
+      <point x="295" y="-408"/>
+      <point x="164" y="-297"/>
+      <point x="164" y="-104" type="curve" smooth="yes"/>
+      <point x="164" y="-8"/>
+      <point x="197" y="106"/>
+      <point x="252" y="225" type="curve"/>
+      <point x="356" y="49"/>
+      <point x="479" y="-106"/>
+      <point x="479" y="-274" type="curve" smooth="yes"/>
+      <point x="479" y="-360"/>
+      <point x="442" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="808"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="210" y="-241" type="curve" smooth="yes"/>
+      <point x="280" y="-241"/>
+      <point x="327" y="-180"/>
+      <point x="327" y="-95" type="curve" smooth="yes"/>
+      <point x="327" y="8"/>
+      <point x="235" y="99"/>
+      <point x="178" y="200" type="curve"/>
+      <point x="225" y="272"/>
+      <point x="285" y="341"/>
+      <point x="347" y="394" type="curve" smooth="yes"/>
+      <point x="415" y="452"/>
+      <point x="486" y="492"/>
+      <point x="545" y="492" type="curve" smooth="yes"/>
+      <point x="647" y="492"/>
+      <point x="655" y="359"/>
+      <point x="655" y="322" type="curve" smooth="yes"/>
+      <point x="655" y="285"/>
+      <point x="642" y="30"/>
+      <point x="478" y="30" type="curve" smooth="yes"/>
+      <point x="427" y="30"/>
+      <point x="378" y="57"/>
+      <point x="378" y="112" type="curve" smooth="yes"/>
+      <point x="378" y="119"/>
+      <point x="379" y="126"/>
+      <point x="381" y="132" type="curve"/>
+      <point x="413" y="136"/>
+      <point x="446" y="151"/>
+      <point x="446" y="194" type="curve" smooth="yes"/>
+      <point x="446" y="225"/>
+      <point x="425" y="244"/>
+      <point x="394" y="244" type="curve" smooth="yes"/>
+      <point x="346" y="244"/>
+      <point x="316" y="206"/>
+      <point x="316" y="140" type="curve" smooth="yes"/>
+      <point x="316" y="51"/>
+      <point x="380" y="-10"/>
+      <point x="486" y="-10" type="curve" smooth="yes"/>
+      <point x="664" y="-10"/>
+      <point x="757" y="159"/>
+      <point x="757" y="306" type="curve" smooth="yes"/>
+      <point x="757" y="437"/>
+      <point x="697" y="549"/>
+      <point x="575" y="549" type="curve" smooth="yes"/>
+      <point x="525" y="549"/>
+      <point x="429" y="512"/>
+      <point x="323" y="419" type="curve" smooth="yes"/>
+      <point x="271" y="373"/>
+      <point x="210" y="310"/>
+      <point x="158" y="238" type="curve"/>
+      <point x="143" y="272"/>
+      <point x="134" y="307"/>
+      <point x="134" y="345" type="curve" smooth="yes"/>
+      <point x="134" y="474"/>
+      <point x="164" y="548"/>
+      <point x="245" y="625" type="curve"/>
+      <point x="229" y="647" type="line"/>
+      <point x="170" y="610"/>
+      <point x="46" y="496"/>
+      <point x="46" y="337" type="curve" smooth="yes"/>
+      <point x="46" y="267"/>
+      <point x="70" y="206"/>
+      <point x="102" y="149" type="curve"/>
+      <point x="67" y="85"/>
+      <point x="41" y="11"/>
+      <point x="41" y="-56" type="curve" smooth="yes"/>
+      <point x="41" y="-163"/>
+      <point x="115" y="-241"/>
+    </contour>
+    <contour>
+      <point x="192" y="-199" type="curve" smooth="yes"/>
+      <point x="148" y="-199"/>
+      <point x="81" y="-145"/>
+      <point x="81" y="-51" type="curve" smooth="yes"/>
+      <point x="81" y="-4"/>
+      <point x="97" y="52"/>
+      <point x="125" y="110" type="curve"/>
+      <point x="179" y="24"/>
+      <point x="240" y="-52"/>
+      <point x="240" y="-134" type="curve" smooth="yes"/>
+      <point x="240" y="-176"/>
+      <point x="221" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1191"/>
+  <unicode hex="2127"/>
+  <anchor x="599" y="1446" name="top"/>
+  <outline>
+    <contour>
+      <point x="606" y="-20" type="curve" smooth="yes"/>
+      <point x="888" y="-20"/>
+      <point x="1079" y="238"/>
+      <point x="1079" y="616" type="curve"/>
+      <point x="1079" y="730" type="line"/>
+      <point x="1079" y="1068"/>
+      <point x="907" y="1399"/>
+      <point x="650" y="1434" type="curve"/>
+      <point x="650" y="1293" type="line"/>
+      <point x="803" y="1258"/>
+      <point x="893" y="1072"/>
+      <point x="893" y="730" type="curve"/>
+      <point x="893" y="614" type="line"/>
+      <point x="893" y="303"/>
+      <point x="782" y="137"/>
+      <point x="606" y="137" type="curve" smooth="yes"/>
+      <point x="428" y="137"/>
+      <point x="317" y="303"/>
+      <point x="317" y="614" type="curve"/>
+      <point x="317" y="730" type="line"/>
+      <point x="317" y="1070"/>
+      <point x="404" y="1257"/>
+      <point x="555" y="1293" type="curve"/>
+      <point x="555" y="1434" type="line"/>
+      <point x="302" y="1397"/>
+      <point x="131" y="1067"/>
+      <point x="131" y="730" type="curve"/>
+      <point x="131" y="616" type="line"/>
+      <point x="131" y="238"/>
+      <point x="324" y="-20"/>
+    </contour>
+    <contour>
+      <point x="141" y="1299" type="line"/>
+      <point x="555" y="1299" type="line"/>
+      <point x="555" y="1456" type="line"/>
+      <point x="141" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="650" y="1299" type="line"/>
+      <point x="1072" y="1299" type="line"/>
+      <point x="1072" y="1456" type="line"/>
+      <point x="650" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2127.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1191"/>
+  <advance width="1188"/>
   <unicode hex="2127"/>
-  <anchor x="599" y="1446" name="top"/>
+  <anchor x="588" y="1446" name="top"/>
   <outline>
     <contour>
-      <point x="606" y="-20" type="curve" smooth="yes"/>
-      <point x="888" y="-20"/>
-      <point x="1079" y="238"/>
-      <point x="1079" y="616" type="curve"/>
-      <point x="1079" y="730" type="line"/>
-      <point x="1079" y="1068"/>
-      <point x="907" y="1399"/>
-      <point x="650" y="1434" type="curve"/>
-      <point x="650" y="1293" type="line"/>
-      <point x="803" y="1258"/>
-      <point x="893" y="1072"/>
-      <point x="893" y="730" type="curve"/>
-      <point x="893" y="614" type="line"/>
-      <point x="893" y="303"/>
-      <point x="782" y="137"/>
-      <point x="606" y="137" type="curve" smooth="yes"/>
-      <point x="428" y="137"/>
-      <point x="317" y="303"/>
-      <point x="317" y="614" type="curve"/>
-      <point x="317" y="730" type="line"/>
-      <point x="317" y="1070"/>
-      <point x="404" y="1257"/>
-      <point x="555" y="1293" type="curve"/>
-      <point x="555" y="1434" type="line"/>
-      <point x="302" y="1397"/>
-      <point x="131" y="1067"/>
-      <point x="131" y="730" type="curve"/>
-      <point x="131" y="616" type="line"/>
-      <point x="131" y="238"/>
-      <point x="324" y="-20"/>
+      <point x="595" y="-20" type="curve" smooth="yes"/>
+      <point x="877" y="-20"/>
+      <point x="1068" y="238"/>
+      <point x="1068" y="616" type="curve"/>
+      <point x="1068" y="730" type="line"/>
+      <point x="1068" y="1068"/>
+      <point x="896" y="1399"/>
+      <point x="639" y="1434" type="curve"/>
+      <point x="639" y="1293" type="line"/>
+      <point x="792" y="1258"/>
+      <point x="882" y="1072"/>
+      <point x="882" y="730" type="curve"/>
+      <point x="882" y="614" type="line"/>
+      <point x="882" y="303"/>
+      <point x="771" y="137"/>
+      <point x="595" y="137" type="curve" smooth="yes"/>
+      <point x="417" y="137"/>
+      <point x="306" y="303"/>
+      <point x="306" y="614" type="curve"/>
+      <point x="306" y="730" type="line"/>
+      <point x="306" y="1070"/>
+      <point x="393" y="1257"/>
+      <point x="544" y="1293" type="curve"/>
+      <point x="544" y="1434" type="line"/>
+      <point x="291" y="1397"/>
+      <point x="120" y="1067"/>
+      <point x="120" y="730" type="curve"/>
+      <point x="120" y="616" type="line"/>
+      <point x="120" y="238"/>
+      <point x="313" y="-20"/>
     </contour>
     <contour>
-      <point x="141" y="1299" type="line"/>
-      <point x="555" y="1299" type="line"/>
-      <point x="555" y="1456" type="line"/>
-      <point x="141" y="1456" type="line"/>
+      <point x="130" y="1299" type="line"/>
+      <point x="544" y="1299" type="line"/>
+      <point x="544" y="1456" type="line"/>
+      <point x="130" y="1456" type="line"/>
     </contour>
     <contour>
-      <point x="650" y="1299" type="line"/>
-      <point x="1072" y="1299" type="line"/>
-      <point x="1072" y="1456" type="line"/>
-      <point x="650" y="1456" type="line"/>
+      <point x="639" y="1299" type="line"/>
+      <point x="1061" y="1299" type="line"/>
+      <point x="1061" y="1456" type="line"/>
+      <point x="639" y="1456" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="614"/>
+  <unicode hex="2129"/>
+  <anchor x="331" y="-200" name="bottom"/>
+  <anchor x="20" y="-200" name="bottom0315"/>
+  <anchor x="331" y="-200" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="249" y="-13" type="line"/>
+      <point x="426" y="-13" type="line"/>
+      <point x="426" y="792" type="line"/>
+      <point x="426" y="1009"/>
+      <point x="327" y="1082"/>
+      <point x="212" y="1082" type="curve" smooth="yes"/>
+      <point x="150" y="1082"/>
+      <point x="111" y="1070"/>
+      <point x="87" y="1061" type="curve"/>
+      <point x="86" y="911" type="line"/>
+      <point x="98" y="915"/>
+      <point x="132" y="923"/>
+      <point x="156" y="923" type="curve" smooth="yes"/>
+      <point x="204" y="923"/>
+      <point x="249" y="904"/>
+      <point x="249" y="793" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2129.glif
@@ -14,8 +14,8 @@
       <point x="327" y="1082"/>
       <point x="212" y="1082" type="curve" smooth="yes"/>
       <point x="150" y="1082"/>
-      <point x="111" y="1070"/>
-      <point x="87" y="1061" type="curve"/>
+      <point x="110" y="1070"/>
+      <point x="86" y="1061" type="curve"/>
       <point x="86" y="911" type="line"/>
       <point x="98" y="915"/>
       <point x="132" y="923"/>
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="470"/>
+  <unicode hex="2139"/>
+  <anchor x="235" y="10" name="bottom"/>
+  <anchor x="450" y="-407" name="bottom_dd"/>
+  <anchor x="236" y="1600" name="parent_top"/>
+  <anchor x="263" y="654" name="rhotichook"/>
+  <anchor x="236" y="1600" name="top"/>
+  <anchor x="450" y="1600" name="top0315"/>
+  <anchor x="450" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2139.glif
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1818"/>
+  <unicode hex="213A"/>
+  <anchor x="1582" y="606" name="bottom"/>
+  <anchor x="1979" y="1211" name="bottom_dd"/>
+  <anchor x="-28" y="608" name="parent_top"/>
+  <anchor x="-28" y="608" name="top"/>
+  <anchor x="-28" y="1211" name="top0315"/>
+  <anchor x="-28" y="1211" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="718" y="117" type="curve"/>
+      <point x="970" y="117" type="line"/>
+      <point x="1383" y="117"/>
+      <point x="1592" y="316"/>
+      <point x="1592" y="607" type="curve" smooth="yes"/>
+      <point x="1592" y="909"/>
+      <point x="1383" y="1096"/>
+      <point x="970" y="1096" type="curve"/>
+      <point x="718" y="1096" type="line"/>
+      <point x="306" y="1096"/>
+      <point x="96" y="908"/>
+      <point x="96" y="606" type="curve" smooth="yes"/>
+      <point x="96" y="314"/>
+      <point x="306" y="117"/>
+    </contour>
+    <contour>
+      <point x="716" y="300" type="line" smooth="yes"/>
+      <point x="396" y="300"/>
+      <point x="260" y="418"/>
+      <point x="260" y="606" type="curve" smooth="yes"/>
+      <point x="260" y="805"/>
+      <point x="396" y="914"/>
+      <point x="716" y="914" type="curve"/>
+      <point x="970" y="914" type="line"/>
+      <point x="1293" y="914"/>
+      <point x="1429" y="808"/>
+      <point x="1429" y="607" type="curve" smooth="yes"/>
+      <point x="1429" y="420"/>
+      <point x="1293" y="300"/>
+      <point x="970" y="300" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1529" y="675" type="line"/>
+      <point x="1818" y="991" type="line"/>
+      <point x="1698" y="1116" type="line"/>
+      <point x="1405" y="793" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni213A_.glif
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1210"/>
+  <unicode hex="2141"/>
+  <anchor x="631" y="-177" name="bottom"/>
+  <anchor x="20" y="-177" name="bottom0315"/>
+  <anchor x="20" y="-144" name="bottom_dd"/>
+  <anchor x="631" y="-177" name="parent_bottom"/>
+  <anchor x="577" y="1465" name="top"/>
+  <anchor x="20" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="596" y="-20" type="curve" smooth="yes"/>
+      <point x="921" y="-20"/>
+      <point x="1086" y="182"/>
+      <point x="1086" y="591" type="curve" smooth="yes"/>
+      <point x="1086" y="864" type="line" smooth="yes"/>
+      <point x="1086" y="1274"/>
+      <point x="878" y="1476"/>
+      <point x="577" y="1476" type="curve" smooth="yes"/>
+      <point x="296" y="1476"/>
+      <point x="189" y="1339"/>
+      <point x="141" y="1274" type="curve"/>
+      <point x="141" y="731" type="line"/>
+      <point x="591" y="731" type="line"/>
+      <point x="591" y="887" type="line"/>
+      <point x="324" y="887" type="line"/>
+      <point x="324" y="1223" type="line"/>
+      <point x="356" y="1251"/>
+      <point x="407" y="1319"/>
+      <point x="576" y="1319" type="curve" smooth="yes"/>
+      <point x="775" y="1319"/>
+      <point x="902" y="1174"/>
+      <point x="902" y="864" type="curve" smooth="yes"/>
+      <point x="902" y="589" type="line" smooth="yes"/>
+      <point x="902" y="287"/>
+      <point x="819" y="138"/>
+      <point x="596" y="138" type="curve" smooth="yes"/>
+      <point x="421" y="138"/>
+      <point x="340" y="246"/>
+      <point x="325" y="426" type="curve"/>
+      <point x="141" y="426" type="line"/>
+      <point x="156" y="146"/>
+      <point x="314" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="974"/>
+  <unicode hex="2142"/>
+  <anchor x="728" y="-140" name="bottom"/>
+  <anchor x="20" y="-140" name="bottom0315"/>
+  <anchor x="20" y="-144" name="bottom_dd"/>
+  <anchor x="728" y="-140" name="parent_bottom"/>
+  <anchor x="434" y="1446" name="top"/>
+  <anchor x="20" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="633" y="0" type="line"/>
+      <point x="817" y="0" type="line"/>
+      <point x="817" y="1456" type="line"/>
+      <point x="633" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="62" y="1299" type="line"/>
+      <point x="666" y="1299" type="line"/>
+      <point x="666" y="1456" type="line"/>
+      <point x="62" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="974"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="633" y="0" type="line"/>
+      <point x="817" y="0" type="line"/>
+      <point x="817" y="1456" type="line"/>
+      <point x="633" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="62" y="0" type="line"/>
+      <point x="666" y="0" type="line"/>
+      <point x="666" y="157" type="line"/>
+      <point x="62" y="157" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1075"/>
+  <unicode hex="2144"/>
+  <anchor x="534" y="-144" name="bottom"/>
+  <anchor x="20" y="-144" name="bottom0315"/>
+  <anchor x="20" y="-144" name="bottom_dd"/>
+  <anchor x="534" y="-144" name="parent_bottom"/>
+  <anchor x="538" y="1455" name="top"/>
+  <anchor x="20" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="33" y="0" type="line"/>
+      <point x="241" y="0" type="line"/>
+      <point x="539" y="731" type="line"/>
+      <point x="836" y="0" type="line"/>
+      <point x="1045" y="0" type="line"/>
+      <point x="631" y="912" type="line"/>
+      <point x="631" y="1456" type="line"/>
+      <point x="447" y="1456" type="line"/>
+      <point x="447" y="912" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni214A_.glif
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214A" format="2">
-  <advance width="1201"/>
+  <advance width="1331"/>
   <unicode hex="214A"/>
   <outline>
     <contour>
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1201"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="154" y="300" type="line"/>
+      <point x="330" y="300" type="line"/>
+      <point x="330" y="1301" type="line"/>
+      <point x="668" y="1301" type="line"/>
+      <point x="850" y="1301"/>
+      <point x="925" y="1162"/>
+      <point x="925" y="1003" type="curve"/>
+      <point x="925" y="841"/>
+      <point x="850" y="719"/>
+      <point x="668" y="719" type="curve"/>
+      <point x="592" y="719" type="line"/>
+      <point x="592" y="564" type="line"/>
+      <point x="668" y="564" type="line"/>
+      <point x="947" y="564"/>
+      <point x="1103" y="731"/>
+      <point x="1103" y="1005" type="curve"/>
+      <point x="1103" y="1270"/>
+      <point x="946" y="1456"/>
+      <point x="668" y="1456" type="curve"/>
+      <point x="154" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="651" y="0" type="line"/>
+      <point x="1269" y="0" type="line"/>
+      <point x="1269" y="154" type="line"/>
+      <point x="651" y="154" type="line"/>
+    </contour>
+    <contour>
+      <point x="525" y="0" type="line"/>
+      <point x="703" y="0" type="line"/>
+      <point x="703" y="1600" type="line"/>
+      <point x="525" y="1600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni214B_.glif
@@ -63,7 +63,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1114"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="599" y="-20" type="curve" smooth="yes"/>
+      <point x="789" y="-20"/>
+      <point x="915" y="106"/>
+      <point x="915" y="333" type="curve" smooth="yes"/>
+      <point x="915" y="482"/>
+      <point x="819" y="604"/>
+      <point x="692" y="780" type="curve" smooth="yes"/>
+      <point x="229" y="1456" type="line"/>
+      <point x="18" y="1456" type="line"/>
+      <point x="591" y="630" type="line" smooth="yes"/>
+      <point x="675" y="515"/>
+      <point x="738" y="418"/>
+      <point x="738" y="327" type="curve" smooth="yes"/>
+      <point x="738" y="222"/>
+      <point x="691" y="131"/>
+      <point x="600" y="131" type="curve" smooth="yes"/>
+      <point x="511" y="131"/>
+      <point x="460" y="208"/>
+      <point x="460" y="287" type="curve"/>
+      <point x="460" y="388"/>
+      <point x="495" y="436"/>
+      <point x="565" y="493" type="curve"/>
+      <point x="744" y="648" type="line"/>
+      <point x="901" y="773"/>
+      <point x="1011" y="881"/>
+      <point x="1011" y="1064" type="curve"/>
+      <point x="1011" y="1304"/>
+      <point x="857" y="1476"/>
+      <point x="609" y="1476" type="curve"/>
+      <point x="492" y="1476"/>
+      <point x="357" y="1422"/>
+      <point x="274" y="1314" type="curve" smooth="yes"/>
+      <point x="264" y="1302"/>
+      <point x="259" y="1284"/>
+      <point x="249" y="1272" type="curve" smooth="yes"/>
+      <point x="141" y="1149"/>
+      <point x="94" y="982"/>
+      <point x="94" y="784" type="curve"/>
+      <point x="252" y="784" type="line"/>
+      <point x="252" y="1107"/>
+      <point x="431" y="1324"/>
+      <point x="609" y="1324" type="curve" smooth="yes"/>
+      <point x="761" y="1324"/>
+      <point x="834" y="1206"/>
+      <point x="834" y="1064" type="curve"/>
+      <point x="834" y="1021"/>
+      <point x="826" y="925"/>
+      <point x="714" y="819" type="curve" smooth="yes"/>
+      <point x="464" y="604" type="line" smooth="yes"/>
+      <point x="360" y="517"/>
+      <point x="297" y="428"/>
+      <point x="297" y="287" type="curve"/>
+      <point x="297" y="122"/>
+      <point x="414" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="615"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="265" y="-10" type="curve" smooth="yes"/>
+      <point x="347" y="-10"/>
+      <point x="374" y="51"/>
+      <point x="374" y="117" type="curve" smooth="yes"/>
+      <point x="374" y="140"/>
+      <point x="366" y="204"/>
+      <point x="358" y="277" type="curve"/>
+      <point x="434" y="291"/>
+      <point x="500" y="326"/>
+      <point x="542" y="375" type="curve"/>
+      <point x="551" y="361"/>
+      <point x="556" y="345"/>
+      <point x="556" y="327" type="curve" smooth="yes"/>
+      <point x="556" y="281"/>
+      <point x="509" y="238"/>
+      <point x="491" y="224" type="curve"/>
+      <point x="525" y="224" type="line"/>
+      <point x="544" y="238"/>
+      <point x="586" y="281"/>
+      <point x="586" y="326" type="curve" smooth="yes"/>
+      <point x="586" y="354"/>
+      <point x="576" y="378"/>
+      <point x="559" y="397" type="curve"/>
+      <point x="580" y="427"/>
+      <point x="592" y="462"/>
+      <point x="592" y="500" type="curve" smooth="yes"/>
+      <point x="592" y="608"/>
+      <point x="521" y="725"/>
+      <point x="412" y="725" type="curve" smooth="yes"/>
+      <point x="329" y="725"/>
+      <point x="302" y="664"/>
+      <point x="302" y="569" type="curve" smooth="yes"/>
+      <point x="302" y="548"/>
+      <point x="303" y="515"/>
+      <point x="304" y="477" type="curve"/>
+      <point x="292" y="478"/>
+      <point x="281" y="478"/>
+      <point x="271" y="478" type="curve" smooth="yes"/>
+      <point x="260" y="478"/>
+      <point x="241" y="477"/>
+      <point x="220" y="475" type="curve"/>
+      <point x="222" y="613" type="line"/>
+      <point x="237" y="635"/>
+      <point x="251" y="658"/>
+      <point x="251" y="675" type="curve" smooth="yes"/>
+      <point x="251" y="681"/>
+      <point x="250" y="708"/>
+      <point x="223" y="708" type="curve" smooth="yes"/>
+      <point x="188" y="708"/>
+      <point x="200" y="669"/>
+      <point x="184" y="669" type="curve" smooth="yes"/>
+      <point x="164" y="669"/>
+      <point x="153" y="715"/>
+      <point x="105" y="715" type="curve" smooth="yes"/>
+      <point x="82" y="715"/>
+      <point x="41" y="702"/>
+      <point x="41" y="643" type="curve" smooth="yes"/>
+      <point x="41" y="603"/>
+      <point x="68" y="572"/>
+      <point x="112" y="572" type="curve" smooth="yes"/>
+      <point x="119" y="572"/>
+      <point x="126" y="573"/>
+      <point x="131" y="574" type="curve"/>
+      <point x="130" y="592" type="line"/>
+      <point x="126" y="591"/>
+      <point x="118" y="590"/>
+      <point x="112" y="590" type="curve" smooth="yes"/>
+      <point x="94" y="590"/>
+      <point x="88" y="606"/>
+      <point x="88" y="617" type="curve" smooth="yes"/>
+      <point x="88" y="630"/>
+      <point x="97" y="644"/>
+      <point x="116" y="644" type="curve" smooth="yes"/>
+      <point x="138" y="644"/>
+      <point x="185" y="625"/>
+      <point x="202" y="615" type="curve"/>
+      <point x="186" y="471" type="line"/>
+      <point x="124" y="460"/>
+      <point x="54" y="433"/>
+      <point x="54" y="369" type="curve" smooth="yes"/>
+      <point x="54" y="315"/>
+      <point x="107" y="290"/>
+      <point x="167" y="279" type="curve"/>
+      <point x="160" y="208"/>
+      <point x="156" y="144"/>
+      <point x="156" y="117" type="curve" smooth="yes"/>
+      <point x="156" y="51"/>
+      <point x="183" y="-10"/>
+    </contour>
+    <contour>
+      <point x="265" y="20" type="curve" smooth="yes"/>
+      <point x="228" y="20"/>
+      <point x="208" y="58"/>
+      <point x="208" y="115" type="curve" smooth="yes"/>
+      <point x="208" y="146"/>
+      <point x="210" y="206"/>
+      <point x="212" y="273" type="curve"/>
+      <point x="237" y="270"/>
+      <point x="261" y="270"/>
+      <point x="282" y="270" type="curve" smooth="yes"/>
+      <point x="292" y="270"/>
+      <point x="303" y="270"/>
+      <point x="314" y="271" type="curve"/>
+      <point x="317" y="195"/>
+      <point x="321" y="132"/>
+      <point x="321" y="115" type="curve" smooth="yes"/>
+      <point x="321" y="58"/>
+      <point x="301" y="20"/>
+    </contour>
+    <contour>
+      <point x="169" y="299" type="line"/>
+      <point x="89" y="318"/>
+      <point x="79" y="358"/>
+      <point x="79" y="372" type="curve" smooth="yes"/>
+      <point x="79" y="384"/>
+      <point x="85" y="434"/>
+      <point x="184" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="281" y="288" type="curve" smooth="yes"/>
+      <point x="254" y="288"/>
+      <point x="233" y="289"/>
+      <point x="213" y="291" type="curve"/>
+      <point x="219" y="458" type="line"/>
+      <point x="234" y="459"/>
+      <point x="251" y="460"/>
+      <point x="270" y="460" type="curve" smooth="yes"/>
+      <point x="282" y="460"/>
+      <point x="293" y="459"/>
+      <point x="305" y="459" type="curve"/>
+      <point x="313" y="289" type="line"/>
+      <point x="302" y="288"/>
+      <point x="292" y="288"/>
+    </contour>
+    <contour>
+      <point x="356" y="295" type="curve"/>
+      <point x="337" y="457" type="line"/>
+      <point x="397" y="452"/>
+      <point x="457" y="439"/>
+      <point x="499" y="414" type="curve"/>
+      <point x="476" y="351"/>
+      <point x="428" y="311"/>
+    </contour>
+    <contour>
+      <point x="504" y="436" type="curve"/>
+      <point x="455" y="460"/>
+      <point x="390" y="471"/>
+      <point x="335" y="475" type="curve"/>
+      <point x="331" y="514"/>
+      <point x="329" y="548"/>
+      <point x="329" y="572" type="curve" smooth="yes"/>
+      <point x="329" y="636"/>
+      <point x="335" y="707"/>
+      <point x="409" y="707" type="curve" smooth="yes"/>
+      <point x="500" y="707"/>
+      <point x="516" y="593"/>
+      <point x="516" y="519" type="curve" smooth="yes"/>
+      <point x="516" y="488"/>
+      <point x="511" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="615"/>
+  <advance width="1260"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="265" y="-10" type="curve" smooth="yes"/>
-      <point x="347" y="-10"/>
-      <point x="374" y="51"/>
-      <point x="374" y="117" type="curve" smooth="yes"/>
-      <point x="374" y="140"/>
-      <point x="366" y="204"/>
-      <point x="358" y="277" type="curve"/>
-      <point x="434" y="291"/>
-      <point x="500" y="326"/>
-      <point x="542" y="375" type="curve"/>
-      <point x="551" y="361"/>
-      <point x="556" y="345"/>
-      <point x="556" y="327" type="curve" smooth="yes"/>
-      <point x="556" y="281"/>
-      <point x="509" y="238"/>
-      <point x="491" y="224" type="curve"/>
-      <point x="525" y="224" type="line"/>
-      <point x="544" y="238"/>
-      <point x="586" y="281"/>
-      <point x="586" y="326" type="curve" smooth="yes"/>
-      <point x="586" y="354"/>
-      <point x="576" y="378"/>
-      <point x="559" y="397" type="curve"/>
-      <point x="580" y="427"/>
-      <point x="592" y="462"/>
-      <point x="592" y="500" type="curve" smooth="yes"/>
-      <point x="592" y="608"/>
-      <point x="521" y="725"/>
-      <point x="412" y="725" type="curve" smooth="yes"/>
-      <point x="329" y="725"/>
-      <point x="302" y="664"/>
-      <point x="302" y="569" type="curve" smooth="yes"/>
-      <point x="302" y="548"/>
-      <point x="303" y="515"/>
-      <point x="304" y="477" type="curve"/>
-      <point x="292" y="478"/>
-      <point x="281" y="478"/>
-      <point x="271" y="478" type="curve" smooth="yes"/>
-      <point x="260" y="478"/>
-      <point x="241" y="477"/>
-      <point x="220" y="475" type="curve"/>
-      <point x="222" y="613" type="line"/>
-      <point x="237" y="635"/>
-      <point x="251" y="658"/>
-      <point x="251" y="675" type="curve" smooth="yes"/>
-      <point x="251" y="681"/>
-      <point x="250" y="708"/>
-      <point x="223" y="708" type="curve" smooth="yes"/>
-      <point x="188" y="708"/>
-      <point x="200" y="669"/>
-      <point x="184" y="669" type="curve" smooth="yes"/>
-      <point x="164" y="669"/>
-      <point x="153" y="715"/>
-      <point x="105" y="715" type="curve" smooth="yes"/>
-      <point x="82" y="715"/>
-      <point x="41" y="702"/>
-      <point x="41" y="643" type="curve" smooth="yes"/>
-      <point x="41" y="603"/>
-      <point x="68" y="572"/>
-      <point x="112" y="572" type="curve" smooth="yes"/>
-      <point x="119" y="572"/>
-      <point x="126" y="573"/>
-      <point x="131" y="574" type="curve"/>
-      <point x="130" y="592" type="line"/>
-      <point x="126" y="591"/>
-      <point x="118" y="590"/>
-      <point x="112" y="590" type="curve" smooth="yes"/>
-      <point x="94" y="590"/>
-      <point x="88" y="606"/>
-      <point x="88" y="617" type="curve" smooth="yes"/>
-      <point x="88" y="630"/>
-      <point x="97" y="644"/>
-      <point x="116" y="644" type="curve" smooth="yes"/>
-      <point x="138" y="644"/>
-      <point x="185" y="625"/>
-      <point x="202" y="615" type="curve"/>
-      <point x="186" y="471" type="line"/>
-      <point x="124" y="460"/>
-      <point x="54" y="433"/>
-      <point x="54" y="369" type="curve" smooth="yes"/>
-      <point x="54" y="315"/>
-      <point x="107" y="290"/>
-      <point x="167" y="279" type="curve"/>
-      <point x="160" y="208"/>
-      <point x="156" y="144"/>
-      <point x="156" y="117" type="curve" smooth="yes"/>
-      <point x="156" y="51"/>
-      <point x="183" y="-10"/>
+      <point x="543" y="-20" type="curve" smooth="yes"/>
+      <point x="711" y="-20"/>
+      <point x="766" y="104"/>
+      <point x="766" y="240" type="curve" smooth="yes"/>
+      <point x="766" y="287"/>
+      <point x="750" y="418"/>
+      <point x="733" y="567" type="curve"/>
+      <point x="889" y="596"/>
+      <point x="1024" y="668"/>
+      <point x="1110" y="768" type="curve"/>
+      <point x="1128" y="739"/>
+      <point x="1139" y="707"/>
+      <point x="1139" y="670" type="curve" smooth="yes"/>
+      <point x="1139" y="575"/>
+      <point x="1042" y="487"/>
+      <point x="1006" y="459" type="curve"/>
+      <point x="1075" y="459" type="line"/>
+      <point x="1114" y="487"/>
+      <point x="1200" y="575"/>
+      <point x="1200" y="668" type="curve" smooth="yes"/>
+      <point x="1200" y="725"/>
+      <point x="1180" y="774"/>
+      <point x="1145" y="813" type="curve"/>
+      <point x="1188" y="874"/>
+      <point x="1212" y="946"/>
+      <point x="1212" y="1024" type="curve" smooth="yes"/>
+      <point x="1212" y="1245"/>
+      <point x="1067" y="1485"/>
+      <point x="844" y="1485" type="curve" smooth="yes"/>
+      <point x="674" y="1485"/>
+      <point x="618" y="1360"/>
+      <point x="618" y="1165" type="curve" smooth="yes"/>
+      <point x="618" y="1122"/>
+      <point x="621" y="1055"/>
+      <point x="623" y="977" type="curve"/>
+      <point x="598" y="979"/>
+      <point x="575" y="979"/>
+      <point x="555" y="979" type="curve" smooth="yes"/>
+      <point x="532" y="979"/>
+      <point x="494" y="977"/>
+      <point x="451" y="973" type="curve"/>
+      <point x="455" y="1255" type="line"/>
+      <point x="485" y="1300"/>
+      <point x="514" y="1348"/>
+      <point x="514" y="1382" type="curve" smooth="yes"/>
+      <point x="514" y="1395"/>
+      <point x="512" y="1450"/>
+      <point x="457" y="1450" type="curve" smooth="yes"/>
+      <point x="385" y="1450"/>
+      <point x="410" y="1370"/>
+      <point x="377" y="1370" type="curve" smooth="yes"/>
+      <point x="336" y="1370"/>
+      <point x="313" y="1464"/>
+      <point x="215" y="1464" type="curve" smooth="yes"/>
+      <point x="168" y="1464"/>
+      <point x="84" y="1438"/>
+      <point x="84" y="1317" type="curve" smooth="yes"/>
+      <point x="84" y="1235"/>
+      <point x="139" y="1171"/>
+      <point x="229" y="1171" type="curve" smooth="yes"/>
+      <point x="244" y="1171"/>
+      <point x="258" y="1174"/>
+      <point x="268" y="1176" type="curve"/>
+      <point x="266" y="1212" type="line"/>
+      <point x="258" y="1210"/>
+      <point x="242" y="1208"/>
+      <point x="229" y="1208" type="curve" smooth="yes"/>
+      <point x="193" y="1208"/>
+      <point x="180" y="1241"/>
+      <point x="180" y="1264" type="curve" smooth="yes"/>
+      <point x="180" y="1290"/>
+      <point x="199" y="1319"/>
+      <point x="238" y="1319" type="curve" smooth="yes"/>
+      <point x="283" y="1319"/>
+      <point x="379" y="1280"/>
+      <point x="414" y="1260" type="curve"/>
+      <point x="381" y="965" type="line"/>
+      <point x="254" y="942"/>
+      <point x="111" y="887"/>
+      <point x="111" y="756" type="curve" smooth="yes"/>
+      <point x="111" y="645"/>
+      <point x="219" y="594"/>
+      <point x="342" y="571" type="curve"/>
+      <point x="328" y="426"/>
+      <point x="319" y="295"/>
+      <point x="319" y="240" type="curve" smooth="yes"/>
+      <point x="319" y="104"/>
+      <point x="375" y="-20"/>
     </contour>
     <contour>
-      <point x="265" y="20" type="curve" smooth="yes"/>
-      <point x="228" y="20"/>
-      <point x="208" y="58"/>
-      <point x="208" y="115" type="curve" smooth="yes"/>
-      <point x="208" y="146"/>
-      <point x="210" y="206"/>
-      <point x="212" y="273" type="curve"/>
-      <point x="237" y="270"/>
-      <point x="261" y="270"/>
-      <point x="282" y="270" type="curve" smooth="yes"/>
-      <point x="292" y="270"/>
-      <point x="303" y="270"/>
-      <point x="314" y="271" type="curve"/>
-      <point x="317" y="195"/>
-      <point x="321" y="132"/>
-      <point x="321" y="115" type="curve" smooth="yes"/>
-      <point x="321" y="58"/>
-      <point x="301" y="20"/>
+      <point x="543" y="41" type="curve" smooth="yes"/>
+      <point x="467" y="41"/>
+      <point x="426" y="119"/>
+      <point x="426" y="236" type="curve" smooth="yes"/>
+      <point x="426" y="299"/>
+      <point x="430" y="422"/>
+      <point x="434" y="559" type="curve"/>
+      <point x="485" y="553"/>
+      <point x="535" y="553"/>
+      <point x="578" y="553" type="curve" smooth="yes"/>
+      <point x="598" y="553"/>
+      <point x="621" y="553"/>
+      <point x="643" y="555" type="curve"/>
+      <point x="649" y="399"/>
+      <point x="657" y="270"/>
+      <point x="657" y="236" type="curve" smooth="yes"/>
+      <point x="657" y="119"/>
+      <point x="616" y="41"/>
     </contour>
     <contour>
-      <point x="169" y="299" type="line"/>
-      <point x="89" y="318"/>
-      <point x="79" y="358"/>
-      <point x="79" y="372" type="curve" smooth="yes"/>
-      <point x="79" y="384"/>
-      <point x="85" y="434"/>
-      <point x="184" y="453" type="curve"/>
+      <point x="346" y="612" type="line"/>
+      <point x="182" y="651"/>
+      <point x="162" y="733"/>
+      <point x="162" y="762" type="curve" smooth="yes"/>
+      <point x="162" y="786"/>
+      <point x="174" y="889"/>
+      <point x="377" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="281" y="288" type="curve" smooth="yes"/>
-      <point x="254" y="288"/>
-      <point x="233" y="289"/>
-      <point x="213" y="291" type="curve"/>
-      <point x="219" y="458" type="line"/>
-      <point x="234" y="459"/>
-      <point x="251" y="460"/>
-      <point x="270" y="460" type="curve" smooth="yes"/>
-      <point x="282" y="460"/>
-      <point x="293" y="459"/>
-      <point x="305" y="459" type="curve"/>
-      <point x="313" y="289" type="line"/>
-      <point x="302" y="288"/>
-      <point x="292" y="288"/>
+      <point x="575" y="590" type="curve" smooth="yes"/>
+      <point x="520" y="590"/>
+      <point x="477" y="592"/>
+      <point x="436" y="596" type="curve"/>
+      <point x="449" y="938" type="line"/>
+      <point x="479" y="940"/>
+      <point x="514" y="942"/>
+      <point x="553" y="942" type="curve" smooth="yes"/>
+      <point x="578" y="942"/>
+      <point x="600" y="940"/>
+      <point x="625" y="940" type="curve"/>
+      <point x="641" y="592" type="line"/>
+      <point x="618" y="590"/>
+      <point x="598" y="590"/>
     </contour>
     <contour>
-      <point x="356" y="295" type="curve"/>
-      <point x="337" y="457" type="line"/>
-      <point x="397" y="452"/>
-      <point x="457" y="439"/>
-      <point x="499" y="414" type="curve"/>
-      <point x="476" y="351"/>
-      <point x="428" y="311"/>
+      <point x="729" y="604" type="curve"/>
+      <point x="690" y="936" type="line"/>
+      <point x="813" y="926"/>
+      <point x="936" y="899"/>
+      <point x="1022" y="848" type="curve"/>
+      <point x="975" y="719"/>
+      <point x="877" y="637"/>
     </contour>
     <contour>
-      <point x="504" y="436" type="curve"/>
-      <point x="455" y="460"/>
-      <point x="390" y="471"/>
-      <point x="335" y="475" type="curve"/>
-      <point x="331" y="514"/>
-      <point x="329" y="548"/>
-      <point x="329" y="572" type="curve" smooth="yes"/>
-      <point x="329" y="636"/>
-      <point x="335" y="707"/>
-      <point x="409" y="707" type="curve" smooth="yes"/>
-      <point x="500" y="707"/>
-      <point x="516" y="593"/>
-      <point x="516" y="519" type="curve" smooth="yes"/>
-      <point x="516" y="488"/>
-      <point x="511" y="461"/>
+      <point x="1034" y="893" type="curve"/>
+      <point x="934" y="942"/>
+      <point x="799" y="965"/>
+      <point x="686" y="973" type="curve"/>
+      <point x="678" y="1053"/>
+      <point x="674" y="1122"/>
+      <point x="674" y="1171" type="curve" smooth="yes"/>
+      <point x="674" y="1303"/>
+      <point x="686" y="1448"/>
+      <point x="838" y="1448" type="curve" smooth="yes"/>
+      <point x="1024" y="1448"/>
+      <point x="1057" y="1214"/>
+      <point x="1057" y="1063" type="curve" smooth="yes"/>
+      <point x="1057" y="999"/>
+      <point x="1049" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="888"/>
+  <unicode hex="214E"/>
+  <anchor x="504" y="10" name="bottom"/>
+  <anchor x="901" y="-407" name="bottom_dd"/>
+  <anchor x="542" y="1320" name="parent_top"/>
+  <anchor x="542" y="1320" name="top"/>
+  <anchor x="901" y="1320" name="top0315"/>
+  <anchor x="901" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="554" y="0" type="line"/>
+      <point x="731" y="0" type="line"/>
+      <point x="731" y="1082" type="line"/>
+      <point x="554" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="70" y="0" type="line"/>
+      <point x="592" y="0" type="line"/>
+      <point x="592" y="153" type="line"/>
+      <point x="70" y="153" type="line"/>
+    </contour>
+    <contour>
+      <point x="136" y="513" type="line"/>
+      <point x="592" y="513" type="line"/>
+      <point x="592" y="665" type="line"/>
+      <point x="136" y="665" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:58:39 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Regular.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-Regular.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:58:39 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Regular.ufo/lib.plist
+++ b/sources/RobotoCondensed-Regular.ufo/lib.plist
@@ -6898,6 +6898,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-Thin.ufo/fontinfo.plist
+++ b/sources/RobotoCondensed-Thin.ufo/fontinfo.plist
@@ -59,7 +59,7 @@
     <key>versionMajor</key>
     <integer>3</integer>
     <key>versionMinor</key>
-    <integer>15</integer>
+    <integer>16</integer>
     <key>xHeight</key>
     <integer>1082</integer>
   </dict>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/contents.plist
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/contents.plist
@@ -544,6 +544,8 @@
     <string>O_grave.glif</string>
     <key>Ograve.smcp</key>
     <string>O_grave.smcp.glif</string>
+    <key>uni2127</key>
+    <string>uni2127.glif</string>
     <key>Ohorn</key>
     <string>O_horn.glif</string>
     <key>Ohungarumlaut</key>
@@ -640,6 +642,8 @@
     <string>R_ho.glif</string>
     <key>Rho.smcp</key>
     <string>R_ho.smcp.glif</string>
+    <key>uni213A</key>
+    <string>uni213A_.glif</string>
     <key>Rsmallcap</key>
     <string>R_smallcap.glif</string>
     <key>Rsmallcapinv</key>
@@ -944,6 +948,8 @@
     <string>ampersand.glif</string>
     <key>ampersand.smcp</key>
     <string>ampersand.smcp.glif</string>
+    <key>uni214B</key>
+    <string>uni214B_.glif</string>
     <key>anglesupnosp</key>
     <string>anglesupnosp.glif</string>
     <key>angstrom</key>
@@ -1014,6 +1020,12 @@
     <string>beta1.glif</string>
     <key>bhook</key>
     <string>bhook.glif</string>
+    <key>uni20BF</key>
+    <string>uni20B_F_.glif</string>
+    <key>blackCircle</key>
+    <string>blackC_ircle.glif</string>
+    <key>blackSquare</key>
+    <string>blackS_quare.glif</string>
     <key>braceleft</key>
     <string>braceleft.glif</string>
     <key>braceright</key>
@@ -1094,6 +1106,8 @@
     <string>cedillanosp.glif</string>
     <key>cent</key>
     <string>cent.glif</string>
+    <key>uni2104</key>
+    <string>uni2104.glif</string>
     <key>charactertie</key>
     <string>charactertie.glif</string>
     <key>chi</key>
@@ -1340,6 +1354,8 @@
     <string>eth.glif</string>
     <key>eturn</key>
     <string>eturn.glif</string>
+    <key>uni2107</key>
+    <string>uni2107.glif</string>
     <key>eurocurrency</key>
     <string>eurocurrency.glif</string>
     <key>exclam</key>
@@ -1540,6 +1556,8 @@
     <string>imacron.glif</string>
     <key>infinity</key>
     <string>infinity.glif</string>
+    <key>uni2139</key>
+    <string>uni2139.glif</string>
     <key>integral</key>
     <string>integral.glif</string>
     <key>interrobang</key>
@@ -1610,6 +1628,8 @@
     <string>largerighthook.glif</string>
     <key>lbar</key>
     <string>lbar.glif</string>
+    <key>uni2114</key>
+    <string>uni2114.glif</string>
     <key>lbelt</key>
     <string>lbelt.glif</string>
     <key>lcaron</key>
@@ -1882,6 +1902,8 @@
     <string>periodcentered.glif</string>
     <key>periodcentered.tnum</key>
     <string>periodcentered.tnum.glif</string>
+    <key>uni214C</key>
+    <string>uni214C_.glif</string>
     <key>pertenthousand</key>
     <string>pertenthousand.glif</string>
     <key>perthousand</key>
@@ -1922,6 +1944,8 @@
     <string>primetriplerev1.glif</string>
     <key>product</key>
     <string>product.glif</string>
+    <key>uni214A</key>
+    <string>uni214A_.glif</string>
     <key>psi</key>
     <string>psi.glif</string>
     <key>published</key>
@@ -1980,6 +2004,8 @@
     <string>registered.glif</string>
     <key>response</key>
     <string>response.glif</string>
+    <key>uni2143</key>
+    <string>uni2143.glif</string>
     <key>reverseddblprime</key>
     <string>reverseddblprime.glif</string>
     <key>rfishhook</key>
@@ -2070,6 +2096,8 @@
     <string>schwahook.glif</string>
     <key>scircumflex</key>
     <string>scircumflex.glif</string>
+    <key>uni2108</key>
+    <string>uni2108.glif</string>
     <key>seagullsubnosp</key>
     <string>seagullsubnosp.glif</string>
     <key>second</key>
@@ -2248,6 +2276,14 @@
     <string>ts.glif</string>
     <key>tturn</key>
     <string>tturn.glif</string>
+    <key>uni2141</key>
+    <string>uni2141.glif</string>
+    <key>uni2142</key>
+    <string>uni2142.glif</string>
+    <key>uni2144</key>
+    <string>uni2144.glif</string>
+    <key>uni2129</key>
+    <string>uni2129.glif</string>
     <key>two</key>
     <string>two.glif</string>
     <key>two.onum</key>
@@ -5602,6 +5638,8 @@
     <string>uni213B_.glif</string>
     <key>uni214D</key>
     <string>uni214D_.glif</string>
+    <key>uni214E</key>
+    <string>uni214E_.glif</string>
     <key>uni214F</key>
     <string>uni214F_.glif</string>
     <key>uni2150</key>
@@ -6706,8 +6744,12 @@
     <string>wcircumflex.glif</string>
     <key>wdieresis</key>
     <string>wdieresis.glif</string>
+    <key>uni2118</key>
+    <string>uni2118.glif</string>
     <key>wgrave</key>
     <string>wgrave.glif</string>
+    <key>whiteCircle</key>
+    <string>whiteC_ircle.glif</string>
     <key>won</key>
     <string>won.glif</string>
     <key>wsuper</key>
@@ -6778,11 +6820,5 @@
     <string>zeta.glif</string>
     <key>zrthook</key>
     <string>zrthook.glif</string>
-    <key>blackCircle</key>
-    <string>blackC_ircle.glif</string>
-    <key>blackSquare</key>
-    <string>blackS_quare.glif</string>
-    <key>whiteCircle</key>
-    <string>whiteC_ircle.glif</string>
   </dict>
 </plist>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni20B_F_.glif
@@ -71,7 +71,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:12:36</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni20B_F_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni20B_F_.glif
@@ -1,0 +1,79 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni20BF" format="2">
+  <advance width="860"/>
+  <unicode hex="20BF"/>
+  <outline>
+    <contour>
+      <point x="188" y="0" type="line"/>
+      <point x="433" y="0" type="line" smooth="yes"/>
+      <point x="638" y="0"/>
+      <point x="747" y="147"/>
+      <point x="747" y="397" type="curve" smooth="yes"/>
+      <point x="747" y="604"/>
+      <point x="675" y="729"/>
+      <point x="513" y="770" type="curve"/>
+      <point x="513" y="772" type="line"/>
+      <point x="642" y="799"/>
+      <point x="716" y="938"/>
+      <point x="716" y="1126" type="curve" smooth="yes"/>
+      <point x="716" y="1344"/>
+      <point x="612" y="1456"/>
+      <point x="419" y="1456" type="curve" smooth="yes"/>
+      <point x="188" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="298" y="-201" type="line"/>
+      <point x="347" y="-201" type="line"/>
+      <point x="347" y="27" type="line"/>
+      <point x="298" y="27" type="line"/>
+    </contour>
+    <contour>
+      <point x="472" y="-201" type="line"/>
+      <point x="521" y="-201" type="line"/>
+      <point x="521" y="27" type="line"/>
+      <point x="472" y="27" type="line"/>
+    </contour>
+    <contour>
+      <point x="241" y="51" type="line"/>
+      <point x="241" y="743" type="line"/>
+      <point x="413" y="743" type="line" smooth="yes"/>
+      <point x="567" y="743"/>
+      <point x="689" y="666"/>
+      <point x="689" y="399" type="curve" smooth="yes"/>
+      <point x="689" y="160"/>
+      <point x="591" y="51"/>
+      <point x="421" y="51" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="241" y="795" type="line"/>
+      <point x="241" y="1405" type="line"/>
+      <point x="392" y="1405" type="line" smooth="yes"/>
+      <point x="589" y="1405"/>
+      <point x="661" y="1313"/>
+      <point x="661" y="1126" type="curve" smooth="yes"/>
+      <point x="661" y="903"/>
+      <point x="567" y="795"/>
+      <point x="407" y="795" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="298" y="1415" type="line"/>
+      <point x="347" y="1415" type="line"/>
+      <point x="347" y="1663" type="line"/>
+      <point x="298" y="1663" type="line"/>
+    </contour>
+    <contour>
+      <point x="472" y="1415" type="line"/>
+      <point x="521" y="1415" type="line"/>
+      <point x="521" y="1663" type="line"/>
+      <point x="472" y="1663" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2104.glif
@@ -47,7 +47,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2104.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2104.glif
@@ -1,0 +1,55 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2104" format="2">
+  <advance width="831"/>
+  <unicode hex="2104"/>
+  <outline>
+    <contour>
+      <point x="281" y="0" type="line"/>
+      <point x="766" y="0" type="line"/>
+      <point x="766" y="51" type="line"/>
+      <point x="334" y="51" type="line"/>
+      <point x="334" y="428" type="line"/>
+      <point x="379" y="414"/>
+      <point x="471" y="428"/>
+      <point x="506" y="457" type="curve"/>
+      <point x="506" y="508" type="line"/>
+      <point x="467" y="479"/>
+      <point x="393" y="459"/>
+      <point x="334" y="481" type="curve"/>
+      <point x="334" y="1147" type="line"/>
+      <point x="383" y="1174"/>
+      <point x="447" y="1167"/>
+      <point x="496" y="1135" type="curve"/>
+      <point x="516" y="1182" type="line"/>
+      <point x="461" y="1214"/>
+      <point x="393" y="1225"/>
+      <point x="334" y="1202" type="curve"/>
+      <point x="334" y="1462" type="line"/>
+      <point x="281" y="1462" type="line"/>
+      <point x="281" y="1174" type="line"/>
+      <point x="195" y="1108"/>
+      <point x="139" y="973"/>
+      <point x="139" y="805" type="curve" smooth="yes"/>
+      <point x="139" y="647"/>
+      <point x="189" y="506"/>
+      <point x="281" y="449" type="curve"/>
+    </contour>
+    <contour>
+      <point x="281" y="516" type="line"/>
+      <point x="221" y="578"/>
+      <point x="195" y="696"/>
+      <point x="195" y="809" type="curve" smooth="yes"/>
+      <point x="195" y="932"/>
+      <point x="226" y="1042"/>
+      <point x="281" y="1106" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2107.glif
@@ -11,6 +11,8 @@
       <string>Letter</string>
       <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
       <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Uppercase</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2107.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2107.glif
@@ -1,0 +1,20 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2107" format="2">
+  <advance width="987"/>
+  <unicode hex="2107"/>
+  <outline>
+    <component base="uniA72A"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Letter</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.widthMetricsKey</key>
+      <string>uni0190</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Uppercase</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2108.glif
@@ -1,0 +1,58 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2108" format="2">
+  <advance width="1165"/>
+  <unicode hex="2108"/>
+  <anchor x="606" y="1634" name="parent_top"/>
+  <anchor x="606" y="1634" name="top"/>
+  <anchor x="1146" y="1634" name="top0315"/>
+  <outline>
+    <contour>
+      <point x="576" y="-20" type="curve" smooth="yes"/>
+      <point x="847" y="-20"/>
+      <point x="1026" y="238"/>
+      <point x="1026" y="617" type="curve" smooth="yes"/>
+      <point x="1026" y="839" type="line" smooth="yes"/>
+      <point x="1026" y="1217"/>
+      <point x="849" y="1476"/>
+      <point x="576" y="1476" type="curve" smooth="yes"/>
+      <point x="326" y="1476"/>
+      <point x="160" y="1324"/>
+      <point x="135" y="1013" type="curve"/>
+      <point x="186" y="1013" type="line"/>
+      <point x="212" y="1281"/>
+      <point x="344" y="1426"/>
+      <point x="576" y="1426" type="curve" smooth="yes"/>
+      <point x="814" y="1426"/>
+      <point x="973" y="1193"/>
+      <point x="973" y="841" type="curve" smooth="yes"/>
+      <point x="973" y="617" type="line" smooth="yes"/>
+      <point x="973" y="263"/>
+      <point x="815" y="31"/>
+      <point x="576" y="31" type="curve" smooth="yes"/>
+      <point x="348" y="31"/>
+      <point x="211" y="158"/>
+      <point x="186" y="444" type="curve"/>
+      <point x="135" y="444" type="line"/>
+      <point x="159" y="130"/>
+      <point x="325" y="-20"/>
+    </contour>
+    <contour>
+      <point x="431" y="712" type="line"/>
+      <point x="979" y="712" type="line"/>
+      <point x="979" y="762" type="line"/>
+      <point x="431" y="762" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2108.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2108.glif
@@ -48,7 +48,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/02 09:58:54</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2114.glif
@@ -65,7 +65,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 18:43:08</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2114.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2114.glif
@@ -1,0 +1,73 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2114" format="2">
+  <advance width="1470"/>
+  <unicode hex="2114"/>
+  <anchor x="995" y="-10" name="bottom"/>
+  <anchor x="1451" y="-407" name="bottom_dd"/>
+  <anchor x="462" y="1502" name="marktop"/>
+  <anchor x="990" y="1613" name="parent_top"/>
+  <anchor x="990" y="1613" name="top"/>
+  <anchor x="1451" y="1613" name="top0315"/>
+  <anchor x="1451" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="1004" y="-22" type="curve" smooth="yes"/>
+      <point x="1221" y="-22"/>
+      <point x="1348" y="138"/>
+      <point x="1348" y="494" type="curve" smooth="yes"/>
+      <point x="1348" y="590" type="line"/>
+      <point x="1348" y="957"/>
+      <point x="1220" y="1102"/>
+      <point x="1002" y="1102" type="curve" smooth="yes"/>
+      <point x="802" y="1102"/>
+      <point x="685" y="966"/>
+      <point x="646" y="789" type="curve"/>
+      <point x="646" y="259" type="line"/>
+      <point x="674" y="114"/>
+      <point x="795" y="-22"/>
+    </contour>
+    <contour>
+      <point x="210" y="0" type="line"/>
+      <point x="263" y="0" type="line"/>
+      <point x="263" y="1536" type="line"/>
+      <point x="210" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="641" y="0" type="line"/>
+      <point x="691" y="0" type="line"/>
+      <point x="693" y="210" type="line"/>
+      <point x="693" y="1536" type="line"/>
+      <point x="641" y="1536" type="line"/>
+    </contour>
+    <contour>
+      <point x="1002" y="29" type="curve" smooth="yes"/>
+      <point x="811" y="29"/>
+      <point x="708" y="146"/>
+      <point x="678" y="287" type="curve"/>
+      <point x="678" y="748" type="line"/>
+      <point x="703" y="867"/>
+      <point x="774" y="1052"/>
+      <point x="999" y="1052" type="curve" smooth="yes"/>
+      <point x="1201" y="1052"/>
+      <point x="1294" y="901"/>
+      <point x="1294" y="590" type="curve" smooth="yes"/>
+      <point x="1294" y="494" type="line"/>
+      <point x="1294" y="179"/>
+      <point x="1200" y="29"/>
+    </contour>
+    <contour>
+      <point x="50" y="1281" type="line"/>
+      <point x="989" y="1281" type="line"/>
+      <point x="989" y="1332" type="line"/>
+      <point x="50" y="1332" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2118.glif
@@ -1,90 +1,90 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2118" format="2">
-  <advance width="811"/>
+  <advance width="1610"/>
   <unicode hex="2118"/>
   <outline>
     <contour>
-      <point x="212" y="-241" type="curve" smooth="yes"/>
-      <point x="282" y="-241"/>
-      <point x="329" y="-180"/>
-      <point x="329" y="-95" type="curve" smooth="yes"/>
-      <point x="329" y="8"/>
-      <point x="237" y="99"/>
-      <point x="180" y="200" type="curve"/>
-      <point x="227" y="272"/>
-      <point x="287" y="341"/>
-      <point x="349" y="394" type="curve" smooth="yes"/>
-      <point x="417" y="452"/>
-      <point x="488" y="492"/>
-      <point x="547" y="492" type="curve" smooth="yes"/>
-      <point x="649" y="492"/>
-      <point x="657" y="359"/>
-      <point x="657" y="322" type="curve" smooth="yes"/>
-      <point x="657" y="285"/>
-      <point x="644" y="30"/>
-      <point x="480" y="30" type="curve" smooth="yes"/>
-      <point x="429" y="30"/>
-      <point x="380" y="57"/>
-      <point x="380" y="112" type="curve" smooth="yes"/>
-      <point x="380" y="119"/>
-      <point x="381" y="126"/>
-      <point x="382" y="132" type="curve"/>
-      <point x="415" y="136"/>
-      <point x="448" y="151"/>
-      <point x="448" y="194" type="curve" smooth="yes"/>
-      <point x="448" y="225"/>
-      <point x="427" y="244"/>
-      <point x="396" y="244" type="curve" smooth="yes"/>
-      <point x="348" y="244"/>
-      <point x="318" y="206"/>
-      <point x="318" y="140" type="curve" smooth="yes"/>
-      <point x="318" y="51"/>
-      <point x="382" y="-10"/>
-      <point x="488" y="-10" type="curve" smooth="yes"/>
-      <point x="666" y="-10"/>
-      <point x="759" y="159"/>
-      <point x="759" y="306" type="curve" smooth="yes"/>
-      <point x="759" y="437"/>
-      <point x="699" y="549"/>
-      <point x="577" y="549" type="curve" smooth="yes"/>
-      <point x="527" y="549"/>
-      <point x="431" y="512"/>
-      <point x="325" y="419" type="curve" smooth="yes"/>
-      <point x="273" y="373"/>
-      <point x="212" y="310"/>
-      <point x="160" y="238" type="curve"/>
-      <point x="145" y="272"/>
-      <point x="136" y="307"/>
-      <point x="136" y="345" type="curve" smooth="yes"/>
-      <point x="136" y="474"/>
-      <point x="166" y="548"/>
-      <point x="247" y="625" type="curve"/>
-      <point x="231" y="647" type="line"/>
-      <point x="172" y="610"/>
-      <point x="48" y="496"/>
-      <point x="48" y="337" type="curve" smooth="yes"/>
-      <point x="48" y="267"/>
-      <point x="72" y="206"/>
-      <point x="104" y="149" type="curve"/>
-      <point x="69" y="85"/>
-      <point x="43" y="11"/>
-      <point x="43" y="-56" type="curve" smooth="yes"/>
-      <point x="43" y="-163"/>
-      <point x="117" y="-241"/>
+      <point x="420" y="-494" type="curve" smooth="yes"/>
+      <point x="557" y="-494"/>
+      <point x="651" y="-369"/>
+      <point x="651" y="-195" type="curve" smooth="yes"/>
+      <point x="651" y="16"/>
+      <point x="469" y="203"/>
+      <point x="356" y="410" type="curve"/>
+      <point x="451" y="557"/>
+      <point x="571" y="698"/>
+      <point x="692" y="807" type="curve" smooth="yes"/>
+      <point x="825" y="926"/>
+      <point x="967" y="1008"/>
+      <point x="1085" y="1008" type="curve" smooth="yes"/>
+      <point x="1288" y="1008"/>
+      <point x="1303" y="735"/>
+      <point x="1303" y="659" type="curve" smooth="yes"/>
+      <point x="1303" y="584"/>
+      <point x="1278" y="61"/>
+      <point x="952" y="61" type="curve" smooth="yes"/>
+      <point x="850" y="61"/>
+      <point x="752" y="117"/>
+      <point x="752" y="229" type="curve" smooth="yes"/>
+      <point x="752" y="244"/>
+      <point x="754" y="258"/>
+      <point x="758" y="270" type="curve"/>
+      <point x="823" y="279"/>
+      <point x="889" y="309"/>
+      <point x="889" y="397" type="curve" smooth="yes"/>
+      <point x="889" y="461"/>
+      <point x="846" y="500"/>
+      <point x="784" y="500" type="curve" smooth="yes"/>
+      <point x="688" y="500"/>
+      <point x="631" y="422"/>
+      <point x="631" y="287" type="curve" smooth="yes"/>
+      <point x="631" y="104"/>
+      <point x="756" y="-20"/>
+      <point x="967" y="-20" type="curve" smooth="yes"/>
+      <point x="1319" y="-20"/>
+      <point x="1505" y="326"/>
+      <point x="1505" y="627" type="curve" smooth="yes"/>
+      <point x="1505" y="895"/>
+      <point x="1384" y="1124"/>
+      <point x="1145" y="1124" type="curve" smooth="yes"/>
+      <point x="1044" y="1124"/>
+      <point x="856" y="1049"/>
+      <point x="645" y="858" type="curve" smooth="yes"/>
+      <point x="541" y="764"/>
+      <point x="420" y="635"/>
+      <point x="317" y="487" type="curve"/>
+      <point x="287" y="557"/>
+      <point x="268" y="629"/>
+      <point x="268" y="707" type="curve" smooth="yes"/>
+      <point x="268" y="971"/>
+      <point x="328" y="1122"/>
+      <point x="487" y="1280" type="curve"/>
+      <point x="457" y="1325" type="line"/>
+      <point x="340" y="1249"/>
+      <point x="94" y="1016"/>
+      <point x="94" y="690" type="curve" smooth="yes"/>
+      <point x="94" y="547"/>
+      <point x="141" y="422"/>
+      <point x="205" y="305" type="curve"/>
+      <point x="135" y="174"/>
+      <point x="84" y="23"/>
+      <point x="84" y="-115" type="curve" smooth="yes"/>
+      <point x="84" y="-334"/>
+      <point x="229" y="-494"/>
     </contour>
     <contour>
-      <point x="194" y="-199" type="curve" smooth="yes"/>
-      <point x="150" y="-199"/>
-      <point x="83" y="-145"/>
-      <point x="83" y="-51" type="curve" smooth="yes"/>
-      <point x="83" y="-4"/>
-      <point x="99" y="52"/>
-      <point x="127" y="110" type="curve"/>
-      <point x="181" y="24"/>
-      <point x="242" y="-52"/>
-      <point x="242" y="-134" type="curve" smooth="yes"/>
-      <point x="242" y="-176"/>
-      <point x="223" y="-199"/>
+      <point x="385" y="-408" type="curve" smooth="yes"/>
+      <point x="295" y="-408"/>
+      <point x="164" y="-297"/>
+      <point x="164" y="-104" type="curve" smooth="yes"/>
+      <point x="164" y="-8"/>
+      <point x="197" y="106"/>
+      <point x="252" y="225" type="curve"/>
+      <point x="356" y="49"/>
+      <point x="479" y="-106"/>
+      <point x="479" y="-274" type="curve" smooth="yes"/>
+      <point x="479" y="-360"/>
+      <point x="442" y="-408"/>
     </contour>
   </outline>
   <lib>
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2118.glif
@@ -92,7 +92,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2118.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2118.glif
@@ -1,0 +1,102 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2118" format="2">
+  <advance width="811"/>
+  <unicode hex="2118"/>
+  <outline>
+    <contour>
+      <point x="212" y="-241" type="curve" smooth="yes"/>
+      <point x="282" y="-241"/>
+      <point x="329" y="-180"/>
+      <point x="329" y="-95" type="curve" smooth="yes"/>
+      <point x="329" y="8"/>
+      <point x="237" y="99"/>
+      <point x="180" y="200" type="curve"/>
+      <point x="227" y="272"/>
+      <point x="287" y="341"/>
+      <point x="349" y="394" type="curve" smooth="yes"/>
+      <point x="417" y="452"/>
+      <point x="488" y="492"/>
+      <point x="547" y="492" type="curve" smooth="yes"/>
+      <point x="649" y="492"/>
+      <point x="657" y="359"/>
+      <point x="657" y="322" type="curve" smooth="yes"/>
+      <point x="657" y="285"/>
+      <point x="644" y="30"/>
+      <point x="480" y="30" type="curve" smooth="yes"/>
+      <point x="429" y="30"/>
+      <point x="380" y="57"/>
+      <point x="380" y="112" type="curve" smooth="yes"/>
+      <point x="380" y="119"/>
+      <point x="381" y="126"/>
+      <point x="382" y="132" type="curve"/>
+      <point x="415" y="136"/>
+      <point x="448" y="151"/>
+      <point x="448" y="194" type="curve" smooth="yes"/>
+      <point x="448" y="225"/>
+      <point x="427" y="244"/>
+      <point x="396" y="244" type="curve" smooth="yes"/>
+      <point x="348" y="244"/>
+      <point x="318" y="206"/>
+      <point x="318" y="140" type="curve" smooth="yes"/>
+      <point x="318" y="51"/>
+      <point x="382" y="-10"/>
+      <point x="488" y="-10" type="curve" smooth="yes"/>
+      <point x="666" y="-10"/>
+      <point x="759" y="159"/>
+      <point x="759" y="306" type="curve" smooth="yes"/>
+      <point x="759" y="437"/>
+      <point x="699" y="549"/>
+      <point x="577" y="549" type="curve" smooth="yes"/>
+      <point x="527" y="549"/>
+      <point x="431" y="512"/>
+      <point x="325" y="419" type="curve" smooth="yes"/>
+      <point x="273" y="373"/>
+      <point x="212" y="310"/>
+      <point x="160" y="238" type="curve"/>
+      <point x="145" y="272"/>
+      <point x="136" y="307"/>
+      <point x="136" y="345" type="curve" smooth="yes"/>
+      <point x="136" y="474"/>
+      <point x="166" y="548"/>
+      <point x="247" y="625" type="curve"/>
+      <point x="231" y="647" type="line"/>
+      <point x="172" y="610"/>
+      <point x="48" y="496"/>
+      <point x="48" y="337" type="curve" smooth="yes"/>
+      <point x="48" y="267"/>
+      <point x="72" y="206"/>
+      <point x="104" y="149" type="curve"/>
+      <point x="69" y="85"/>
+      <point x="43" y="11"/>
+      <point x="43" y="-56" type="curve" smooth="yes"/>
+      <point x="43" y="-163"/>
+      <point x="117" y="-241"/>
+    </contour>
+    <contour>
+      <point x="194" y="-199" type="curve" smooth="yes"/>
+      <point x="150" y="-199"/>
+      <point x="83" y="-145"/>
+      <point x="83" y="-51" type="curve" smooth="yes"/>
+      <point x="83" y="-4"/>
+      <point x="99" y="52"/>
+      <point x="127" y="110" type="curve"/>
+      <point x="181" y="24"/>
+      <point x="242" y="-52"/>
+      <point x="242" y="-134" type="curve" smooth="yes"/>
+      <point x="242" y="-176"/>
+      <point x="223" y="-199"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2127.glif
@@ -1,52 +1,52 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni2127" format="2">
-  <advance width="1160"/>
+  <advance width="1157"/>
   <unicode hex="2127"/>
-  <anchor x="577" y="1446" name="top"/>
+  <anchor x="574" y="1446" name="top"/>
   <outline>
     <contour>
-      <point x="586" y="-20" type="curve" smooth="yes"/>
-      <point x="848" y="-20"/>
-      <point x="1025" y="229"/>
-      <point x="1025" y="607" type="curve"/>
-      <point x="1025" y="723" type="line"/>
-      <point x="1025" y="1154"/>
-      <point x="832" y="1351"/>
-      <point x="667" y="1439" type="curve"/>
-      <point x="667" y="1382" type="line"/>
-      <point x="805" y="1298"/>
-      <point x="971" y="1127"/>
-      <point x="971" y="723" type="curve"/>
-      <point x="971" y="605" type="line"/>
-      <point x="971" y="284"/>
-      <point x="823" y="31"/>
-      <point x="586" y="31" type="curve" smooth="yes"/>
-      <point x="346" y="31"/>
-      <point x="196" y="284"/>
-      <point x="196" y="605" type="curve"/>
-      <point x="196" y="723" type="line"/>
-      <point x="196" y="1125"/>
-      <point x="357" y="1297"/>
-      <point x="496" y="1382" type="curve"/>
-      <point x="496" y="1439" type="line"/>
-      <point x="333" y="1349"/>
-      <point x="142" y="1153"/>
-      <point x="142" y="723" type="curve"/>
-      <point x="142" y="607" type="line"/>
-      <point x="142" y="229"/>
-      <point x="324" y="-20"/>
+      <point x="583" y="-20" type="curve" smooth="yes"/>
+      <point x="845" y="-20"/>
+      <point x="1022" y="229"/>
+      <point x="1022" y="607" type="curve"/>
+      <point x="1022" y="723" type="line"/>
+      <point x="1022" y="1154"/>
+      <point x="829" y="1351"/>
+      <point x="664" y="1439" type="curve"/>
+      <point x="664" y="1382" type="line"/>
+      <point x="802" y="1298"/>
+      <point x="968" y="1127"/>
+      <point x="968" y="723" type="curve"/>
+      <point x="968" y="605" type="line"/>
+      <point x="968" y="284"/>
+      <point x="820" y="31"/>
+      <point x="583" y="31" type="curve" smooth="yes"/>
+      <point x="343" y="31"/>
+      <point x="193" y="284"/>
+      <point x="193" y="605" type="curve"/>
+      <point x="193" y="723" type="line"/>
+      <point x="193" y="1125"/>
+      <point x="354" y="1297"/>
+      <point x="493" y="1382" type="curve"/>
+      <point x="493" y="1439" type="line"/>
+      <point x="330" y="1349"/>
+      <point x="139" y="1153"/>
+      <point x="139" y="723" type="curve"/>
+      <point x="139" y="607" type="line"/>
+      <point x="139" y="229"/>
+      <point x="321" y="-20"/>
     </contour>
     <contour>
-      <point x="126" y="1405" type="line"/>
-      <point x="496" y="1405" type="line"/>
-      <point x="496" y="1456" type="line"/>
-      <point x="126" y="1456" type="line"/>
+      <point x="123" y="1405" type="line"/>
+      <point x="493" y="1405" type="line"/>
+      <point x="493" y="1456" type="line"/>
+      <point x="123" y="1456" type="line"/>
     </contour>
     <contour>
-      <point x="667" y="1405" type="line"/>
-      <point x="1037" y="1405" type="line"/>
-      <point x="1037" y="1456" type="line"/>
-      <point x="667" y="1456" type="line"/>
+      <point x="664" y="1405" type="line"/>
+      <point x="1034" y="1405" type="line"/>
+      <point x="1034" y="1456" type="line"/>
+      <point x="664" y="1456" type="line"/>
     </contour>
   </outline>
   <lib>
@@ -54,7 +54,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/02 09:05:46</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2127.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2127.glif
@@ -1,0 +1,64 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2127" format="2">
+  <advance width="1160"/>
+  <unicode hex="2127"/>
+  <anchor x="577" y="1446" name="top"/>
+  <outline>
+    <contour>
+      <point x="586" y="-20" type="curve" smooth="yes"/>
+      <point x="848" y="-20"/>
+      <point x="1025" y="229"/>
+      <point x="1025" y="607" type="curve"/>
+      <point x="1025" y="723" type="line"/>
+      <point x="1025" y="1154"/>
+      <point x="832" y="1351"/>
+      <point x="667" y="1439" type="curve"/>
+      <point x="667" y="1382" type="line"/>
+      <point x="805" y="1298"/>
+      <point x="971" y="1127"/>
+      <point x="971" y="723" type="curve"/>
+      <point x="971" y="605" type="line"/>
+      <point x="971" y="284"/>
+      <point x="823" y="31"/>
+      <point x="586" y="31" type="curve" smooth="yes"/>
+      <point x="346" y="31"/>
+      <point x="196" y="284"/>
+      <point x="196" y="605" type="curve"/>
+      <point x="196" y="723" type="line"/>
+      <point x="196" y="1125"/>
+      <point x="357" y="1297"/>
+      <point x="496" y="1382" type="curve"/>
+      <point x="496" y="1439" type="line"/>
+      <point x="333" y="1349"/>
+      <point x="142" y="1153"/>
+      <point x="142" y="723" type="curve"/>
+      <point x="142" y="607" type="line"/>
+      <point x="142" y="229"/>
+      <point x="324" y="-20"/>
+    </contour>
+    <contour>
+      <point x="126" y="1405" type="line"/>
+      <point x="496" y="1405" type="line"/>
+      <point x="496" y="1456" type="line"/>
+      <point x="126" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="667" y="1405" type="line"/>
+      <point x="1037" y="1405" type="line"/>
+      <point x="1037" y="1456" type="line"/>
+      <point x="667" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/17 08:50:15</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2129.glif
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2129" format="2">
+  <advance width="522"/>
+  <unicode hex="2129"/>
+  <anchor x="331" y="-195" name="bottom"/>
+  <anchor x="19" y="-195" name="bottom0315"/>
+  <anchor x="331" y="-195" name="parent_bottom"/>
+  <outline>
+    <contour>
+      <point x="305" y="-8" type="line"/>
+      <point x="358" y="-8" type="line"/>
+      <point x="358" y="804" type="line"/>
+      <point x="358" y="1021"/>
+      <point x="286" y="1080"/>
+      <point x="169" y="1080" type="curve" smooth="yes"/>
+      <point x="143" y="1080"/>
+      <point x="96" y="1082"/>
+      <point x="72" y="1071" type="curve"/>
+      <point x="78" y="1022" type="line"/>
+      <point x="107" y="1028"/>
+      <point x="134" y="1031"/>
+      <point x="168" y="1031" type="curve" smooth="yes"/>
+      <point x="242" y="1031"/>
+      <point x="305" y="995"/>
+      <point x="305" y="805" type="curve"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.script</key>
+      <string>greek</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2129.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2129.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.script</key>
       <string>greek</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2139.glif
@@ -20,6 +20,8 @@
       <string>i</string>
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026/05/26 11:26:23</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2139.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2139.glif
@@ -1,0 +1,29 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2139" format="2">
+  <advance width="399"/>
+  <unicode hex="2139"/>
+  <anchor x="200" y="10" name="bottom"/>
+  <anchor x="380" y="-407" name="bottom_dd"/>
+  <anchor x="207" y="1600" name="parent_top"/>
+  <anchor x="201" y="654" name="rhotichook"/>
+  <anchor x="207" y="1600" name="top"/>
+  <anchor x="380" y="1600" name="top0315"/>
+  <anchor x="380" y="1600" name="top_dd"/>
+  <outline>
+    <component base="i"/>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>i</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni213A_.glif
@@ -53,7 +53,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni213A_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni213A_.glif
@@ -1,0 +1,63 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni213A" format="2">
+  <advance width="1857"/>
+  <unicode hex="213A"/>
+  <anchor x="1602" y="688" name="bottom"/>
+  <anchor x="1999" y="1255" name="bottom_dd"/>
+  <anchor x="-8" y="690" name="parent_top"/>
+  <anchor x="-8" y="690" name="top"/>
+  <anchor x="-8" y="1255" name="top0315"/>
+  <anchor x="-8" y="1255" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="678" y="214" type="curve"/>
+      <point x="1050" y="214" type="line"/>
+      <point x="1406" y="214"/>
+      <point x="1614" y="393"/>
+      <point x="1614" y="675" type="curve" smooth="yes"/>
+      <point x="1614" y="961"/>
+      <point x="1406" y="1136"/>
+      <point x="1050" y="1136" type="curve"/>
+      <point x="678" y="1136" type="line"/>
+      <point x="323" y="1136"/>
+      <point x="116" y="960"/>
+      <point x="116" y="674" type="curve" smooth="yes"/>
+      <point x="116" y="391"/>
+      <point x="323" y="214"/>
+    </contour>
+    <contour>
+      <point x="676" y="269" type="line" smooth="yes"/>
+      <point x="358" y="269"/>
+      <point x="167" y="413"/>
+      <point x="167" y="674" type="curve" smooth="yes"/>
+      <point x="167" y="939"/>
+      <point x="358" y="1082"/>
+      <point x="676" y="1082" type="curve"/>
+      <point x="1050" y="1082" type="line"/>
+      <point x="1371" y="1082"/>
+      <point x="1562" y="940"/>
+      <point x="1562" y="675" type="curve" smooth="yes"/>
+      <point x="1562" y="415"/>
+      <point x="1371" y="269"/>
+      <point x="1050" y="269" type="curve" smooth="yes"/>
+    </contour>
+    <contour>
+      <point x="1573" y="817" type="line"/>
+      <point x="1857" y="1073" type="line"/>
+      <point x="1824" y="1111" type="line"/>
+      <point x="1536" y="856" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2141.glif
@@ -1,0 +1,59 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2141" format="2">
+  <advance width="1231"/>
+  <unicode hex="2141"/>
+  <anchor x="616" y="-179" name="bottom"/>
+  <anchor x="19" y="-179" name="bottom0315"/>
+  <anchor x="19" y="-146" name="bottom_dd"/>
+  <anchor x="616" y="-179" name="parent_bottom"/>
+  <anchor x="593" y="1454" name="top"/>
+  <anchor x="19" y="1861" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="608" y="-22" type="curve" smooth="yes"/>
+      <point x="883" y="-22"/>
+      <point x="1063" y="177"/>
+      <point x="1063" y="519" type="curve" smooth="yes"/>
+      <point x="1063" y="912" type="line" smooth="yes"/>
+      <point x="1063" y="1266"/>
+      <point x="876" y="1476"/>
+      <point x="593" y="1476" type="curve" smooth="yes"/>
+      <point x="349" y="1476"/>
+      <point x="211" y="1351"/>
+      <point x="172" y="1299" type="curve"/>
+      <point x="172" y="796" type="line"/>
+      <point x="596" y="796" type="line"/>
+      <point x="596" y="847" type="line"/>
+      <point x="224" y="847" type="line"/>
+      <point x="224" y="1274" type="line"/>
+      <point x="262" y="1319"/>
+      <point x="394" y="1425"/>
+      <point x="594" y="1425" type="curve" smooth="yes"/>
+      <point x="853" y="1425"/>
+      <point x="1010" y="1231"/>
+      <point x="1010" y="912" type="curve" smooth="yes"/>
+      <point x="1010" y="517" type="line" smooth="yes"/>
+      <point x="1010" y="210"/>
+      <point x="858" y="28"/>
+      <point x="608" y="28" type="curve" smooth="yes"/>
+      <point x="355" y="28"/>
+      <point x="250" y="168"/>
+      <point x="225" y="390" type="curve"/>
+      <point x="172" y="390" type="line"/>
+      <point x="195" y="126"/>
+      <point x="341" y="-22"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2141.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2141.glif
@@ -49,7 +49,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2142.glif
@@ -1,0 +1,41 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2142" format="2">
+  <advance width="937"/>
+  <unicode hex="2142"/>
+  <anchor x="718" y="-92" name="bottom"/>
+  <anchor x="18" y="-92" name="bottom0315"/>
+  <anchor x="18" y="-144" name="bottom_dd"/>
+  <anchor x="718" y="-92" name="parent_bottom"/>
+  <anchor x="389" y="1446" name="top"/>
+  <anchor x="18" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="695" y="0" type="line"/>
+      <point x="749" y="0" type="line"/>
+      <point x="749" y="1456" type="line"/>
+      <point x="695" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="65" y="1405" type="line"/>
+      <point x="725" y="1405" type="line"/>
+      <point x="725" y="1456" type="line"/>
+      <point x="65" y="1456" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2142.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2142.glif
@@ -31,7 +31,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2143.glif
@@ -25,7 +25,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>=|L</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2143.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2143.glif
@@ -1,0 +1,35 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2143" format="2">
+  <advance width="937"/>
+  <unicode hex="2143"/>
+  <outline>
+    <contour>
+      <point x="695" y="0" type="line"/>
+      <point x="749" y="0" type="line"/>
+      <point x="749" y="1456" type="line"/>
+      <point x="695" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="65" y="0" type="line"/>
+      <point x="725" y="0" type="line"/>
+      <point x="725" y="51" type="line"/>
+      <point x="65" y="51" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>=|L</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2144.glif
@@ -30,7 +30,7 @@
       <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
       <string>Y</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/04 08:37:18</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Math</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni2144.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni2144.glif
@@ -1,0 +1,40 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni2144" format="2">
+  <advance width="1075"/>
+  <unicode hex="2144"/>
+  <anchor x="539" y="-146" name="bottom"/>
+  <anchor x="18" y="-146" name="bottom0315"/>
+  <anchor x="18" y="-144" name="bottom_dd"/>
+  <anchor x="539" y="-146" name="parent_bottom"/>
+  <anchor x="538" y="1446" name="top"/>
+  <anchor x="18" y="1863" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="49" y="0" type="line"/>
+      <point x="113" y="0" type="line"/>
+      <point x="539" y="850" type="line"/>
+      <point x="962" y="0" type="line"/>
+      <point x="1029" y="0" type="line"/>
+      <point x="566" y="903" type="line"/>
+      <point x="566" y="1456" type="line"/>
+      <point x="513" y="1456" type="line"/>
+      <point x="513" y="903" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.leftMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.glyph.rightMetricsKey</key>
+      <string>Y</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Math</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni214A_.glif
@@ -1,0 +1,49 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214A" format="2">
+  <advance width="1165"/>
+  <unicode hex="214A"/>
+  <outline>
+    <contour>
+      <point x="174" y="300" type="line"/>
+      <point x="226" y="300" type="line"/>
+      <point x="226" y="1406" type="line"/>
+      <point x="563" y="1406" type="line"/>
+      <point x="810" y="1406"/>
+      <point x="911" y="1236"/>
+      <point x="911" y="1029" type="curve"/>
+      <point x="911" y="830"/>
+      <point x="810" y="667"/>
+      <point x="563" y="667" type="curve"/>
+      <point x="539" y="667" type="line"/>
+      <point x="539" y="615" type="line"/>
+      <point x="563" y="615" type="line"/>
+      <point x="828" y="615"/>
+      <point x="964" y="775"/>
+      <point x="964" y="1031" type="curve"/>
+      <point x="964" y="1289"/>
+      <point x="826" y="1456"/>
+      <point x="563" y="1456" type="curve"/>
+      <point x="174" y="1456" type="line"/>
+    </contour>
+    <contour>
+      <point x="541" y="0" type="line"/>
+      <point x="1100" y="0" type="line"/>
+      <point x="1100" y="51" type="line"/>
+      <point x="541" y="51" type="line"/>
+    </contour>
+    <contour>
+      <point x="507" y="0" type="line"/>
+      <point x="561" y="0" type="line"/>
+      <point x="561" y="1600" type="line"/>
+      <point x="507" y="1600" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni214A_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni214A_.glif
@@ -41,7 +41,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni214B_.glif
@@ -63,7 +63,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni214B_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni214B_.glif
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214B" format="2">
+  <advance width="1098"/>
+  <unicode hex="214B"/>
+  <outline>
+    <contour>
+      <point x="602" y="-20" type="curve" smooth="yes"/>
+      <point x="762" y="-20"/>
+      <point x="864" y="110"/>
+      <point x="864" y="291" type="curve" smooth="yes"/>
+      <point x="864" y="440"/>
+      <point x="790" y="563"/>
+      <point x="666" y="731" type="curve" smooth="yes"/>
+      <point x="125" y="1458" type="line"/>
+      <point x="62" y="1458" type="line"/>
+      <point x="676" y="632" type="line" smooth="yes"/>
+      <point x="767" y="507"/>
+      <point x="810" y="391"/>
+      <point x="810" y="289" type="curve" smooth="yes"/>
+      <point x="810" y="148"/>
+      <point x="738" y="32"/>
+      <point x="601" y="32" type="curve" smooth="yes"/>
+      <point x="481" y="32"/>
+      <point x="416" y="134"/>
+      <point x="416" y="245" type="curve"/>
+      <point x="416" y="342"/>
+      <point x="480" y="431"/>
+      <point x="552" y="500" type="curve"/>
+      <point x="762" y="696" type="line"/>
+      <point x="882" y="813"/>
+      <point x="982" y="943"/>
+      <point x="982" y="1109" type="curve"/>
+      <point x="982" y="1335"/>
+      <point x="842" y="1478"/>
+      <point x="612" y="1478" type="curve"/>
+      <point x="465" y="1478"/>
+      <point x="344" y="1393"/>
+      <point x="251" y="1276" type="curve" smooth="yes"/>
+      <point x="241" y="1264"/>
+      <point x="245" y="1271"/>
+      <point x="235" y="1259" type="curve" smooth="yes"/>
+      <point x="158" y="1146"/>
+      <point x="111" y="1010"/>
+      <point x="111" y="826" type="curve"/>
+      <point x="163" y="826" type="line"/>
+      <point x="163" y="1185"/>
+      <point x="378" y="1427"/>
+      <point x="612" y="1427" type="curve" smooth="yes"/>
+      <point x="829" y="1427"/>
+      <point x="929" y="1273"/>
+      <point x="929" y="1109" type="curve"/>
+      <point x="929" y="1016"/>
+      <point x="902" y="906"/>
+      <point x="735" y="732" type="curve" smooth="yes"/>
+      <point x="527" y="539" type="line" smooth="yes"/>
+      <point x="460" y="479"/>
+      <point x="364" y="365"/>
+      <point x="364" y="245" type="curve"/>
+      <point x="364" y="98"/>
+      <point x="448" y="-20"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni214C_.glif
@@ -1,168 +1,168 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <glyph name="uni214C" format="2">
-  <advance width="615"/>
+  <advance width="1260"/>
   <unicode hex="214C"/>
   <outline>
     <contour>
-      <point x="265" y="-10" type="curve" smooth="yes"/>
-      <point x="347" y="-10"/>
-      <point x="374" y="51"/>
-      <point x="374" y="117" type="curve" smooth="yes"/>
-      <point x="374" y="140"/>
-      <point x="366" y="204"/>
-      <point x="358" y="277" type="curve"/>
-      <point x="434" y="291"/>
-      <point x="500" y="326"/>
-      <point x="542" y="375" type="curve"/>
-      <point x="551" y="361"/>
-      <point x="556" y="345"/>
-      <point x="556" y="327" type="curve" smooth="yes"/>
-      <point x="556" y="281"/>
-      <point x="509" y="238"/>
-      <point x="491" y="224" type="curve"/>
-      <point x="525" y="224" type="line"/>
-      <point x="544" y="238"/>
-      <point x="586" y="281"/>
-      <point x="586" y="326" type="curve" smooth="yes"/>
-      <point x="586" y="354"/>
-      <point x="576" y="378"/>
-      <point x="559" y="397" type="curve"/>
-      <point x="580" y="427"/>
-      <point x="592" y="462"/>
-      <point x="592" y="500" type="curve" smooth="yes"/>
-      <point x="592" y="608"/>
-      <point x="521" y="725"/>
-      <point x="412" y="725" type="curve" smooth="yes"/>
-      <point x="329" y="725"/>
-      <point x="302" y="664"/>
-      <point x="302" y="569" type="curve" smooth="yes"/>
-      <point x="302" y="548"/>
-      <point x="303" y="515"/>
-      <point x="304" y="477" type="curve"/>
-      <point x="292" y="478"/>
-      <point x="281" y="478"/>
-      <point x="271" y="478" type="curve" smooth="yes"/>
-      <point x="260" y="478"/>
-      <point x="241" y="477"/>
-      <point x="220" y="475" type="curve"/>
-      <point x="222" y="613" type="line"/>
-      <point x="237" y="635"/>
-      <point x="251" y="658"/>
-      <point x="251" y="675" type="curve" smooth="yes"/>
-      <point x="251" y="681"/>
-      <point x="250" y="708"/>
-      <point x="223" y="708" type="curve" smooth="yes"/>
-      <point x="188" y="708"/>
-      <point x="200" y="669"/>
-      <point x="184" y="669" type="curve" smooth="yes"/>
-      <point x="164" y="669"/>
-      <point x="153" y="715"/>
-      <point x="105" y="715" type="curve" smooth="yes"/>
-      <point x="82" y="715"/>
-      <point x="41" y="702"/>
-      <point x="41" y="643" type="curve" smooth="yes"/>
-      <point x="41" y="603"/>
-      <point x="68" y="572"/>
-      <point x="112" y="572" type="curve" smooth="yes"/>
-      <point x="119" y="572"/>
-      <point x="126" y="573"/>
-      <point x="131" y="574" type="curve"/>
-      <point x="130" y="592" type="line"/>
-      <point x="126" y="591"/>
-      <point x="118" y="590"/>
-      <point x="112" y="590" type="curve" smooth="yes"/>
-      <point x="94" y="590"/>
-      <point x="88" y="606"/>
-      <point x="88" y="617" type="curve" smooth="yes"/>
-      <point x="88" y="630"/>
-      <point x="97" y="644"/>
-      <point x="116" y="644" type="curve" smooth="yes"/>
-      <point x="138" y="644"/>
-      <point x="185" y="625"/>
-      <point x="202" y="615" type="curve"/>
-      <point x="186" y="471" type="line"/>
-      <point x="124" y="460"/>
-      <point x="54" y="433"/>
-      <point x="54" y="369" type="curve" smooth="yes"/>
-      <point x="54" y="315"/>
-      <point x="107" y="290"/>
-      <point x="167" y="279" type="curve"/>
-      <point x="160" y="208"/>
-      <point x="156" y="144"/>
-      <point x="156" y="117" type="curve" smooth="yes"/>
-      <point x="156" y="51"/>
-      <point x="183" y="-10"/>
+      <point x="543" y="-20" type="curve" smooth="yes"/>
+      <point x="711" y="-20"/>
+      <point x="766" y="104"/>
+      <point x="766" y="240" type="curve" smooth="yes"/>
+      <point x="766" y="287"/>
+      <point x="750" y="418"/>
+      <point x="733" y="567" type="curve"/>
+      <point x="889" y="596"/>
+      <point x="1024" y="668"/>
+      <point x="1110" y="768" type="curve"/>
+      <point x="1128" y="739"/>
+      <point x="1139" y="707"/>
+      <point x="1139" y="670" type="curve" smooth="yes"/>
+      <point x="1139" y="575"/>
+      <point x="1042" y="487"/>
+      <point x="1006" y="459" type="curve"/>
+      <point x="1075" y="459" type="line"/>
+      <point x="1114" y="487"/>
+      <point x="1200" y="575"/>
+      <point x="1200" y="668" type="curve" smooth="yes"/>
+      <point x="1200" y="725"/>
+      <point x="1180" y="774"/>
+      <point x="1145" y="813" type="curve"/>
+      <point x="1188" y="874"/>
+      <point x="1212" y="946"/>
+      <point x="1212" y="1024" type="curve" smooth="yes"/>
+      <point x="1212" y="1245"/>
+      <point x="1067" y="1485"/>
+      <point x="844" y="1485" type="curve" smooth="yes"/>
+      <point x="674" y="1485"/>
+      <point x="618" y="1360"/>
+      <point x="618" y="1165" type="curve" smooth="yes"/>
+      <point x="618" y="1122"/>
+      <point x="621" y="1055"/>
+      <point x="623" y="977" type="curve"/>
+      <point x="598" y="979"/>
+      <point x="575" y="979"/>
+      <point x="555" y="979" type="curve" smooth="yes"/>
+      <point x="532" y="979"/>
+      <point x="494" y="977"/>
+      <point x="451" y="973" type="curve"/>
+      <point x="455" y="1255" type="line"/>
+      <point x="485" y="1300"/>
+      <point x="514" y="1348"/>
+      <point x="514" y="1382" type="curve" smooth="yes"/>
+      <point x="514" y="1395"/>
+      <point x="512" y="1450"/>
+      <point x="457" y="1450" type="curve" smooth="yes"/>
+      <point x="385" y="1450"/>
+      <point x="410" y="1370"/>
+      <point x="377" y="1370" type="curve" smooth="yes"/>
+      <point x="336" y="1370"/>
+      <point x="313" y="1464"/>
+      <point x="215" y="1464" type="curve" smooth="yes"/>
+      <point x="168" y="1464"/>
+      <point x="84" y="1438"/>
+      <point x="84" y="1317" type="curve" smooth="yes"/>
+      <point x="84" y="1235"/>
+      <point x="139" y="1171"/>
+      <point x="229" y="1171" type="curve" smooth="yes"/>
+      <point x="244" y="1171"/>
+      <point x="258" y="1174"/>
+      <point x="268" y="1176" type="curve"/>
+      <point x="266" y="1212" type="line"/>
+      <point x="258" y="1210"/>
+      <point x="242" y="1208"/>
+      <point x="229" y="1208" type="curve" smooth="yes"/>
+      <point x="193" y="1208"/>
+      <point x="180" y="1241"/>
+      <point x="180" y="1264" type="curve" smooth="yes"/>
+      <point x="180" y="1290"/>
+      <point x="199" y="1319"/>
+      <point x="238" y="1319" type="curve" smooth="yes"/>
+      <point x="283" y="1319"/>
+      <point x="379" y="1280"/>
+      <point x="414" y="1260" type="curve"/>
+      <point x="381" y="965" type="line"/>
+      <point x="254" y="942"/>
+      <point x="111" y="887"/>
+      <point x="111" y="756" type="curve" smooth="yes"/>
+      <point x="111" y="645"/>
+      <point x="219" y="594"/>
+      <point x="342" y="571" type="curve"/>
+      <point x="328" y="426"/>
+      <point x="319" y="295"/>
+      <point x="319" y="240" type="curve" smooth="yes"/>
+      <point x="319" y="104"/>
+      <point x="375" y="-20"/>
     </contour>
     <contour>
-      <point x="265" y="20" type="curve" smooth="yes"/>
-      <point x="228" y="20"/>
-      <point x="208" y="58"/>
-      <point x="208" y="115" type="curve" smooth="yes"/>
-      <point x="208" y="146"/>
-      <point x="210" y="206"/>
-      <point x="212" y="273" type="curve"/>
-      <point x="237" y="270"/>
-      <point x="261" y="270"/>
-      <point x="282" y="270" type="curve" smooth="yes"/>
-      <point x="292" y="270"/>
-      <point x="303" y="270"/>
-      <point x="314" y="271" type="curve"/>
-      <point x="317" y="195"/>
-      <point x="321" y="132"/>
-      <point x="321" y="115" type="curve" smooth="yes"/>
-      <point x="321" y="58"/>
-      <point x="301" y="20"/>
+      <point x="543" y="41" type="curve" smooth="yes"/>
+      <point x="467" y="41"/>
+      <point x="426" y="119"/>
+      <point x="426" y="236" type="curve" smooth="yes"/>
+      <point x="426" y="299"/>
+      <point x="430" y="422"/>
+      <point x="434" y="559" type="curve"/>
+      <point x="485" y="553"/>
+      <point x="535" y="553"/>
+      <point x="578" y="553" type="curve" smooth="yes"/>
+      <point x="598" y="553"/>
+      <point x="621" y="553"/>
+      <point x="643" y="555" type="curve"/>
+      <point x="649" y="399"/>
+      <point x="657" y="270"/>
+      <point x="657" y="236" type="curve" smooth="yes"/>
+      <point x="657" y="119"/>
+      <point x="616" y="41"/>
     </contour>
     <contour>
-      <point x="169" y="299" type="line"/>
-      <point x="89" y="318"/>
-      <point x="79" y="358"/>
-      <point x="79" y="372" type="curve" smooth="yes"/>
-      <point x="79" y="384"/>
-      <point x="85" y="434"/>
-      <point x="184" y="453" type="curve"/>
+      <point x="346" y="612" type="line"/>
+      <point x="182" y="651"/>
+      <point x="162" y="733"/>
+      <point x="162" y="762" type="curve" smooth="yes"/>
+      <point x="162" y="786"/>
+      <point x="174" y="889"/>
+      <point x="377" y="928" type="curve"/>
     </contour>
     <contour>
-      <point x="281" y="288" type="curve" smooth="yes"/>
-      <point x="254" y="288"/>
-      <point x="233" y="289"/>
-      <point x="213" y="291" type="curve"/>
-      <point x="219" y="458" type="line"/>
-      <point x="234" y="459"/>
-      <point x="251" y="460"/>
-      <point x="270" y="460" type="curve" smooth="yes"/>
-      <point x="282" y="460"/>
-      <point x="293" y="459"/>
-      <point x="305" y="459" type="curve"/>
-      <point x="313" y="289" type="line"/>
-      <point x="302" y="288"/>
-      <point x="292" y="288"/>
+      <point x="575" y="590" type="curve" smooth="yes"/>
+      <point x="520" y="590"/>
+      <point x="477" y="592"/>
+      <point x="436" y="596" type="curve"/>
+      <point x="449" y="938" type="line"/>
+      <point x="479" y="940"/>
+      <point x="514" y="942"/>
+      <point x="553" y="942" type="curve" smooth="yes"/>
+      <point x="578" y="942"/>
+      <point x="600" y="940"/>
+      <point x="625" y="940" type="curve"/>
+      <point x="641" y="592" type="line"/>
+      <point x="618" y="590"/>
+      <point x="598" y="590"/>
     </contour>
     <contour>
-      <point x="356" y="295" type="curve"/>
-      <point x="337" y="457" type="line"/>
-      <point x="397" y="452"/>
-      <point x="457" y="439"/>
-      <point x="499" y="414" type="curve"/>
-      <point x="476" y="351"/>
-      <point x="428" y="311"/>
+      <point x="729" y="604" type="curve"/>
+      <point x="690" y="936" type="line"/>
+      <point x="813" y="926"/>
+      <point x="936" y="899"/>
+      <point x="1022" y="848" type="curve"/>
+      <point x="975" y="719"/>
+      <point x="877" y="637"/>
     </contour>
     <contour>
-      <point x="505" y="436" type="curve"/>
-      <point x="456" y="460"/>
-      <point x="390" y="471"/>
-      <point x="335" y="475" type="curve"/>
-      <point x="331" y="514"/>
-      <point x="329" y="548"/>
-      <point x="329" y="572" type="curve" smooth="yes"/>
-      <point x="329" y="636"/>
-      <point x="335" y="707"/>
-      <point x="409" y="707" type="curve" smooth="yes"/>
-      <point x="500" y="707"/>
-      <point x="516" y="593"/>
-      <point x="516" y="519" type="curve" smooth="yes"/>
-      <point x="516" y="488"/>
-      <point x="512" y="461"/>
+      <point x="1034" y="893" type="curve"/>
+      <point x="934" y="942"/>
+      <point x="799" y="965"/>
+      <point x="686" y="973" type="curve"/>
+      <point x="678" y="1053"/>
+      <point x="674" y="1122"/>
+      <point x="674" y="1171" type="curve" smooth="yes"/>
+      <point x="674" y="1303"/>
+      <point x="686" y="1448"/>
+      <point x="838" y="1448" type="curve" smooth="yes"/>
+      <point x="1024" y="1448"/>
+      <point x="1057" y="1214"/>
+      <point x="1057" y="1063" type="curve" smooth="yes"/>
+      <point x="1057" y="999"/>
+      <point x="1049" y="944"/>
     </contour>
   </outline>
   <lib>
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026/06/01 15:11:51</string>
+      <string>2026/06/05 10:05:22</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni214C_.glif
@@ -1,0 +1,180 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214C" format="2">
+  <advance width="615"/>
+  <unicode hex="214C"/>
+  <outline>
+    <contour>
+      <point x="265" y="-10" type="curve" smooth="yes"/>
+      <point x="347" y="-10"/>
+      <point x="374" y="51"/>
+      <point x="374" y="117" type="curve" smooth="yes"/>
+      <point x="374" y="140"/>
+      <point x="366" y="204"/>
+      <point x="358" y="277" type="curve"/>
+      <point x="434" y="291"/>
+      <point x="500" y="326"/>
+      <point x="542" y="375" type="curve"/>
+      <point x="551" y="361"/>
+      <point x="556" y="345"/>
+      <point x="556" y="327" type="curve" smooth="yes"/>
+      <point x="556" y="281"/>
+      <point x="509" y="238"/>
+      <point x="491" y="224" type="curve"/>
+      <point x="525" y="224" type="line"/>
+      <point x="544" y="238"/>
+      <point x="586" y="281"/>
+      <point x="586" y="326" type="curve" smooth="yes"/>
+      <point x="586" y="354"/>
+      <point x="576" y="378"/>
+      <point x="559" y="397" type="curve"/>
+      <point x="580" y="427"/>
+      <point x="592" y="462"/>
+      <point x="592" y="500" type="curve" smooth="yes"/>
+      <point x="592" y="608"/>
+      <point x="521" y="725"/>
+      <point x="412" y="725" type="curve" smooth="yes"/>
+      <point x="329" y="725"/>
+      <point x="302" y="664"/>
+      <point x="302" y="569" type="curve" smooth="yes"/>
+      <point x="302" y="548"/>
+      <point x="303" y="515"/>
+      <point x="304" y="477" type="curve"/>
+      <point x="292" y="478"/>
+      <point x="281" y="478"/>
+      <point x="271" y="478" type="curve" smooth="yes"/>
+      <point x="260" y="478"/>
+      <point x="241" y="477"/>
+      <point x="220" y="475" type="curve"/>
+      <point x="222" y="613" type="line"/>
+      <point x="237" y="635"/>
+      <point x="251" y="658"/>
+      <point x="251" y="675" type="curve" smooth="yes"/>
+      <point x="251" y="681"/>
+      <point x="250" y="708"/>
+      <point x="223" y="708" type="curve" smooth="yes"/>
+      <point x="188" y="708"/>
+      <point x="200" y="669"/>
+      <point x="184" y="669" type="curve" smooth="yes"/>
+      <point x="164" y="669"/>
+      <point x="153" y="715"/>
+      <point x="105" y="715" type="curve" smooth="yes"/>
+      <point x="82" y="715"/>
+      <point x="41" y="702"/>
+      <point x="41" y="643" type="curve" smooth="yes"/>
+      <point x="41" y="603"/>
+      <point x="68" y="572"/>
+      <point x="112" y="572" type="curve" smooth="yes"/>
+      <point x="119" y="572"/>
+      <point x="126" y="573"/>
+      <point x="131" y="574" type="curve"/>
+      <point x="130" y="592" type="line"/>
+      <point x="126" y="591"/>
+      <point x="118" y="590"/>
+      <point x="112" y="590" type="curve" smooth="yes"/>
+      <point x="94" y="590"/>
+      <point x="88" y="606"/>
+      <point x="88" y="617" type="curve" smooth="yes"/>
+      <point x="88" y="630"/>
+      <point x="97" y="644"/>
+      <point x="116" y="644" type="curve" smooth="yes"/>
+      <point x="138" y="644"/>
+      <point x="185" y="625"/>
+      <point x="202" y="615" type="curve"/>
+      <point x="186" y="471" type="line"/>
+      <point x="124" y="460"/>
+      <point x="54" y="433"/>
+      <point x="54" y="369" type="curve" smooth="yes"/>
+      <point x="54" y="315"/>
+      <point x="107" y="290"/>
+      <point x="167" y="279" type="curve"/>
+      <point x="160" y="208"/>
+      <point x="156" y="144"/>
+      <point x="156" y="117" type="curve" smooth="yes"/>
+      <point x="156" y="51"/>
+      <point x="183" y="-10"/>
+    </contour>
+    <contour>
+      <point x="265" y="20" type="curve" smooth="yes"/>
+      <point x="228" y="20"/>
+      <point x="208" y="58"/>
+      <point x="208" y="115" type="curve" smooth="yes"/>
+      <point x="208" y="146"/>
+      <point x="210" y="206"/>
+      <point x="212" y="273" type="curve"/>
+      <point x="237" y="270"/>
+      <point x="261" y="270"/>
+      <point x="282" y="270" type="curve" smooth="yes"/>
+      <point x="292" y="270"/>
+      <point x="303" y="270"/>
+      <point x="314" y="271" type="curve"/>
+      <point x="317" y="195"/>
+      <point x="321" y="132"/>
+      <point x="321" y="115" type="curve" smooth="yes"/>
+      <point x="321" y="58"/>
+      <point x="301" y="20"/>
+    </contour>
+    <contour>
+      <point x="169" y="299" type="line"/>
+      <point x="89" y="318"/>
+      <point x="79" y="358"/>
+      <point x="79" y="372" type="curve" smooth="yes"/>
+      <point x="79" y="384"/>
+      <point x="85" y="434"/>
+      <point x="184" y="453" type="curve"/>
+    </contour>
+    <contour>
+      <point x="281" y="288" type="curve" smooth="yes"/>
+      <point x="254" y="288"/>
+      <point x="233" y="289"/>
+      <point x="213" y="291" type="curve"/>
+      <point x="219" y="458" type="line"/>
+      <point x="234" y="459"/>
+      <point x="251" y="460"/>
+      <point x="270" y="460" type="curve" smooth="yes"/>
+      <point x="282" y="460"/>
+      <point x="293" y="459"/>
+      <point x="305" y="459" type="curve"/>
+      <point x="313" y="289" type="line"/>
+      <point x="302" y="288"/>
+      <point x="292" y="288"/>
+    </contour>
+    <contour>
+      <point x="356" y="295" type="curve"/>
+      <point x="337" y="457" type="line"/>
+      <point x="397" y="452"/>
+      <point x="457" y="439"/>
+      <point x="499" y="414" type="curve"/>
+      <point x="476" y="351"/>
+      <point x="428" y="311"/>
+    </contour>
+    <contour>
+      <point x="505" y="436" type="curve"/>
+      <point x="456" y="460"/>
+      <point x="390" y="471"/>
+      <point x="335" y="475" type="curve"/>
+      <point x="331" y="514"/>
+      <point x="329" y="548"/>
+      <point x="329" y="572" type="curve" smooth="yes"/>
+      <point x="329" y="636"/>
+      <point x="335" y="707"/>
+      <point x="409" y="707" type="curve" smooth="yes"/>
+      <point x="500" y="707"/>
+      <point x="516" y="593"/>
+      <point x="516" y="519" type="curve" smooth="yes"/>
+      <point x="516" y="488"/>
+      <point x="512" y="461"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.category</key>
+      <string>Symbol</string>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>com.schriftgestaltung.Glyphs.subCategory</key>
+      <string>Other</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni214C_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni214C_.glif
@@ -170,7 +170,7 @@
       <key>com.schriftgestaltung.Glyphs.category</key>
       <string>Symbol</string>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>com.schriftgestaltung.Glyphs.subCategory</key>
       <string>Other</string>
       <key>public.markColor</key>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni214E_.glif
@@ -31,7 +31,7 @@
   <lib>
     <dict>
       <key>com.schriftgestaltung.Glyphs.lastChange</key>
-      <string>2026-05-27 10:56:40 +0000</string>
+      <string>2026/06/01 15:11:51</string>
       <key>public.markColor</key>
       <string>0.04,0.57,0.04,1</string>
     </dict>

--- a/sources/RobotoCondensed-Thin.ufo/glyphs/uni214E_.glif
+++ b/sources/RobotoCondensed-Thin.ufo/glyphs/uni214E_.glif
@@ -1,0 +1,39 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<glyph name="uni214E" format="2">
+  <advance width="925"/>
+  <unicode hex="214E"/>
+  <anchor x="499" y="10" name="bottom"/>
+  <anchor x="950" y="-407" name="bottom_dd"/>
+  <anchor x="571" y="1320" name="parent_top"/>
+  <anchor x="571" y="1320" name="top"/>
+  <anchor x="950" y="1320" name="top0315"/>
+  <anchor x="950" y="1600" name="top_dd"/>
+  <outline>
+    <contour>
+      <point x="684" y="0" type="line"/>
+      <point x="737" y="0" type="line"/>
+      <point x="737" y="1082" type="line"/>
+      <point x="684" y="1082" type="line"/>
+    </contour>
+    <contour>
+      <point x="79" y="0" type="line"/>
+      <point x="713" y="0" type="line"/>
+      <point x="713" y="52" type="line"/>
+      <point x="79" y="52" type="line"/>
+    </contour>
+    <contour>
+      <point x="153" y="547" type="line"/>
+      <point x="713" y="547" type="line"/>
+      <point x="713" y="598" type="line"/>
+      <point x="153" y="598" type="line"/>
+    </contour>
+  </outline>
+  <lib>
+    <dict>
+      <key>com.schriftgestaltung.Glyphs.lastChange</key>
+      <string>2026-05-27 10:56:40 +0000</string>
+      <key>public.markColor</key>
+      <string>0.04,0.57,0.04,1</string>
+    </dict>
+  </lib>
+</glyph>

--- a/sources/RobotoCondensed-Thin.ufo/lib.plist
+++ b/sources/RobotoCondensed-Thin.ufo/lib.plist
@@ -6825,6 +6825,24 @@
       <string>uni25CF</string>
       <string>filledbox</string>
       <string>circle</string>
+      <string>uni2107</string>
+      <string>uni214E</string>
+      <string>uni2129</string>
+      <string>uni2104</string>
+      <string>uni214A</string>
+      <string>uni20BF</string>
+      <string>uni2127</string>
+      <string>uni214B</string>
+      <string>uni2143</string>
+      <string>uni2141</string>
+      <string>uni2142</string>
+      <string>uni2144</string>
+      <string>uni213A</string>
+      <string>uni2139</string>
+      <string>uni214C</string>
+      <string>uni2108</string>
+      <string>uni2118</string>
+      <string>uni2114</string>
     </array>
   </dict>
 </plist>

--- a/sources/vtt-hinting.ttx
+++ b/sources/vtt-hinting.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.62">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.59">
 
   <TSI1>
 
@@ -7445,8 +7445,8 @@ IUP[X]
     <glyphProgram name="blackCircle">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
 MDAP[R], 8
+CALL[], 8, 0, 106
 IUP[Y]
 IUP[X]
 
@@ -7456,7 +7456,9 @@ IUP[X]
 /* VTT 6.35 compiler */
 SVTCA[Y]
 CALL[], 0, 18, 114
-MDAP[R], 1
+CALL[], 0, 1, 106
+IUP[Y]
+IUP[X]
 
     </glyphProgram>
 
@@ -14525,15 +14527,19 @@ IUP[X]
     <glyphProgram name="riyalSaudi">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 16
 MDAP[R], 8
+CALL[], 8, 17, 105
+IP[], 16
+MDAP[R], 16
+SLOOP[], 3
+IP[], 24, 0, 20
+SRP2[], 8
+SLOOP[], 12
+IP[], 21, 3, 33, 4, 42, 25, 38, 39, 32, 34, 5, 37
+SRP1[], 25
 SHP[1], 28
-SRP1[], 16
-SHP[1], 24
-SRP1[], 8
-SHP[1], 36
-SRP1[], 16
-SHP[1], 32
+SRP1[], 32
+SHP[1], 29
 IUP[Y]
 IUP[X]
 
@@ -15654,13 +15660,12 @@ IUP[X]
 /* VTT 6.35 compiler */
 SVTCA[Y]
 CALL[], 13, 11, 114
-MDAP[R], 0
-CALL[], 0, 26, 106
-SRP2[], 13
+SHP[2], 40
+CALL[], 13, 0, 105
+SHP[2], 26
 IP[], 48
 MDAP[R], 48
-CALL[], 48, 32, 106
-CALL[], 13, 40, 106
+SHP[1], 32
 IUP[Y]
 IUP[X]
 
@@ -24821,14 +24826,14 @@ OFFSET[R], 588, 0, 0
     <glyphProgram name="uni0472">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-CALL[], 12, 9, 114
 CALL[], 0, 3, 114
-CALL[], 0, 24, 106
-SRP2[], 12
+SHP[2], 24
+CALL[], 12, 9, 114
+SHP[2], 41
+SRP2[], 0
 IP[], 50
 MDAP[R], 50
-CALL[], 50, 32, 106
-CALL[], 12, 41, 106
+SHP[1], 32
 IUP[Y]
 IUP[X]
 
@@ -24837,14 +24842,14 @@ IUP[X]
     <glyphProgram name="uni0473">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-CALL[], 11, 11, 114
 CALL[], 0, 7, 114
-CALL[], 0, 22, 106
-SRP2[], 11
+SHP[2], 22
+CALL[], 11, 11, 114
+SHP[2], 33
+SRP2[], 0
 IP[], 39
 MDAP[R], 39
-CALL[], 39, 27, 106
-CALL[], 11, 33, 106
+SHP[1], 27
 IUP[Y]
 IUP[X]
 
@@ -40274,30 +40279,29 @@ IUP[X]
     <glyphProgram name="uni20BF">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 20
-MDAP[R], 50
-SRP2[], 20
-IP[], 1
-MDAP[R], 1
-CALL[], 1, 48, 106
-SRP1[], 50
-SRP2[], 20
-IP[], 38
-MDAP[R], 38
-CALL[], 38, 39, 106
-SRP1[], 50
-SRP2[], 20
-IP[], 0
-MDAP[R], 0
-CALL[], 0, 28, 106
-SRP1[], 38
+CALL[], 0, 8, 114
+CALL[], 0, 20, 106
+SHP[2], 24
+SHP[1], 28
+SRP2[], 28
+IP[], 22
+SRP1[], 22
 SHP[1], 25
-SRP1[], 20
-SHP[1], 24
-SRP1[], 50
-SHP[1], 54
-SRP1[], 38
+CALL[], 1, 2, 114
+SRP2[], 0
+IP[], 39
+MDAP[R], 39
+SHP[1], 38
+SRP2[], 38
+IP[], 10
+SRP1[], 1
+SHP[1], 48
+SRP2[], 48
+IP[], 52
+SRP1[], 52
 SHP[1], 53
+CALL[], 1, 50, 106
+SHP[2], 54
 IUP[Y]
 IUP[X]
 
@@ -40360,13 +40364,22 @@ IUP[X]
     <glyphProgram name="uni2104">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 9
-CALL[], 0, 27, 106
-SRP1[], 9
-SHP[1], 31
-SRP1[], 0
+CALL[], 0, 8, 114
+SHP[2], 27
+CALL[], 9, 2, 114
+SRP2[], 0
+IP[], 1
+IP[], 8
+SRP1[], 1
+SHP[1], 26
 SHP[1], 30
+SRP1[], 30
+SHP[1], 19
+SRP1[], 8
+SHP[1], 11
+SHP[1], 31
+SRP1[], 31
+SHP[1], 18
 IUP[Y]
 IUP[X]
 
@@ -40394,17 +40407,23 @@ IUP[X]
 
     </glyphProgram>
 
+    <glyphProgram name="uni2107">
+USEMYMETRICS[]
+OFFSET[R], 1637, 0, 0
+
+    </glyphProgram>
+
     <glyphProgram name="uni2108">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 30
-CALL[], 30, 21, 106
-SRP2[], 0
+CALL[], 0, 9, 114
+SHP[2], 9
+CALL[], 30, 3, 114
+SHP[2], 21
+SRP1[], 0
 IP[], 41
 MDAP[R], 41
-CALL[], 41, 42, 106
-CALL[], 0, 9, 106
+SHP[1], 42
 IUP[Y]
 IUP[X]
 
@@ -40429,22 +40448,18 @@ IUP[X]
     <glyphProgram name="uni2114">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 23
-IP[], 53
-MDAP[R], 53
-CALL[], 53, 52, 106
-SRP1[], 23
-SRP2[], 0
-IP[], 11
-MDAP[R], 11
-CALL[], 11, 42, 106
-CALL[], 0, 31, 106
-SRP1[], 23
-SHP[1], 27
-SRP1[], 0
-SHP[1], 26
-SHP[1], 25
+CALL[], 0, 11, 114
+SHP[2], 31
+CALL[], 11, 7, 114
+SHP[2], 42
+CALL[], 23, 0, 114
+SHP[2], 27
+SRP1[], 11
+IP[], 52
+SRP1[], 52
+SHP[1], 53
+CALL[], 26, 10, 114
+SHP[2], 25
 IUP[Y]
 IUP[X]
 
@@ -40502,17 +40517,16 @@ IUP[X]
     <glyphProgram name="uni2118">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 15
-IP[], 29
-MDAP[R], 29
-CALL[], 29, 66, 106
-SRP1[], 15
-SRP2[], 0
-IP[], 38
-MDAP[R], 38
-CALL[], 38, 55, 106
-CALL[], 0, 79, 106
+CALL[], 38, 9, 114
+SHP[2], 55
+CALL[], 38, 0, 105
+SHP[2], 79
+CALL[], 38, 29, 105
+CALL[], 29, 15, 105
+SHP[1], 66
+SRP2[], 38
+SLOOP[], 6
+IP[], 86, 50, 7, 72, 23, 44
 IUP[Y]
 IUP[X]
 
@@ -40521,17 +40535,19 @@ IUP[X]
     <glyphProgram name="uni2127">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 47
-CALL[], 47, 46, 106
-CALL[], 0, 23, 106
-SRP1[], 47
-SHP[1], 51
-SRP1[], 0
-SHP[1], 50
-SRP1[], 47
+CALL[], 0, 8, 114
+SHP[2], 23
+CALL[], 47, 2, 114
+SHP[2], 52
+SHP[2], 11
+SRP1[], 11
 SHP[1], 35
-SHP[1], 11
+SHP[2], 46
+SRP1[], 46
+SHP[1], 53
+SHP[1], 12
+SRP1[], 12
+SHP[1], 34
 IUP[Y]
 IUP[X]
 
@@ -40540,24 +40556,32 @@ IUP[X]
     <glyphProgram name="uni2129">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 12
-CALL[], 12, 5, 106
-SHP[1], 9
+CALL[], 0, 13, 114
+CALL[], 0, 12, 105
+SHP[2], 5
+SHP[2], 9
 IUP[Y]
 IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2139">
+USEMYMETRICS[]
+OFFSET[R], 78, 0, 0
 
     </glyphProgram>
 
     <glyphProgram name="uni213A">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 38
-IP[], 8
 MDAP[R], 8
-CALL[], 8, 28, 106
-CALL[], 0, 18, 106
+SHP[1], 28
+CALL[], 8, 0, 105
+SHP[2], 18
+IP[], 36
+IP[], 37
+CALL[], 37, 39, 105
+SHP[2], 38
 IUP[Y]
 IUP[X]
 
@@ -40598,14 +40622,18 @@ IUP[X]
     <glyphProgram name="uni2141">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 33
-CALL[], 33, 20, 106
-SRP2[], 0
+CALL[], 0, 9, 114
+SHP[2], 9
+CALL[], 33, 3, 114
+SHP[2], 20
+SRP1[], 0
 IP[], 25
 MDAP[R], 25
-CALL[], 25, 28, 106
-CALL[], 0, 9, 106
+IP[], 29
+IP[], 24
+SRP2[], 0
+IP[], 5
+SHP[1], 28
 IUP[Y]
 IUP[X]
 
@@ -40614,11 +40642,11 @@ IUP[X]
     <glyphProgram name="uni2142">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 1
-IP[], 5
-MDAP[R], 5
-CALL[], 5, 4, 106
+CALL[], 0, 8, 114
+CALL[], 1, 2, 114
+SHP[2], 5
+SRP1[], 5
+SHP[1], 4
 IUP[Y]
 IUP[X]
 
@@ -40627,11 +40655,11 @@ IUP[X]
     <glyphProgram name="uni2143">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 1
-IP[], 4
-MDAP[R], 4
-CALL[], 4, 5, 106
+CALL[], 1, 2, 114
+CALL[], 3, 8, 114
+SHP[2], 7
+SRP1[], 7
+SHP[1], 6
 IUP[Y]
 IUP[X]
 
@@ -40640,9 +40668,12 @@ IUP[X]
     <glyphProgram name="uni2144">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 2
+CALL[], 0, 8, 114
 SHP[2], 6
+CALL[], 2, 2, 114
+SRP2[], 6
+SLOOP[], 3
+IP[], 7, 1, 4
 IUP[Y]
 IUP[X]
 
@@ -40651,19 +40682,18 @@ IUP[X]
     <glyphProgram name="uni214A">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 24
-MDAP[R], 29
-SRP2[], 24
-IP[], 1
-MDAP[R], 1
-CALL[], 1, 22, 106
-SRP1[], 29
-SRP2[], 24
+CALL[], 1, 2, 114
+SHP[2], 22
+CALL[], 1, 29, 106
+CALL[], 24, 8, 114
+SHP[2], 25
+SHP[2], 28
+SRP2[], 1
 IP[], 11
 MDAP[R], 11
-CALL[], 11, 12, 106
-CALL[], 24, 25, 106
-SHP[1], 31
+SRP2[], 24
+IP[], 23
+SHP[1], 12
 IUP[Y]
 IUP[X]
 
@@ -40672,12 +40702,14 @@ IUP[X]
     <glyphProgram name="uni214B">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 33
-CALL[], 33, 17, 106
-CALL[], 0, 48, 106
-SRP1[], 33
-SHP[1], 58
+CALL[], 0, 19, 114
+SHP[2], 48
+CALL[], 33, 3, 114
+SHP[2], 17
+SRP2[], 0
+SLOOP[], 9
+IP[], 42, 8, 56, 41, 59, 22, 9, 27, 30
+CALL[], 58, 2, 114
 IUP[Y]
 IUP[X]
 
@@ -40686,37 +40718,32 @@ IUP[X]
     <glyphProgram name="uni214C">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 64
-CALL[], 64, 147, 106
-SRP2[], 0
-IP[], 38
-MDAP[R], 38
-CALL[], 38, 19, 106
-SRP1[], 64
-SRP2[], 0
-IP[], 25
-MDAP[R], 25
-CALL[], 25, 31, 106
-SRP1[], 64
-SRP2[], 0
-IP[], 55
-MDAP[R], 55
-CALL[], 55, 128, 106
-SHP[2], 139
-SHP[1], 153
-SRP1[], 64
-SRP2[], 0
-IP[], 103
-MDAP[R], 103
-CALL[], 103, 121, 106
-CALL[], 0, 94, 106
-SRP1[], 55
-SHP[1], 113
+CALL[], 0, 9, 114
+SHP[2], 94
+CALL[], 64, 3, 114
+SHP[2], 46
+SHP[2], 147
+SHP[2], 38
+SRP1[], 38
+SHP[1], 19
+SHP[1], 42
+SRP1[], 0
+SLOOP[], 7
+IP[], 78, 103, 84, 71, 136, 140, 55
 SRP1[], 103
+SHP[1], 7
+SHP[1], 87
+SHP[1], 121
+SRP1[], 121
 SHP[1], 112
-SRP1[], 64
-SHP[1], 46
+SHP[1], 134
+SRP1[], 55
+SHP[1], 14
+SHP[1], 153
+SHP[1], 128
+SRP1[], 128
+SHP[1], 113
+SHP[1], 139
 IUP[Y]
 IUP[X]
 
@@ -40750,16 +40777,15 @@ IUP[X]
     <glyphProgram name="uni214E">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
-MDAP[R], 1
+CALL[], 0, 13, 114
+CALL[], 0, 1, 106
 IP[], 8
 MDAP[R], 8
-CALL[], 8, 9, 106
-SRP1[], 1
-SRP2[], 0
-IP[], 4
+SHP[1], 9
+SRP1[], 0
+SHP[1], 4
 MDAP[R], 4
-CALL[], 4, 5, 106
+SHP[1], 5
 IUP[Y]
 IUP[X]
 
@@ -49513,10 +49539,10 @@ SHC[2], 4
     <glyphProgram name="whiteCircle">
 /* VTT 6.35 compiler */
 SVTCA[Y]
-MDAP[R], 0
 MDAP[R], 8
-CALL[], 8, 24, 106
-CALL[], 0, 16, 106
+SHP[1], 24
+CALL[], 8, 0, 105
+SHP[2], 16
 IUP[Y]
 IUP[X]
 
@@ -59838,42 +59864,24 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="blackCircle">
-/* VTTTalk Unicode 0x25cf */
-/* ACT generated Tue Sep 16 09:34:43 2025 */
+/* Y direction */
+YAnchor(8)
+ResYDist(8,0)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(8)	/* max */
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="blackSquare">
-/* VTTTalk Unicode 0x25a0 */
-/* ACT generated Tue Sep 16 09:34:43 2025 */
+/* Y direction */
+ResYAnchor(0,18)
+ResYDist(0,1)
 
-/* Auto-Hinting Light */
+/* X direction */
 
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 18 */
-/* Min and Max */
-ResYAnchor(0,18)	/* min, CVT */
-YAnchor(1)	/* max */
-
-/* CVTs - beginning */
-/* CVTs - end */
+Smooth()
 
     </glyphProgram>
 
@@ -65813,29 +65821,16 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="riyalSaudi">
-/* VTTTalk Unicode 0x20c1 */
-/* ACT generated Fri Dec  5 13:39:13 2025 */
+/* Y direction */
+YAnchor(8)
+ResYDist(8,17)
+YIPAnchor(17,16,8)
+YInterpolate(17,24,0,20,16)
+YInterpolate(16,21,3,33,4,42,25,38,39,32,34,5,37,8)
+YShift(25,28)
+YShift(32,29)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 8 17  DISABLED for a NON-LATIN glyph */
-/* CVT 16 19  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(16)	/* min */
-YAnchor(8)	/* max */
-
-/* Contour #2 */
-YShift(8,28) /* max */
-YShift(16,24) /* min */
-
-/* Contour #3 */
-YShift(8,36) /* max */
-YShift(16,32) /* min */
+/* X direction */
 
 Smooth()
 
@@ -66727,35 +66722,15 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="theta">
-/* VTTTalk Unicode 0x3b8 */
-/* ACT generated Tue Nov  3 08:51:00 2020 */
+/* Y direction */
+ResYAnchor(13,11)
+YShift(13,40)
+ResYDist(13,0)
+YShift(0,26)
+YIPAnchor(0,48,13)
+YShift(48,32)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 13 11 */
-/* Min and Max */
-ResYAnchor(13,11)	/* min, CVT */
-YAnchor(0)	/* max */
-
-/* CVTs - beginning */
-/* CVTs - end */
-
-
-/* YDir: Stroke #0 */
-ResYDist(0,26) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(0,48,13)
-YAnchor(48)
-ResYDist(48,32) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #2 */
-ResYDist(13,40) /*perpendicular to the stroke*/
+/* X direction */
 
 Smooth()
 
@@ -75507,72 +75482,30 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="uni0472">
-/* VTTTalk Unicode 0x472 */
-/* ACT generated Tue Nov  3 08:51:00 2020 */
+/* Y direction */
+ResYAnchor(0,3)
+YShift(0,24)
+ResYAnchor(12,9)
+YShift(12,41)
+YIPAnchor(0,50,12)
+YShift(50,32)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 3 */
-/* CVT 12 9 */
-/* Min and Max */
-ResYAnchor(12,9)	/* min, CVT */
-ResYAnchor(0,3)	/* max, CVT */
-
-/* CVTs - beginning */
-/* CVTs - end */
-
-
-/* YDir: Stroke #0 */
-ResYDist(0,24) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(0,50,12)
-YAnchor(50)
-ResYDist(50,32) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #2 */
-ResYDist(12,41) /*perpendicular to the stroke*/
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="uni0473">
-/* VTTTalk Unicode 0x473 */
-/* ACT generated Tue Nov  3 08:51:00 2020 */
+/* Y direction */
+ResYAnchor(0,7)
+YShift(0,22)
+ResYAnchor(11,11)
+YShift(11,33)
+YIPAnchor(0,39,11)
+YShift(39,27)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 7 */
-/* CVT 11 11 */
-/* Min and Max */
-ResYAnchor(11,11)	/* min, CVT */
-ResYAnchor(0,7)	/* max, CVT */
-
-/* CVTs - beginning */
-/* CVTs - end */
-
-
-/* YDir: Stroke #0 */
-ResYDist(0,22) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(0,39,11)
-YAnchor(39)
-ResYDist(39,27) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #2 */
-ResYDist(11,33) /*perpendicular to the stroke*/
+/* X direction */
 
 Smooth()
 
@@ -83318,44 +83251,24 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="uni20BF">
-/* VTTTalk Unicode 0x20bf */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
+/* Y direction */
+ResYAnchor(0,8)
+ResYDist(0,20,&gt;=)
+YShift(20,24)
+YShift(0,28)
+YInterpolate(28,22,0)
+YShift(22,25)
+ResYAnchor(1,2)
+YIPAnchor(0,39,1)
+YShift(39,38)
+YInterpolate(38,10,39)
+YShift(1,48)
+YInterpolate(1,52,48)
+YShift(52,53)
+ResYDist(1,50,&gt;=)
+YShift(50,54)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 18  DISABLED for a NON-LATIN glyph */
-/* CVT 1 16  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(20)	/* min */
-YAnchor(50)	/* max */
-
-/* YDir: Stroke #0 */
-YInterpolate(50,1,20)
-YAnchor(1)
-ResYDist(1,48) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(50,38,20)
-YAnchor(38)
-ResYDist(38,39) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #2 */
-YInterpolate(50,0,20)
-YAnchor(0)
-ResYDist(0,28) /*perpendicular to the stroke*/
-
-/* Contour #2 */
-YShift(38,25) /* max */
-YShift(20,24) /* min */
-
-/* Contour #6 */
-YShift(50,54) /* max */
-YShift(38,53) /* min */
+/* X direction */
 
 Smooth()
 
@@ -83398,28 +83311,19 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="uni2104">
-/* VTTTalk Unicode 0x2104 */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
+/* Y direction */
+ResYAnchor(0,8)
+YShift(0,27)
+ResYAnchor(9,2)
+YInterpolate(0,1,8,9)
+YShift(1,26)
+YShift(1,30)
+YShift(30,19)
+YShift(8,11)
+YShift(8,31)
+YShift(31,18)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 18  DISABLED for a NON-LATIN glyph */
-/* CVT 9 16  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(9)	/* max */
-
-/* YDir: Stroke #0 */
-ResYDist(0,27) /*perpendicular to the stroke*/
-
-/* Contour #1 */
-YShift(9,31) /* max */
-YShift(0,30) /* min */
+/* X direction */
 
 Smooth()
 
@@ -83447,32 +83351,15 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="uni2108">
-/* VTTTalk Unicode 0x2108 */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
+/* Y direction */
+ResYAnchor(0,9)
+YShift(0,9)
+ResYAnchor(30,3)
+YShift(30,21)
+YIPAnchor(30,41,0)
+YShift(41,42)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 19  DISABLED for a NON-LATIN glyph */
-/* CVT 30 17  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(30)	/* max */
-
-/* YDir: Stroke #0 */
-ResYDist(30,21) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(30,41,0)
-YAnchor(41)
-ResYDist(41,42) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #2 */
-ResYDist(0,9) /*perpendicular to the stroke*/
+/* X direction */
 
 Smooth()
 
@@ -83494,41 +83381,19 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="uni2114">
-/* VTTTalk Unicode 0x2114 */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
+/* Y direction */
+ResYAnchor(0,11)
+YShift(0,31)
+ResYAnchor(11,7)
+YShift(11,42)
+ResYAnchor(23,0)
+YShift(23,27)
+YInterpolate(23,52,11)
+YShift(52,53)
+ResYAnchor(26,10)
+YShift(26,25)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 19  DISABLED for a NON-LATIN glyph */
-/* CVT 22 18  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(23)	/* max */
-
-/* YDir: Stroke #0 */
-YInterpolate(23,53,0)
-YAnchor(53)
-ResYDist(53,52) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(23,11,0)
-YAnchor(11)
-ResYDist(11,42) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #2 */
-ResYDist(0,31) /*perpendicular to the stroke*/
-
-/* Contour #2 */
-YShift(23,27) /* max */
-YShift(0,26) /* min */
-
-/* Extreme Min */
-YShift(0,25)
+/* X direction */
 
 Smooth()
 
@@ -83579,123 +83444,65 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="uni2118">
-/* VTTTalk Unicode 0x2118 */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
+/* Y direction */
+ResYAnchor(38,9)
+YShift(38,55)
+ResYDist(38,0)
+YShift(0,79)
+ResYDist(38,29)
+ResYDist(29,15)
+YShift(29,66)
+YInterpolate(38,86,50,7,72,23,44,29)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 38 19  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(15)	/* max */
-
-/* YDir: Stroke #0 */
-YInterpolate(15,29,0)
-YAnchor(29)
-ResYDist(29,66) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(15,38,0)
-YAnchor(38)
-ResYDist(38,55) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #2 */
-ResYDist(0,79) /*perpendicular to the stroke*/
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="uni2127">
-/* VTTTalk Unicode 0x2127 */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
-
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 19  DISABLED for a NON-LATIN glyph */
-/* CVT 47 16  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(47)	/* max */
-
-/* YDir: Stroke #0 */
-ResYDist(47,46) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-ResYDist(0,23) /*perpendicular to the stroke*/
-
-/* Contour #2 */
-YShift(47,51) /* max */
-YShift(0,50) /* min */
-
-/* Extreme Max */
-YShift(47,35)
-
-/* Extreme Max */
+/* Y direction */
+ResYAnchor(0,8)
+YShift(0,23)
+ResYAnchor(47,2)
+YShift(47,52)
 YShift(47,11)
+YShift(11,35)
+YShift(47,46)
+YShift(46,53)
+YShift(46,12)
+YShift(12,34)
+
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="uni2129">
-/* VTTTalk Unicode 0x2129 */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
-
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 17 19  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(12)	/* max */
-
-/* YDir: Stroke #0 */
-ResYDist(12,5) /*perpendicular to the stroke*/
-
-/* Extreme Max */
+/* Y direction */
+ResYAnchor(0,13)
+ResYDist(0,12)
+YShift(12,5)
 YShift(12,9)
+
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="uni213A">
-/* VTTTalk Unicode 0x213a */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
-
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(38)	/* max */
-
-/* YDir: Stroke #0 */
-YInterpolate(38,8,0)
+/* Y direction */
 YAnchor(8)
-ResYDist(8,28) /*perpendicular to the stroke*/
+YShift(8,28)
+ResYDist(8,0)
+YShift(0,18)
+YInterpolate(0,36,37,8)
+ResYDist(37,39)
+YShift(39,38)
 
-/* YDir: Stroke #1 */
-ResYDist(0,18) /*perpendicular to the stroke*/
+/* X direction */
 
 Smooth()
 
@@ -83724,233 +83531,117 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="uni2141">
-/* VTTTalk Unicode 0x2141 */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
+/* Y direction */
+ResYAnchor(0,9)
+YShift(0,9)
+ResYAnchor(33,3)
+YShift(33,20)
+YIPAnchor(33,25,0)
+YInterpolate(33,29,24,25)
+YInterpolate(25,5,0)
+YShift(25,28)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 19  DISABLED for a NON-LATIN glyph */
-/* CVT 33 17  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(33)	/* max */
-
-/* YDir: Stroke #0 */
-ResYDist(33,20) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(33,25,0)
-YAnchor(25)
-ResYDist(25,28) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #2 */
-ResYDist(0,9) /*perpendicular to the stroke*/
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="uni2142">
-/* VTTTalk Unicode 0x2142 */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
+/* Y direction */
+ResYAnchor(0,8)
+ResYAnchor(1,2)
+YShift(1,5)
+YShift(5,4)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 3 18  DISABLED for a NON-LATIN glyph */
-/* CVT 5 16  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(1)	/* max */
-
-/* YDir: Stroke #0 */
-YInterpolate(1,5,0)
-YAnchor(5)
-ResYDist(5,4) /*perpendicular to the stroke*/
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="uni2143">
-/* VTTTalk Unicode 0x2143 */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
+/* Y direction */
+ResYAnchor(1,2)
+ResYAnchor(3,8)
+YShift(3,7)
+YShift(7,6)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 2 16  DISABLED for a NON-LATIN glyph */
-/* CVT 4 18  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(1)	/* max */
-
-/* YDir: Stroke #0 */
-YInterpolate(1,4,0)
-YAnchor(4)
-ResYDist(4,5) /*perpendicular to the stroke*/
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="uni2144">
-/* VTTTalk Unicode 0x2144 */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
-
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 18  DISABLED for a NON-LATIN glyph */
-/* CVT 3 16  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(2)	/* max */
-
-/* Extreme Min */
+/* Y direction */
+ResYAnchor(0,8)
 YShift(0,6)
+ResYAnchor(2,2)
+YInterpolate(6,7,1,4,2)
+
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="uni214A">
-/* VTTTalk Unicode 0x214a */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
+/* Y direction */
+ResYAnchor(1,2)
+YShift(1,22)
+ResYDist(1,29,&gt;=)
+ResYAnchor(24,8)
+YShift(24,25)
+YShift(24,28)
+YIPAnchor(1,11,24)
+YInterpolate(11,23,24)
+YShift(11,12)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 1 16  DISABLED for a NON-LATIN glyph */
-/* CVT 28 18  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(24)	/* min */
-YAnchor(29)	/* max */
-
-/* YDir: Stroke #0 */
-YInterpolate(29,1,24)
-YAnchor(1)
-ResYDist(1,22) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(29,11,24)
-YAnchor(11)
-ResYDist(11,12) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #2 */
-ResYDist(24,25) /*perpendicular to the stroke*/
-
-/* Extreme Min */
-YShift(24,31)
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="uni214B">
-/* VTTTalk Unicode 0x214b */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
+/* Y direction */
+ResYAnchor(0,19)
+YShift(0,48)
+ResYAnchor(33,3)
+YShift(33,17)
+YInterpolate(0,42,8,56,41,59,22,9,27,30,33)
+ResYAnchor(58,2)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 19  DISABLED for a NON-LATIN glyph */
-/* CVT 33 17  DISABLED for a NON-LATIN glyph */
-/* CVT 57 16  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(33)	/* max */
-
-/* YDir: Stroke #0 */
-ResYDist(33,17) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-ResYDist(0,48) /*perpendicular to the stroke*/
-
-/* Extreme Max */
-YShift(33,58)
+/* X direction */
 
 Smooth()
 
     </glyphProgram>
 
     <glyphProgram name="uni214C">
-/* VTTTalk Unicode 0x214c */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
-
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 0 19  DISABLED for a NON-LATIN glyph */
-/* CVT 46 16  DISABLED for a NON-LATIN glyph */
-/* CVT 64 17  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(64)	/* max */
-
-/* YDir: Stroke #0 */
-ResYDist(64,147) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(64,38,0)
-YAnchor(38)
-ResYDist(38,19) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #2 */
-YInterpolate(64,25,0)
-YAnchor(25)
-ResYDist(25,31) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #3 */
-YInterpolate(64,55,0)
-YAnchor(55)
-ResYDist(55,128) /*perpendicular to the stroke*/
-YShift(128,139) /*along bottom edge*/
-YShift(55,153) /*along top edge*/
-
-/* YDir: Stroke #4 */
-YInterpolate(64,103,0)
-YAnchor(103)
-ResYDist(103,121) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #5 */
-ResYDist(0,94) /*perpendicular to the stroke*/
-
-/* Contour #2 */
-YShift(55,113) /* max */
-YShift(103,112) /* min */
-
-/* Extreme Max */
+/* Y direction */
+ResYAnchor(0,9)
+YShift(0,94)
+ResYAnchor(64,3)
 YShift(64,46)
+YShift(64,147)
+YShift(64,38)
+YShift(38,19)
+YShift(38,42)
+YInterpolate(0,78,103,84,71,136,140,55,64)
+YShift(103,7)
+YShift(103,87)
+YShift(103,121)
+YShift(121,112)
+YShift(121,134)
+YShift(55,14)
+YShift(55,153)
+YShift(55,128)
+YShift(128,113)
+YShift(128,139)
+
+/* X direction */
 
 Smooth()
 
@@ -83979,30 +83670,16 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="uni214E">
-/* VTTTalk Unicode 0x214e */
-/* ACT generated Tue Jun  9 13:33:49 2026 */
-
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* CVT 4 18  DISABLED for a NON-LATIN glyph */
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(1)	/* max */
-
-/* YDir: Stroke #0 */
-YInterpolate(1,8,0)
-YAnchor(8)
-ResYDist(8,9) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-YInterpolate(1,4,0)
+/* Y direction */
+ResYAnchor(0,13)
+ResYDist(0,1)
+YIPAnchor(1,8,0)
+YShift(8,9)
+YShift(0,4)
 YAnchor(4)
-ResYDist(4,5) /*perpendicular to the stroke*/
+YShift(4,5)
+
+/* X direction */
 
 Smooth()
 
@@ -91514,25 +91191,13 @@ Smooth()
     </glyphProgram>
 
     <glyphProgram name="whiteCircle">
-/* VTTTalk Unicode 0x25cb */
-/* ACT generated Tue Sep 16 09:34:43 2025 */
+/* Y direction */
+YAnchor(8)
+YShift(8,24)
+ResYDist(8,0)
+YShift(0,16)
 
-/* Auto-Hinting Light */
-
-/* ***Settings*** */
-/* ModeHinting = LightLatin */
-/* ToAnchorBottom = true */
-
-
-/* Min and Max */
-YAnchor(0)	/* min */
-YAnchor(8)	/* max */
-
-/* YDir: Stroke #0 */
-ResYDist(8,24) /*perpendicular to the stroke*/
-
-/* YDir: Stroke #1 */
-ResYDist(0,16) /*perpendicular to the stroke*/
+/* X direction */
 
 Smooth()
 

--- a/sources/vtt-hinting.ttx
+++ b/sources/vtt-hinting.ttx
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.40">
+<ttFont sfntVersion="\x00\x01\x00\x00" ttLibVersion="4.62">
 
   <TSI1>
 
@@ -40271,6 +40271,38 @@ IUP[X]
 
     </glyphProgram>
 
+    <glyphProgram name="uni20BF">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 20
+MDAP[R], 50
+SRP2[], 20
+IP[], 1
+MDAP[R], 1
+CALL[], 1, 48, 106
+SRP1[], 50
+SRP2[], 20
+IP[], 38
+MDAP[R], 38
+CALL[], 38, 39, 106
+SRP1[], 50
+SRP2[], 20
+IP[], 0
+MDAP[R], 0
+CALL[], 0, 28, 106
+SRP1[], 38
+SHP[1], 25
+SRP1[], 20
+SHP[1], 24
+SRP1[], 50
+SHP[1], 54
+SRP1[], 38
+SHP[1], 53
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
     <glyphProgram name="uni20DB">
 /* VTTTalk Unicode 0x20db */
 /* ACT generated Thu Dec  5 13:36:29 2019 */
@@ -40325,6 +40357,21 @@ IUP[X]
 
     </glyphProgram>
 
+    <glyphProgram name="uni2104">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 9
+CALL[], 0, 27, 106
+SRP1[], 9
+SHP[1], 31
+SRP1[], 0
+SHP[1], 30
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
     <glyphProgram name="uni2105">
 /* VTT 6.35 compiler */
 SVTCA[Y]
@@ -40347,6 +40394,22 @@ IUP[X]
 
     </glyphProgram>
 
+    <glyphProgram name="uni2108">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 30
+CALL[], 30, 21, 106
+SRP2[], 0
+IP[], 41
+MDAP[R], 41
+CALL[], 41, 42, 106
+CALL[], 0, 9, 106
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
     <glyphProgram name="uni2113">
 /* VTT 6.35 compiler */
 SVTCA[Y]
@@ -40357,6 +40420,30 @@ SHP[1], 36
 SRP2[], 1
 IP[], 24
 MDAP[R], 24
+SHP[1], 25
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2114">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 23
+IP[], 53
+MDAP[R], 53
+CALL[], 53, 52, 106
+SRP1[], 23
+SRP2[], 0
+IP[], 11
+MDAP[R], 11
+CALL[], 11, 42, 106
+CALL[], 0, 31, 106
+SRP1[], 23
+SHP[1], 27
+SRP1[], 0
+SHP[1], 26
 SHP[1], 25
 IUP[Y]
 IUP[X]
@@ -40412,6 +40499,70 @@ IUP[X]
 
     </glyphProgram>
 
+    <glyphProgram name="uni2118">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 15
+IP[], 29
+MDAP[R], 29
+CALL[], 29, 66, 106
+SRP1[], 15
+SRP2[], 0
+IP[], 38
+MDAP[R], 38
+CALL[], 38, 55, 106
+CALL[], 0, 79, 106
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2127">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 47
+CALL[], 47, 46, 106
+CALL[], 0, 23, 106
+SRP1[], 47
+SHP[1], 51
+SRP1[], 0
+SHP[1], 50
+SRP1[], 47
+SHP[1], 35
+SHP[1], 11
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2129">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 12
+CALL[], 12, 5, 106
+SHP[1], 9
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni213A">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 38
+IP[], 8
+MDAP[R], 8
+CALL[], 8, 28, 106
+CALL[], 0, 18, 106
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
     <glyphProgram name="uni213B">
 /* VTT 6.35 compiler */
 SVTCA[Y]
@@ -40444,6 +40595,133 @@ IUP[X]
 
     </glyphProgram>
 
+    <glyphProgram name="uni2141">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 33
+CALL[], 33, 20, 106
+SRP2[], 0
+IP[], 25
+MDAP[R], 25
+CALL[], 25, 28, 106
+CALL[], 0, 9, 106
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2142">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 1
+IP[], 5
+MDAP[R], 5
+CALL[], 5, 4, 106
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2143">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 1
+IP[], 4
+MDAP[R], 4
+CALL[], 4, 5, 106
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2144">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 2
+SHP[2], 6
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni214A">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 24
+MDAP[R], 29
+SRP2[], 24
+IP[], 1
+MDAP[R], 1
+CALL[], 1, 22, 106
+SRP1[], 29
+SRP2[], 24
+IP[], 11
+MDAP[R], 11
+CALL[], 11, 12, 106
+CALL[], 24, 25, 106
+SHP[1], 31
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni214B">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 33
+CALL[], 33, 17, 106
+CALL[], 0, 48, 106
+SRP1[], 33
+SHP[1], 58
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni214C">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 64
+CALL[], 64, 147, 106
+SRP2[], 0
+IP[], 38
+MDAP[R], 38
+CALL[], 38, 19, 106
+SRP1[], 64
+SRP2[], 0
+IP[], 25
+MDAP[R], 25
+CALL[], 25, 31, 106
+SRP1[], 64
+SRP2[], 0
+IP[], 55
+MDAP[R], 55
+CALL[], 55, 128, 106
+SHP[2], 139
+SHP[1], 153
+SRP1[], 64
+SRP2[], 0
+IP[], 103
+MDAP[R], 103
+CALL[], 103, 121, 106
+CALL[], 0, 94, 106
+SRP1[], 55
+SHP[1], 113
+SRP1[], 103
+SHP[1], 112
+SRP1[], 64
+SHP[1], 46
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
     <glyphProgram name="uni214D">
 /* VTT 6.35 compiler */
 SVTCA[Y]
@@ -40464,6 +40742,24 @@ MDRP[m&gt;RGr], 26
 SHP[2], 35
 IP[], 14
 IP[], 39
+IUP[Y]
+IUP[X]
+
+    </glyphProgram>
+
+    <glyphProgram name="uni214E">
+/* VTT 6.35 compiler */
+SVTCA[Y]
+MDAP[R], 0
+MDAP[R], 1
+IP[], 8
+MDAP[R], 8
+CALL[], 8, 9, 106
+SRP1[], 1
+SRP2[], 0
+IP[], 4
+MDAP[R], 4
+CALL[], 4, 5, 106
 IUP[Y]
 IUP[X]
 
@@ -83021,6 +83317,50 @@ Smooth()
 
     </glyphProgram>
 
+    <glyphProgram name="uni20BF">
+/* VTTTalk Unicode 0x20bf */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 0 18  DISABLED for a NON-LATIN glyph */
+/* CVT 1 16  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(20)	/* min */
+YAnchor(50)	/* max */
+
+/* YDir: Stroke #0 */
+YInterpolate(50,1,20)
+YAnchor(1)
+ResYDist(1,48) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+YInterpolate(50,38,20)
+YAnchor(38)
+ResYDist(38,39) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #2 */
+YInterpolate(50,0,20)
+YAnchor(0)
+ResYDist(0,28) /*perpendicular to the stroke*/
+
+/* Contour #2 */
+YShift(38,25) /* max */
+YShift(20,24) /* min */
+
+/* Contour #6 */
+YShift(50,54) /* max */
+YShift(38,53) /* min */
+
+Smooth()
+
+    </glyphProgram>
+
     <glyphProgram name="uni20E3">
 /* VTTTalk Unicode 0x20e3 */
 /* ACT generated Thu Dec  5 13:36:29 2019 */
@@ -83057,6 +83397,34 @@ Smooth()
 
     </glyphProgram>
 
+    <glyphProgram name="uni2104">
+/* VTTTalk Unicode 0x2104 */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 0 18  DISABLED for a NON-LATIN glyph */
+/* CVT 9 16  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(9)	/* max */
+
+/* YDir: Stroke #0 */
+ResYDist(0,27) /*perpendicular to the stroke*/
+
+/* Contour #1 */
+YShift(9,31) /* max */
+YShift(0,30) /* min */
+
+Smooth()
+
+    </glyphProgram>
+
     <glyphProgram name="uni2105">
 /* Y direction */
 ResYAnchor(14,5)
@@ -83078,6 +83446,38 @@ Smooth()
 
     </glyphProgram>
 
+    <glyphProgram name="uni2108">
+/* VTTTalk Unicode 0x2108 */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 0 19  DISABLED for a NON-LATIN glyph */
+/* CVT 30 17  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(30)	/* max */
+
+/* YDir: Stroke #0 */
+ResYDist(30,21) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+YInterpolate(30,41,0)
+YAnchor(41)
+ResYDist(41,42) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #2 */
+ResYDist(0,9) /*perpendicular to the stroke*/
+
+Smooth()
+
+    </glyphProgram>
+
     <glyphProgram name="uni2113">
 /* Y direction */
 YAnchor(1)
@@ -83088,6 +83488,47 @@ YIPAnchor(1,24,12)
 YShift(24,25)
 
 /* X direction */
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2114">
+/* VTTTalk Unicode 0x2114 */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 0 19  DISABLED for a NON-LATIN glyph */
+/* CVT 22 18  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(23)	/* max */
+
+/* YDir: Stroke #0 */
+YInterpolate(23,53,0)
+YAnchor(53)
+ResYDist(53,52) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+YInterpolate(23,11,0)
+YAnchor(11)
+ResYDist(11,42) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #2 */
+ResYDist(0,31) /*perpendicular to the stroke*/
+
+/* Contour #2 */
+YShift(23,27) /* max */
+YShift(0,26) /* min */
+
+/* Extreme Min */
+YShift(0,25)
 
 Smooth()
 
@@ -83137,6 +83578,129 @@ Smooth()
 
     </glyphProgram>
 
+    <glyphProgram name="uni2118">
+/* VTTTalk Unicode 0x2118 */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 38 19  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(15)	/* max */
+
+/* YDir: Stroke #0 */
+YInterpolate(15,29,0)
+YAnchor(29)
+ResYDist(29,66) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+YInterpolate(15,38,0)
+YAnchor(38)
+ResYDist(38,55) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #2 */
+ResYDist(0,79) /*perpendicular to the stroke*/
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2127">
+/* VTTTalk Unicode 0x2127 */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 0 19  DISABLED for a NON-LATIN glyph */
+/* CVT 47 16  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(47)	/* max */
+
+/* YDir: Stroke #0 */
+ResYDist(47,46) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+ResYDist(0,23) /*perpendicular to the stroke*/
+
+/* Contour #2 */
+YShift(47,51) /* max */
+YShift(0,50) /* min */
+
+/* Extreme Max */
+YShift(47,35)
+
+/* Extreme Max */
+YShift(47,11)
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2129">
+/* VTTTalk Unicode 0x2129 */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 17 19  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(12)	/* max */
+
+/* YDir: Stroke #0 */
+ResYDist(12,5) /*perpendicular to the stroke*/
+
+/* Extreme Max */
+YShift(12,9)
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni213A">
+/* VTTTalk Unicode 0x213a */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(38)	/* max */
+
+/* YDir: Stroke #0 */
+YInterpolate(38,8,0)
+YAnchor(8)
+ResYDist(8,28) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+ResYDist(0,18) /*perpendicular to the stroke*/
+
+Smooth()
+
+    </glyphProgram>
+
     <glyphProgram name="uni213B">
 /* Y direction */
 YAnchor(2,16)
@@ -83159,6 +83723,239 @@ Smooth()
 
     </glyphProgram>
 
+    <glyphProgram name="uni2141">
+/* VTTTalk Unicode 0x2141 */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 0 19  DISABLED for a NON-LATIN glyph */
+/* CVT 33 17  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(33)	/* max */
+
+/* YDir: Stroke #0 */
+ResYDist(33,20) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+YInterpolate(33,25,0)
+YAnchor(25)
+ResYDist(25,28) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #2 */
+ResYDist(0,9) /*perpendicular to the stroke*/
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2142">
+/* VTTTalk Unicode 0x2142 */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 3 18  DISABLED for a NON-LATIN glyph */
+/* CVT 5 16  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(1)	/* max */
+
+/* YDir: Stroke #0 */
+YInterpolate(1,5,0)
+YAnchor(5)
+ResYDist(5,4) /*perpendicular to the stroke*/
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2143">
+/* VTTTalk Unicode 0x2143 */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 2 16  DISABLED for a NON-LATIN glyph */
+/* CVT 4 18  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(1)	/* max */
+
+/* YDir: Stroke #0 */
+YInterpolate(1,4,0)
+YAnchor(4)
+ResYDist(4,5) /*perpendicular to the stroke*/
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni2144">
+/* VTTTalk Unicode 0x2144 */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 0 18  DISABLED for a NON-LATIN glyph */
+/* CVT 3 16  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(2)	/* max */
+
+/* Extreme Min */
+YShift(0,6)
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni214A">
+/* VTTTalk Unicode 0x214a */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 1 16  DISABLED for a NON-LATIN glyph */
+/* CVT 28 18  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(24)	/* min */
+YAnchor(29)	/* max */
+
+/* YDir: Stroke #0 */
+YInterpolate(29,1,24)
+YAnchor(1)
+ResYDist(1,22) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+YInterpolate(29,11,24)
+YAnchor(11)
+ResYDist(11,12) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #2 */
+ResYDist(24,25) /*perpendicular to the stroke*/
+
+/* Extreme Min */
+YShift(24,31)
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni214B">
+/* VTTTalk Unicode 0x214b */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 0 19  DISABLED for a NON-LATIN glyph */
+/* CVT 33 17  DISABLED for a NON-LATIN glyph */
+/* CVT 57 16  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(33)	/* max */
+
+/* YDir: Stroke #0 */
+ResYDist(33,17) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+ResYDist(0,48) /*perpendicular to the stroke*/
+
+/* Extreme Max */
+YShift(33,58)
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni214C">
+/* VTTTalk Unicode 0x214c */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 0 19  DISABLED for a NON-LATIN glyph */
+/* CVT 46 16  DISABLED for a NON-LATIN glyph */
+/* CVT 64 17  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(64)	/* max */
+
+/* YDir: Stroke #0 */
+ResYDist(64,147) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+YInterpolate(64,38,0)
+YAnchor(38)
+ResYDist(38,19) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #2 */
+YInterpolate(64,25,0)
+YAnchor(25)
+ResYDist(25,31) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #3 */
+YInterpolate(64,55,0)
+YAnchor(55)
+ResYDist(55,128) /*perpendicular to the stroke*/
+YShift(128,139) /*along bottom edge*/
+YShift(55,153) /*along top edge*/
+
+/* YDir: Stroke #4 */
+YInterpolate(64,103,0)
+YAnchor(103)
+ResYDist(103,121) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #5 */
+ResYDist(0,94) /*perpendicular to the stroke*/
+
+/* Contour #2 */
+YShift(55,113) /* max */
+YShift(103,112) /* min */
+
+/* Extreme Max */
+YShift(64,46)
+
+Smooth()
+
+    </glyphProgram>
+
     <glyphProgram name="uni214D">
 /* Y direction */
 YAnchor(3)
@@ -83176,6 +83973,36 @@ YShift(26,35)
 YInterpolate(51,14,39,26)
 
 /* X direction */
+
+Smooth()
+
+    </glyphProgram>
+
+    <glyphProgram name="uni214E">
+/* VTTTalk Unicode 0x214e */
+/* ACT generated Tue Jun  9 13:33:49 2026 */
+
+/* Auto-Hinting Light */
+
+/* ***Settings*** */
+/* ModeHinting = LightLatin */
+/* ToAnchorBottom = true */
+
+
+/* CVT 4 18  DISABLED for a NON-LATIN glyph */
+/* Min and Max */
+YAnchor(0)	/* min */
+YAnchor(1)	/* max */
+
+/* YDir: Stroke #0 */
+YInterpolate(1,8,0)
+YAnchor(8)
+ResYDist(8,9) /*perpendicular to the stroke*/
+
+/* YDir: Stroke #1 */
+YInterpolate(1,4,0)
+YAnchor(4)
+ResYDist(4,5) /*perpendicular to the stroke*/
 
 Smooth()
 
@@ -93895,17 +94722,35 @@ Smooth()
     <glyphgroup name="uni20BD" value="1"/>
     <glyphgroup name="uni20BD.smcp" value="1"/>
     <glyphgroup name="uni20BE" value="1"/>
+    <glyphgroup name="uni20BF" value="0"/>
     <glyphgroup name="uni20DB" value="1"/>
     <glyphgroup name="uni20DC" value="1"/>
     <glyphgroup name="uni20E3" value="1"/>
     <glyphgroup name="uni20E8" value="1"/>
     <glyphgroup name="uni20F0" value="1"/>
+    <glyphgroup name="uni2104" value="0"/>
     <glyphgroup name="uni2105" value="1"/>
+    <glyphgroup name="uni2107" value="0"/>
+    <glyphgroup name="uni2108" value="0"/>
     <glyphgroup name="uni2113" value="1"/>
+    <glyphgroup name="uni2114" value="0"/>
     <glyphgroup name="uni2116" value="1"/>
     <glyphgroup name="uni2116.smcp" value="1"/>
+    <glyphgroup name="uni2118" value="0"/>
+    <glyphgroup name="uni2127" value="0"/>
+    <glyphgroup name="uni2129" value="0"/>
+    <glyphgroup name="uni2139" value="0"/>
+    <glyphgroup name="uni213A" value="0"/>
     <glyphgroup name="uni213B" value="1"/>
+    <glyphgroup name="uni2141" value="0"/>
+    <glyphgroup name="uni2142" value="0"/>
+    <glyphgroup name="uni2143" value="0"/>
+    <glyphgroup name="uni2144" value="0"/>
+    <glyphgroup name="uni214A" value="0"/>
+    <glyphgroup name="uni214B" value="0"/>
+    <glyphgroup name="uni214C" value="0"/>
     <glyphgroup name="uni214D" value="1"/>
+    <glyphgroup name="uni214E" value="0"/>
     <glyphgroup name="uni214F" value="1"/>
     <glyphgroup name="uni2150" value="1"/>
     <glyphgroup name="uni2151" value="1"/>
@@ -94500,7 +95345,7 @@ Smooth()
   <maxp>
     <!-- Most of this table will be recalculated by the compiler -->
     <tableVersion value="0x10000"/>
-    <numGlyphs value="3391"/>
+    <numGlyphs value="3409"/>
     <maxPoints value="336"/>
     <maxContours value="21"/>
     <maxCompositePoints value="118"/>


### PR DESCRIPTION
Following glyphs have been requested:


Unicode | Symbol | Name | Unicode | Symbol | Name
-- | -- | -- | -- | -- | --
U+20BF | ₿ | Bitcoin Sign | U+213A | ℺ | Rotated Capital Q
U+2104 | ℄ | Centre Line Symbol | U+2141 | ⅁ | Turned Sans-Serif Capital G
U+2107 | ℇ | Euler Constant | U+2142 | ⅂ | Turned Sans-Serif Capital L
U+2108 | ℈ | Scruple | U+2143 | ⅃ | Reversed Sans-Serif Capital L
U+2114 | ℔ | L B Bar Symbol | U+2144 | ⅄ | Turned Sans-Serif Capital Y
U+2118 | ℘ | Script Capital P | U+214A | ⅊ | Property Line
U+2127 | ℧ | Inverted Ohm Sign | U+214B | ⅋ | Turned Ampersand
U+2129 | ℩ | Turned Greek Small Letter Iota | U+214C | ⅌ | Per Sign
U+2139 |   | Information Source | U+214E | ⅎ | Turned Small F

